### PR TITLE
ci: skip tests for supabase-releaser - exit with 0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,59 +20,95 @@ concurrency:
 
 jobs:
   test-type-check:
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'supabase-releaser[bot]'
+    if: github.event.pull_request.draft == false
     name: Check types
     runs-on: ubuntu-latest
     steps:
+      - name: Skip if release bot
+        if: github.event.pull_request.user.login == 'supabase-releaser[bot]'
+        run: |
+          echo "✓ Skipping type check for release bot"
+          exit 0
+
       - name: Checkout
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: actions/checkout@v6
 
       - name: Setup
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: ./.github/actions/setup
 
       - name: Check types
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         run: pnpm check-types
 
   test-format-and-lint:
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'supabase-releaser[bot]'
+    if: github.event.pull_request.draft == false
     name: Format and lint
     runs-on: ubuntu-latest
     steps:
+      - name: Skip if release bot
+        if: github.event.pull_request.user.login == 'supabase-releaser[bot]'
+        run: |
+          echo "✓ Skipping format and lint for release bot"
+          exit 0
+
       - name: Checkout
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: actions/checkout@v6
 
       - name: Setup
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: ./.github/actions/setup
 
       - name: Format and lint
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         run: pnpm format-and-lint
 
   test-knip:
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'supabase-releaser[bot]'
+    if: github.event.pull_request.draft == false
     name: Knip
     runs-on: ubuntu-latest
     steps:
+      - name: Skip if release bot
+        if: github.event.pull_request.user.login == 'supabase-releaser[bot]'
+        run: |
+          echo "✓ Skipping knip for release bot"
+          exit 0
+
       - name: Checkout
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: actions/checkout@v6
 
       - name: Setup
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: ./.github/actions/setup
 
       - name: Knip
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         run: pnpm knip
 
   test-unit:
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'supabase-releaser[bot]'
+    if: github.event.pull_request.draft == false
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
+      - name: Skip if release bot
+        if: github.event.pull_request.user.login == 'supabase-releaser[bot]'
+        run: |
+          echo "✓ Skipping unit tests for release bot"
+          exit 0
+
       - name: Checkout
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: actions/checkout@v6
 
       - name: Setup
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: ./.github/actions/setup
 
       - name: Run unit tests
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         run: pnpm test --project=unit --coverage
 
       # TODO: Uncomment this when we have the repository made public
@@ -82,20 +118,29 @@ jobs:
       #     path-to-lcov: coverage/lcov.info
 
   test-integration:
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'supabase-releaser[bot]'
+    if: github.event.pull_request.draft == false
     name: Integration tests (PostgreSQL ${{ matrix.postgres_version }})
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:
         postgres_version: [15, 17]
     steps:
+      - name: Skip if release bot
+        if: github.event.pull_request.user.login == 'supabase-releaser[bot]'
+        run: |
+          echo "✓ Skipping integration tests for release bot"
+          exit 0
+
       - name: Checkout
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: actions/checkout@v6
 
       - name: Setup
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         uses: ./.github/actions/setup
 
       - name: Run integration tests
+        if: github.event.pull_request.user.login != 'supabase-releaser[bot]'
         env:
           PGDELTA_TEST_POSTGRES_VERSIONS: ${{ matrix.postgres_version }}
         run: pnpm test --project=integration --coverage


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI update

## What is the current behavior?

When supabase-releaser creates a PR, the tests are skipped, but stuck in pending.

## What is the new behavior?

Add step to return success (0), so that each required job is marked as successful.

## Additional context

- supabase-releaser should not run required tests.
- Discussed with @jgoux 

