### PR TITLE
fix(pg-delta): drop out of order operations

### DIFF
--- a/.changeset/fix-drop-ordering.md
+++ b/.changeset/fix-drop-ordering.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(sort): order FK-related table drops and publication table removals before dependent destructive operations

--- a/packages/pg-delta/src/core/objects/publication/changes/publication.alter.test.ts
+++ b/packages/pg-delta/src/core/objects/publication/changes/publication.alter.test.ts
@@ -156,6 +156,10 @@ describe("publication.alter", () => {
       stableId.table("public", "logs"),
       stableId.table("audit", "events"),
     ]);
+    expect(change.drops).toEqual([
+      stableId.table("public", "logs"),
+      stableId.table("audit", "events"),
+    ]);
     await assertValidSql(change.serialize());
     expect(change.serialize()).toBe(
       "ALTER PUBLICATION pub_drop_tables DROP TABLE public.logs, audit.events",

--- a/packages/pg-delta/src/core/objects/publication/changes/publication.alter.ts
+++ b/packages/pg-delta/src/core/objects/publication/changes/publication.alter.ts
@@ -151,6 +151,8 @@ export class AlterPublicationDropTables extends AlterPublicationChange {
   }
 
   get drops() {
+    // Treat ALTER PUBLICATION ... DROP TABLE as a destructive change so it runs
+    // in the drop phase before DROP TABLE removes the referenced relation.
     return this.tables.map((table) => stableId.table(table.schema, table.name));
   }
 

--- a/packages/pg-delta/src/core/objects/publication/changes/publication.alter.ts
+++ b/packages/pg-delta/src/core/objects/publication/changes/publication.alter.ts
@@ -150,6 +150,10 @@ export class AlterPublicationDropTables extends AlterPublicationChange {
     return Array.from(dependencies);
   }
 
+  get drops() {
+    return this.tables.map((table) => stableId.table(table.schema, table.name));
+  }
+
   serialize(): string {
     const targets = this.tables.map((table) => `${table.schema}.${table.name}`);
     return `ALTER PUBLICATION ${this.publication.name} DROP TABLE ${targets.join(", ")}`;

--- a/packages/pg-delta/src/core/objects/table/changes/table.drop.ts
+++ b/packages/pg-delta/src/core/objects/table/changes/table.drop.ts
@@ -27,6 +27,8 @@ export class DropTable extends DropTableChange {
       ...this.table.columns.map((column) =>
         stableId.column(this.table.schema, this.table.name, column.name),
       ),
+      // Include constraint stableIds so FK relationships that only exist at the
+      // constraint level still affect whole-table drop ordering.
       ...this.table.constraints.map((constraint) =>
         stableId.constraint(
           this.table.schema,
@@ -43,6 +45,8 @@ export class DropTable extends DropTableChange {
       ...this.table.columns.map((col) =>
         stableId.column(this.table.schema, this.table.name, col.name),
       ),
+      // Mirror the dropped constraint ids in requires so drop-phase graph
+      // consumers can connect catalog FK edges back to this table drop.
       ...this.table.constraints.map((constraint) =>
         stableId.constraint(
           this.table.schema,

--- a/packages/pg-delta/src/core/objects/table/changes/table.drop.ts
+++ b/packages/pg-delta/src/core/objects/table/changes/table.drop.ts
@@ -27,6 +27,13 @@ export class DropTable extends DropTableChange {
       ...this.table.columns.map((column) =>
         stableId.column(this.table.schema, this.table.name, column.name),
       ),
+      ...this.table.constraints.map((constraint) =>
+        stableId.constraint(
+          this.table.schema,
+          this.table.name,
+          constraint.name,
+        ),
+      ),
     ];
   }
 
@@ -35,6 +42,13 @@ export class DropTable extends DropTableChange {
       this.table.stableId,
       ...this.table.columns.map((col) =>
         stableId.column(this.table.schema, this.table.name, col.name),
+      ),
+      ...this.table.constraints.map((constraint) =>
+        stableId.constraint(
+          this.table.schema,
+          this.table.name,
+          constraint.name,
+        ),
       ),
     ];
   }

--- a/packages/pg-delta/tests/integration/fk-constraint-ordering.test.ts
+++ b/packages/pg-delta/tests/integration/fk-constraint-ordering.test.ts
@@ -6,7 +6,7 @@
  * before the referenced table existed.
  */
 
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { POSTGRES_VERSIONS } from "../constants.ts";
 import { withDb } from "../utils.ts";
 import { roundtripFidelityTest } from "./roundtrip.ts";
@@ -191,6 +191,42 @@ for (const pgVersion of POSTGRES_VERSIONS) {
           FOREIGN KEY (user_id) REFERENCES test_schema.users(id)
           ON DELETE CASCADE ON UPDATE CASCADE;
         `,
+        });
+      }),
+    );
+
+    test(
+      "drop referencing table before referenced table",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE TABLE public.challenge_levels (
+            id BIGSERIAL PRIMARY KEY
+          );
+
+          CREATE TABLE public.user_challenge_progress (
+            id BIGSERIAL PRIMARY KEY,
+            level_id BIGINT REFERENCES public.challenge_levels(id)
+          );
+        `,
+          testSql: `
+          DROP TABLE public.user_challenge_progress;
+          DROP TABLE public.challenge_levels;
+        `,
+          assertSqlStatements: (statements) => {
+            const dropTableStatements = statements.filter((statement) =>
+              statement.startsWith("DROP TABLE public."),
+            );
+
+            expect(dropTableStatements).toMatchInlineSnapshot(`
+              [
+                "DROP TABLE public.user_challenge_progress",
+                "DROP TABLE public.challenge_levels",
+              ]
+            `);
+          },
         });
       }),
     );

--- a/packages/pg-delta/tests/integration/publication-operations.test.ts
+++ b/packages/pg-delta/tests/integration/publication-operations.test.ts
@@ -1,4 +1,4 @@
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { Change } from "../../src/core/change.types.ts";
 import { POSTGRES_VERSIONS } from "../constants.ts";
 import { withDb, withDbIsolated } from "../utils.ts";
@@ -203,6 +203,42 @@ for (const pgVersion of POSTGRES_VERSIONS) {
           ALTER PUBLICATION pub_metadata OWNER TO pub_owner;
           COMMENT ON PUBLICATION pub_metadata IS 'audit publication';
         `,
+        });
+      }),
+    );
+
+    test(
+      "drop table from publication before dropping table",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE TABLE public.challenge_levels (
+            id BIGINT PRIMARY KEY
+          );
+
+          CREATE PUBLICATION pub_drop_order FOR TABLE public.challenge_levels;
+        `,
+          testSql: `
+          ALTER PUBLICATION pub_drop_order DROP TABLE public.challenge_levels;
+          DROP TABLE public.challenge_levels;
+        `,
+          assertSqlStatements: (statements) => {
+            const relevantStatements = statements.filter(
+              (statement) =>
+                statement ===
+                  "ALTER PUBLICATION pub_drop_order DROP TABLE public.challenge_levels" ||
+                statement === "DROP TABLE public.challenge_levels",
+            );
+
+            expect(relevantStatements).toMatchInlineSnapshot(`
+              [
+                "ALTER PUBLICATION pub_drop_order DROP TABLE public.challenge_levels",
+                "DROP TABLE public.challenge_levels",
+              ]
+            `);
+          },
         });
       }),
     );


