### PR TITLE
fix(diff): handle table trigger constraints types

### DIFF
--- a/.changeset/many-bobcats-divide.md
+++ b/.changeset/many-bobcats-divide.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Handle constraint triggers in table introspection and trigger updates

--- a/src/core/objects/table/table.model.ts
+++ b/src/core/objects/table/table.model.ts
@@ -47,6 +47,7 @@ const tableConstraintPropsSchema = z.object({
     "c", // CHECK constraint
     "f", // FOREIGN KEY constraint
     "p", // PRIMARY KEY constraint
+    "t", // TRIGGER constraint
     "u", // UNIQUE constraint
     "x", // EXCLUDE constraint
   ]),
@@ -369,6 +370,8 @@ select
       and de.refclassid = 'pg_extension'::regclass
 
       where c.conrelid = t.oid
+        -- Skip constraint triggers; they are modeled as triggers, not table constraints
+        and c.contype <> 't'
         and not c.connamespace::regnamespace::text like any(array['pg\\_%', 'information\\_schema'])
         and de.objid is null
     ),

--- a/src/core/objects/trigger/changes/trigger.create.ts
+++ b/src/core/objects/trigger/changes/trigger.create.ts
@@ -73,10 +73,11 @@ export class CreateTrigger extends CreateTriggerChange {
 
   serialize(): string {
     let definition = this.trigger.definition.trim();
+    const isConstraintTrigger = this.trigger.isConstraintTrigger;
 
     definition = definition.replace(
       /^CREATE\s+(?:OR\s+REPLACE\s+)?/i,
-      `CREATE ${this.orReplace ? "OR REPLACE " : ""}`,
+      `CREATE ${this.orReplace && !isConstraintTrigger ? "OR REPLACE " : ""}`,
     );
 
     return definition;

--- a/src/core/objects/trigger/trigger.model.ts
+++ b/src/core/objects/trigger/trigger.model.ts
@@ -97,6 +97,10 @@ export class Trigger extends BasePgModel {
     this.comment = props.comment;
   }
 
+  get isConstraintTrigger(): boolean {
+    return /^CREATE\s+CONSTRAINT\s+TRIGGER/i.test(this.definition.trim());
+  }
+
   get stableId(): `trigger:${string}` {
     return `trigger:${this.schema}.${this.table_name}.${this.name}`;
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dogfooding over some database schemas (platform). Found out this was a missing part of the implementation, where a table can have a "trigger" constraint. Causing parse error at zod level. This is now handled at introspection time with appropriate integrations tests to cover the case.