### PR TITLE
fix(introspection): pg driver migration and type serialization issues

### DIFF
--- a/.changeset/calm-jeans-study.md
+++ b/.changeset/calm-jeans-study.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix pg driver type compatibility for instrospection

--- a/src/core/objects/aggregate/aggregate.model.ts
+++ b/src/core/objects/aggregate/aggregate.model.ts
@@ -278,7 +278,9 @@ select
   end as argument_names,
   array(select format_type(oid, null) from unnest(p.proargtypes) as oid) as argument_types,
   array(select format_type(oid, null) from unnest(p.proallargtypes) as oid) as all_argument_types,
-  p.proargmodes as argument_modes,
+  case when p.proargmodes is null then null
+       else array(select mode::text from unnest(p.proargmodes) as mode)
+  end as argument_modes,
   pg_get_expr(p.proargdefaults, 0) as argument_defaults,
   p.proowner::regrole::text as owner,
   obj_description(p.oid, 'pg_proc') as comment,

--- a/src/core/objects/index/index.model.ts
+++ b/src/core/objects/index/index.model.ts
@@ -248,7 +248,10 @@ export async function extractIndexes(pool: Pool): Promise<Index[]> {
         i.indimmediate                     as immediate,
         i.indisclustered                   as is_clustered,
         i.indisreplident                   as is_replica_identity,
-        i.indkey                           as key_columns,
+        coalesce(
+          (select array_agg(n::int) from unnest(string_to_array(trim(i.indkey::text), ' ')) as n where n <> ''),
+          array[]::int[]
+        )                                  as key_columns,
 
         -- NEW: partitioned-index / index-partition tagging
         (c.relkind = 'I')                  as is_partitioned_index,

--- a/src/core/objects/procedure/procedure.model.ts
+++ b/src/core/objects/procedure/procedure.model.ts
@@ -223,7 +223,9 @@ select
     select format_type(oid, null)
     from unnest(p.proallargtypes) as oid
   ) as all_argument_types,
-  p.proargmodes as argument_modes,
+  case when p.proargmodes is null then null
+       else array(select mode::text from unnest(p.proargmodes) as mode)
+  end as argument_modes,
   pg_get_expr(p.proargdefaults, 0) as argument_defaults,
   p.prosrc as source_code,
   p.probin as binary_path,

--- a/src/core/objects/sequence/sequence.model.ts
+++ b/src/core/objects/sequence/sequence.model.ts
@@ -12,8 +12,9 @@ const sequencePropsSchema = z.object({
   name: z.string(),
   data_type: z.string(),
   start_value: z.number(),
-  minimum_value: z.bigint(),
-  maximum_value: z.bigint(),
+  // pg driver returns bigin bigint as string, so we need to coerce it to bigint
+  minimum_value: z.coerce.bigint(),
+  maximum_value: z.coerce.bigint(),
   increment: z.number(),
   cycle_option: z.boolean(),
   cache_size: z.number(),

--- a/src/core/objects/trigger/trigger.model.ts
+++ b/src/core/objects/trigger/trigger.model.ts
@@ -170,7 +170,9 @@ export async function extractTriggers(pool: Pool): Promise<Trigger[]> {
         t.tgdeferrable                       as deferrable,
         t.tginitdeferred                     as initially_deferred,
         t.tgnargs                            as argument_count,
-        t.tgattr                             as column_numbers,
+        case when t.tgattr is null or trim(t.tgattr::text) = '' then null
+             else (select array_agg(n::int) from unnest(string_to_array(trim(t.tgattr::text), ' ')) as n where n <> '')
+        end                                  as column_numbers,
 
         case when t.tgnargs > 0
             then array_fill(''::text, array[t.tgnargs])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dogfooding over some db schemas, found out that, migrating from `postgres` to `pg` some things diverge.

`pg` handle some types differently than `postgres` does natively. For instance:

1. Some array will be represented as string like `'{a,b}'` except if explicit cast is performed.
2. `bigint` are returned as pure string by `pg`, so they need to be coerced

TODO: add unit tests over this so it doesn't happen again.