### PR DESCRIPTION
I dug into the reported DROP-ordering regressions and reproduced both cases with focused integration tests before changing sorter behavior.

## Context

There were two concrete failures in generated plan SQL:

1. FK-related table drops were ordered as:
   - `DROP TABLE challenge_levels`
   - `DROP TABLE user_challenge_progress`

   That fails because the FK on `user_challenge_progress` still depends on `challenge_levels`.

2. Publication membership changes were ordered as:
   - `DROP TABLE challenge_levels`
   - `ALTER PUBLICATION pub DROP TABLE challenge_levels`

   That fails because the table must still exist when removing it from the publication.

## Root Cause

The interesting part is that the catalog dependency extraction was already capturing the important relationships:
- FK dependencies exist at the constraint level
- publication-to-table dependencies already exist in the dependency data

The actual gap was in the change metadata that feeds the sorter:

- `DropTable` only exposed table and column stable IDs, so FK edges that only existed at the constraint level were not influencing whole-table drop ordering.
- `AlterPublicationDropTables` exposed `requires`, but not `drops`, so it was treated like a non-destructive `ALTER` and sorted after the real table drop.

## Fix

This patch fixes the ordering by making the destructive changes advertise the right stable IDs to the sorter:

- `DropTable` now includes table constraint stable IDs in its drop-phase metadata, which lets FK constraint dependencies affect whole-table drop ordering.
- `AlterPublicationDropTables` now exposes dropped table stable IDs, so it participates in the destructive/drop phase and runs before `DROP TABLE`.

I also added focused integration coverage for both reported scenarios, plus a small unit assertion around the publication change metadata.

## Verification

Verified with:
- `PGDELTA_TEST_POSTGRES_VERSIONS=17 bun run test tests/integration/fk-constraint-ordering.test.ts`
- `PGDELTA_TEST_POSTGRES_VERSIONS=17 bun run test tests/integration/publication-operations.test.ts`
- `PGDELTA_TEST_POSTGRES_VERSIONS=17 bun run test tests/integration/trigger-operations.test.ts`
- `bun run test src/core/objects/publication/changes/publication.alter.test.ts`
- `bun run test src/core/objects/table/changes/table.drop.test.ts`

So this ends up being less about missing raw dependency extraction and more about making sure destructive change objects surface enough information for the sorter to use the dependency graph correctly.


Fixes #193