### PR TITLE
chore(ci): improve perfs with sharding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,6 +156,34 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+  test-integration-pg15-compat:
+    if: always() && github.event.pull_request.draft == false
+    needs:
+      - test-integration
+    name: Integration tests (PostgreSQL 15)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate integration matrix status
+        run: |
+          if [ "${{ needs.test-integration.result }}" != "success" ]; then
+            echo "Integration matrix status: ${{ needs.test-integration.result }}"
+            exit 1
+          fi
+
+  test-integration-pg17-compat:
+    if: always() && github.event.pull_request.draft == false
+    needs:
+      - test-integration
+    name: Integration tests (PostgreSQL 17)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate integration matrix status
+        run: |
+          if [ "${{ needs.test-integration.result }}" != "success" ]; then
+            echo "Integration matrix status: ${{ needs.test-integration.result }}"
+            exit 1
+          fi
+
   test-integration-merge-reports:
     if: github.event.pull_request.draft == false
     needs:
@@ -196,6 +224,8 @@ jobs:
       - test-knip
       - test-unit
       - test-integration
+      - test-integration-pg15-compat
+      - test-integration-pg17-compat
       - test-integration-merge-reports
     name: Release preview
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the integration test workflow to improve test performance and reporting by introducing test sharding and merging of coverage reports. The integration tests are now split across multiple shards to run in parallel, and a new job is added to merge the results and coverage reports from all shards. This should speed up CI and provide a unified test report.

**Integration test sharding and reporting improvements:**

* Integration tests are now run in four shards, each identified by `shard_index` and `shard_total` in the job matrix, allowing tests to run in parallel for faster execution. The job name is updated to reflect the shard being run.
* The integration test command now includes `--reporter=blob` and `--shard` flags to support sharded test execution and reporting.
* Each shard uploads its test report as an artifact named with its PostgreSQL version and shard index, ensuring that all results are available for later merging.

**Merging of shard reports:**

* A new `test-integration-merge-reports` job is added to download all shard reports, merge them, and generate a unified coverage and test report. This job runs after all shards complete.
* The `release-preview` job is updated to depend on the new merge reports job, ensuring that the unified report is available before release preview runs.

Going from ~8mins to ~1mins total time.