### PR TITLE
chore: simplify exclusion of internal schemas

### DIFF
--- a/src/inspect/objects/collations.ts
+++ b/src/inspect/objects/collations.ts
@@ -74,7 +74,7 @@ export async function inspectCollations(
         pg_catalog.pg_collation c
         left outer join extension_oids e on c.oid = e.objid
         -- <EXCLUDE_INTERNAL>
-        where not c.collnamespace::regnamespace::text like any(array['pg\_*', 'information\_schema'])
+        where not c.collnamespace::regnamespace::text like any(array['pg\\_%', 'information\\_schema'])
         and e.objid is null
         -- </EXCLUDE_INTERNAL>
       order by
@@ -108,7 +108,7 @@ export async function inspectCollations(
         pg_catalog.pg_collation c
         left outer join extension_oids e on c.oid = e.objid
         -- <EXCLUDE_INTERNAL>
-        where not c.collnamespace::regnamespace::text like any(array['pg\_*', 'information\_schema'])
+        where not c.collnamespace::regnamespace::text like any(array['pg\\_%', 'information\\_schema'])
         and e.objid is null
         -- </EXCLUDE_INTERNAL>
       order by
@@ -142,7 +142,7 @@ export async function inspectCollations(
         pg_catalog.pg_collation c
         left outer join extension_oids e on c.oid = e.objid
         -- <EXCLUDE_INTERNAL>
-        where not c.collnamespace::regnamespace::text like any(array['pg\_*', 'information\_schema'])
+        where not c.collnamespace::regnamespace::text like any(array['pg\\_%', 'information\\_schema'])
         and e.objid is null
         -- </EXCLUDE_INTERNAL>
       order by


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Missing oid for roles now explicitly errors at inspection time instead of being cast to `unknown (OID=xxxx)` and then failing later during the diff process.

> Schema names beginning with pg_ are reserved for system purposes

We can simply omit all internal schemas with `pg\_%` wildcard matching the reserved namespace. This is preferred over hardcoding the schema name since new major postgres versions may introduce additional schemas.

## Additional context

https://www.postgresql.org/docs/current/ddl-schemas.html
