### PR TITLE
fix: add 'cli_login_postgres' to SUPABASE_SYSTEM_ROLES

### DIFF
--- a/src/core/integrations/supabase.ts
+++ b/src/core/integrations/supabase.ts
@@ -39,6 +39,7 @@ const SUPABASE_SYSTEM_ROLES = [
   "anon",
   "authenticated",
   "authenticator",
+  "cli_login_postgres",
   "dashboard_user",
   "pgbouncer",
   "pgsodium_keyholder",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Not possible to create temporary login role via migration.

## Additional context

Add any other context or screenshots.
