### PR TITLE
fix: index extraction partitions tables

### DIFF
--- a/src/objects/index/index.model.ts
+++ b/src/objects/index/index.model.ts
@@ -220,6 +220,7 @@ export async function extractIndexes(sql: Sql): Promise<Index[]> {
     join pg_am am    on am.oid = c.relam
     left join pg_tablespace ts on ts.oid = c.reltablespace
     left join extension_oids e  on c.oid = e.objid
+    left join extension_oids e_table on tc.oid = e_table.objid
 
     -- single lateral aggregate keeps order by ic2.ord
     left join lateral (
@@ -279,10 +280,10 @@ export async function extractIndexes(sql: Sql): Promise<Index[]> {
       and n.nspname <> 'information_schema'
       and i.indislive is true
       and e.objid is null
+      and e_table.objid is null
 
     order by 1, 2;
     `;
-
     // Validate and parse each row using the Zod schema
     const validatedRows = indexRows.map((row: unknown) =>
       indexPropsSchema.parse(row),


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Allow partitioned tables relkinds
- Filter out indexed based on table that are part of extensions (should we do this ? If we don't we are missing objects when creation because we filter them out for tables fetching. So either we filter in both cases, or in none of them).

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
