### PR TITLE
chore: export catalog-export

### DIFF
--- a/.changeset/add-catalog-export-subpath.md
+++ b/.changeset/add-catalog-export-subpath.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": minor
+---
+
+Add `@supabase/pg-delta/catalog-export` subpath export for programmatic catalog export (extract, serialize, deserialize, createManagedPool) without pulling in the full package API.

--- a/.changeset/nine-candles-sleep.md
+++ b/.changeset/nine-candles-sleep.md
@@ -1,0 +1,6 @@
+---
+"@supabase/pg-delta": minor
+"@supabase/pg-topo": minor
+---
+
+feat: add declarative export/apply and catalog-export to pg-delta

--- a/packages/pg-delta/package.json
+++ b/packages/pg-delta/package.json
@@ -20,6 +20,20 @@
       "require": "./dist/core/integrations/supabase.js",
       "types": "./dist/core/integrations/supabase.d.ts",
       "default": "./dist/core/integrations/supabase.js"
+    },
+    "./declarative": {
+      "bun": "./src/core/declarative-apply/index.ts",
+      "import": "./dist/core/declarative-apply/index.js",
+      "require": "./dist/core/declarative-apply/index.js",
+      "types": "./dist/core/declarative-apply/index.d.ts",
+      "default": "./dist/core/declarative-apply/index.js"
+    },
+    "./catalog-export": {
+      "bun": "./src/core/catalog-export/index.ts",
+      "import": "./dist/core/catalog-export/index.js",
+      "require": "./dist/core/catalog-export/index.js",
+      "types": "./dist/core/catalog-export/index.d.ts",
+      "default": "./dist/core/catalog-export/index.js"
     }
   },
   "bin": {

--- a/packages/pg-delta/src/core/catalog-export/index.ts
+++ b/packages/pg-delta/src/core/catalog-export/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Catalog export – programmatic API for extracting a database catalog
+ * and serializing it to a JSON snapshot.
+ *
+ * Use this subpath when you only need catalog export (e.g. Supabase CLI
+ * edge-runtime templates) without pulling in the full pg-delta API.
+ */
+
+export {
+  Catalog,
+  createEmptyCatalog,
+  extractCatalog,
+} from "../catalog.model.ts";
+export type { CatalogSnapshot } from "../catalog.snapshot.ts";
+export {
+  deserializeCatalog,
+  serializeCatalog,
+  stringifyCatalogSnapshot,
+} from "../catalog.snapshot.ts";
+export { createManagedPool } from "../postgres-config.ts";

--- a/packages/pg-delta/src/core/declarative-apply/index.ts
+++ b/packages/pg-delta/src/core/declarative-apply/index.ts
@@ -197,5 +197,9 @@ export async function applyDeclarativeSchema(
   }
 }
 
+export type { SqlFileEntry } from "./discover-sql.ts";
+
+// Re-export file discovery for programmatic callers (e.g. Supabase CLI edge-runtime templates)
+export { loadDeclarativeSchema } from "./discover-sql.ts";
 // Re-export result types for callers that need them (StatementError is imported from round-apply directly where needed)
 export type { ApplyResult, RoundResult } from "./round-apply.ts";


### PR DESCRIPTION
This pull request introduces new subpath exports to the `@supabase/pg-delta` package, enabling more modular and programmatic access to catalog export and declarative schema operations. The changes allow consumers, such as the Supabase CLI, to use only the necessary parts of the API without loading the entire package, improving flexibility and reducing bundle size.

**New modular exports for catalog and declarative schema operations:**

* Added a new `@supabase/pg-delta/catalog-export` subpath export for programmatic catalog export, including extraction, serialization, deserialization, and managed pool creation. This allows users to access catalog export functionality without importing the full package API. (`.changeset/add-catalog-export-subpath.md`, [[1]](diffhunk://#diff-a182898c6bb22a5e12dc1847c47869ddf7c2d5bd9951807bfcb611765854d841R23-R36) [[2]](diffhunk://#diff-2d2e1aad6979d143056bf92d4031ba095ab75de9e8c162fbc698eba093a44c40R1-R20)
* Introduced a new `@supabase/pg-delta/declarative` subpath export, providing access to declarative schema apply and file discovery methods for programmatic use cases. (`.changeset/nine-candles-sleep.md`, [[1]](diffhunk://#diff-a182898c6bb22a5e12dc1847c47869ddf7c2d5bd9951807bfcb611765854d841R23-R36) [[2]](diffhunk://#diff-757ce02d04ef198da04878bf7248dca613c15fc754cbdcdf661be8b2145bd38cR200-R203)

**Enhancements for programmatic usage:**

* Re-exported relevant types and functions (e.g., `SqlFileEntry`, `loadDeclarativeSchema`, `ApplyResult`, `RoundResult`) for easier integration in tools like Supabase CLI edge-runtime templates.

These changes make the package more modular and easier to integrate in scenarios where only specific functionality is needed, without unnecessary dependencies.