### PR TITLE
fix: escape underscores in sql string literal

### DIFF
--- a/src/inspect/dependencies.ts
+++ b/src/inspect/dependencies.ts
@@ -116,7 +116,7 @@ things as (
     where
       kind in ('r', 'v', 'm', 'c', 'f') and
       n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-      and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+      and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
       and extension_objids.extension_objid is null
 ),
 combined as (

--- a/src/inspect/objects/collations.ts
+++ b/src/inspect/objects/collations.ts
@@ -68,7 +68,7 @@ export async function inspectCollations(
         left outer join extension_oids e on c.oid = e.objid
         -- <EXCLUDE_INTERNAL>
         where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-        and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+        and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
         and e.objid is null
         -- </EXCLUDE_INTERNAL>
       order by
@@ -104,7 +104,7 @@ export async function inspectCollations(
         left outer join extension_oids e on c.oid = e.objid
         -- <EXCLUDE_INTERNAL>
         where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-        and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+        and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
         and e.objid is null
         -- </EXCLUDE_INTERNAL>
       order by
@@ -140,7 +140,7 @@ export async function inspectCollations(
         left outer join extension_oids e on c.oid = e.objid
         -- <EXCLUDE_INTERNAL>
         where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-        and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+        and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
         and e.objid is null
         -- </EXCLUDE_INTERNAL>
       order by

--- a/src/inspect/objects/composite-types.ts
+++ b/src/inspect/objects/composite-types.ts
@@ -60,7 +60,7 @@ from
   left outer join extension_oids e on c.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and c.relkind = 'c'
   -- </EXCLUDE_INTERNAL>

--- a/src/inspect/objects/constraints.ts
+++ b/src/inspect/objects/constraints.ts
@@ -111,7 +111,7 @@ from
   left outer join extension_oids e on c.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   -- </EXCLUDE_INTERNAL>
 order by

--- a/src/inspect/objects/domains.ts
+++ b/src/inspect/objects/domains.ts
@@ -55,7 +55,7 @@ from
   left outer join extension_oids e on t.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and t.typtype = 'd'
   -- </EXCLUDE_INTERNAL>

--- a/src/inspect/objects/enums.ts
+++ b/src/inspect/objects/enums.ts
@@ -43,7 +43,7 @@ from
   left outer join extension_oids ext on t.oid = ext.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and ext.objid is null
   -- </EXCLUDE_INTERNAL>
 order by

--- a/src/inspect/objects/extensions.ts
+++ b/src/inspect/objects/extensions.ts
@@ -31,7 +31,7 @@ from
   inner join pg_catalog.pg_namespace n on n.oid = e.extnamespace
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   -- </EXCLUDE_INTERNAL>
 order by
   1;

--- a/src/inspect/objects/functions.ts
+++ b/src/inspect/objects/functions.ts
@@ -125,7 +125,7 @@ from
   left outer join extension_oids e on p.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and l.lanname not in ('c', 'internal')
   -- </EXCLUDE_INTERNAL>

--- a/src/inspect/objects/indexes.ts
+++ b/src/inspect/objects/indexes.ts
@@ -70,7 +70,7 @@ from
   left outer join extension_oids e on c.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and c.relkind = 'i'
   -- </EXCLUDE_INTERNAL>

--- a/src/inspect/objects/materialized-views.ts
+++ b/src/inspect/objects/materialized-views.ts
@@ -64,7 +64,7 @@ from
   left outer join extension_oids e on c.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and c.relkind = 'm'
   -- </EXCLUDE_INTERNAL>

--- a/src/inspect/objects/rls-policies.ts
+++ b/src/inspect/objects/rls-policies.ts
@@ -70,7 +70,7 @@ from
   left outer join extension_oids e on p.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where tn.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and tn.nspname not like 'pg_temp_%' and tn.nspname not like 'pg_toast_temp_%'
+  and tn.nspname not like 'pg\_temp\_%' and tn.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   -- </EXCLUDE_INTERNAL>
 order by

--- a/src/inspect/objects/schemas.ts
+++ b/src/inspect/objects/schemas.ts
@@ -33,7 +33,7 @@ from
   left outer join extension_oids e on e.objid = oid
   -- <EXCLUDE_INTERNAL>
   where nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and nspname not like 'pg_temp_%' and nspname not like 'pg_toast_temp_%'
+  and nspname not like 'pg\_temp\_%' and nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   -- </EXCLUDE_INTERNAL>
 order by

--- a/src/inspect/objects/sequences.ts
+++ b/src/inspect/objects/sequences.ts
@@ -53,7 +53,7 @@ from
   left outer join extension_oids e on c.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and c.relkind = 'S'
   -- </EXCLUDE_INTERNAL>

--- a/src/inspect/objects/tables.ts
+++ b/src/inspect/objects/tables.ts
@@ -89,7 +89,7 @@ from
   left join pg_namespace n_parent on c_parent.relnamespace = n_parent.oid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and c.relkind in ('r', 'p')
   -- </EXCLUDE_INTERNAL>

--- a/src/inspect/objects/triggers.ts
+++ b/src/inspect/objects/triggers.ts
@@ -80,7 +80,7 @@ from
   left outer join extension_oids e on t.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where tn.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and tn.nspname not like 'pg_temp_%' and tn.nspname not like 'pg_toast_temp_%'
+  and tn.nspname not like 'pg\_temp\_%' and tn.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and not t.tgisinternal
   -- </EXCLUDE_INTERNAL>

--- a/src/inspect/objects/types.ts
+++ b/src/inspect/objects/types.ts
@@ -129,7 +129,7 @@ from
   left outer join extension_oids e on t.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   -- </EXCLUDE_INTERNAL>
 order by

--- a/src/inspect/objects/views.ts
+++ b/src/inspect/objects/views.ts
@@ -61,7 +61,7 @@ from
   left outer join extension_oids e on c.oid = e.objid
   -- <EXCLUDE_INTERNAL>
   where n.nspname not in ('pg_internal', 'pg_catalog', 'information_schema', 'pg_toast')
-  and n.nspname not like 'pg_temp_%' and n.nspname not like 'pg_toast_temp_%'
+  and n.nspname not like 'pg\_temp\_%' and n.nspname not like 'pg\_toast\_temp\_%'
   and e.objid is null
   and c.relkind = 'v'
   -- </EXCLUDE_INTERNAL>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

> An underscore (_) in pattern stands for (matches) any single character; a percent sign (%) matches any sequence of zero or more characters.

Underscores in `like` patterns should be escaped to avoid being matched as wildcard.

## Additional context

https://www.postgresql.org/docs/current/functions-matching.html
