### PR TITLE
fix(pg-delta): declarative export accept SerializeDSL

### DIFF
--- a/.changeset/fresh-geese-check.md
+++ b/.changeset/fresh-geese-check.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(export): allow declarative schema export to accept raw integration DSL without requiring callers to precompile serialize rules

--- a/packages/pg-delta/src/core/export/index.ts
+++ b/packages/pg-delta/src/core/export/index.ts
@@ -4,7 +4,11 @@
 
 import type { Change } from "../change.types.ts";
 import { buildPlanScopeFingerprint, hashStableIds } from "../fingerprint.ts";
-import type { Integration } from "../integrations/integration.types.ts";
+import {
+  type Integration,
+  type ResolvedIntegration,
+  resolveIntegration,
+} from "../integrations/integration.types.ts";
 import type { createPlan } from "../plan/create.ts";
 import { DEFAULT_OPTIONS } from "../plan/sql-format/constants.ts";
 import type { SqlFormatOptions } from "../plan/sql-format/types.ts";
@@ -29,7 +33,7 @@ type PlanResult = NonNullable<Awaited<ReturnType<typeof createPlan>>>;
 
 export interface ExportOptions {
   /** Integration for custom serialization */
-  integration?: Integration;
+  integration?: Pick<Integration, "serialize">;
   /**
    * SQL formatter options to control the output style.
    * Merged on top of the default export options (maxWidth: 180, keywordCase: "upper").
@@ -64,7 +68,9 @@ export function exportDeclarativeSchema(
   options?: ExportOptions,
 ): DeclarativeSchemaOutput {
   const { ctx, sortedChanges } = planResult;
-  const integration = options?.integration;
+  const integration = options?.integration
+    ? resolveIntegration(options?.integration)
+    : {};
   const formatOptions: SqlFormatOptions | undefined =
     options?.formatOptions === null
       ? undefined
@@ -108,7 +114,10 @@ export function exportDeclarativeSchema(
   };
 }
 
-function serializeChange(change: Change, integration?: Integration): string {
+function serializeChange(
+  change: Change,
+  integration?: ResolvedIntegration,
+): string {
   return integration?.serialize?.(change) ?? change.serialize();
 }
 

--- a/packages/pg-delta/src/core/integrations/integration.types.ts
+++ b/packages/pg-delta/src/core/integrations/integration.types.ts
@@ -1,7 +1,65 @@
+import { compileFilterDSL, type FilterDSL } from "./filter/dsl.ts";
 import type { ChangeFilter } from "./filter/filter.types.ts";
+import { compileSerializeDSL, type SerializeDSL } from "./serialize/dsl.ts";
 import type { ChangeSerializer } from "./serialize/serialize.types.ts";
 
-export type Integration = {
+/**
+ * A resolved integration is an integration that has been compiled to a function.
+ */
+export type ResolvedIntegration = {
   filter?: ChangeFilter;
   serialize?: ChangeSerializer;
 };
+
+/**
+ * A raw integration is an integration that has not been compiled to a function.
+ */
+export type IntegrationDSL = {
+  filter?: FilterDSL;
+  serialize?: SerializeDSL;
+};
+
+/**
+ * An integration is a raw integration that has not been compiled to a function.
+ */
+export type Integration = {
+  filter?: ResolvedIntegration["filter"] | IntegrationDSL["filter"];
+  serialize?: ResolvedIntegration["serialize"] | IntegrationDSL["serialize"];
+};
+
+/**
+ * Resolve an integration either DSL or already resovled into a ResolvedIntegration.
+ * @param integration - The integration to resolve.
+ * @returns The resolved integration.
+ */
+export function resolveIntegration(
+  integration: Integration,
+): ResolvedIntegration | undefined {
+  // Determine if filter/serialize are DSL or functions, and extract DSL for storage
+  const isFilterDSL =
+    integration.filter && typeof integration.filter !== "function";
+  const isSerializeDSL =
+    integration.serialize && typeof integration.serialize !== "function";
+  const filterDSL = isFilterDSL ? (integration.filter as FilterDSL) : undefined;
+  const serializeDSL = isSerializeDSL
+    ? (integration.serialize as SerializeDSL)
+    : undefined;
+
+  // Build final integration: compile DSL if needed, use functions directly otherwise
+  if (integration.filter || integration.serialize) {
+    return {
+      filter:
+        typeof integration.filter === "function"
+          ? integration.filter
+          : filterDSL
+            ? compileFilterDSL(filterDSL)
+            : undefined,
+      serialize:
+        typeof integration.serialize === "function"
+          ? integration.serialize
+          : serializeDSL
+            ? compileSerializeDSL(serializeDSL)
+            : undefined,
+    };
+  }
+}

--- a/packages/pg-delta/src/core/plan/create.ts
+++ b/packages/pg-delta/src/core/plan/create.ts
@@ -10,15 +10,12 @@ import { createEmptyCatalog, extractCatalog } from "../catalog.model.ts";
 import type { Change } from "../change.types.ts";
 import type { DiffContext } from "../context.ts";
 import { buildPlanScopeFingerprint, hashStableIds } from "../fingerprint.ts";
+import type { FilterDSL } from "../integrations/filter/dsl.ts";
 import {
-  compileFilterDSL,
-  type FilterDSL,
-} from "../integrations/filter/dsl.ts";
-import type { Integration } from "../integrations/integration.types.ts";
-import {
-  compileSerializeDSL,
-  type SerializeDSL,
-} from "../integrations/serialize/dsl.ts";
+  type ResolvedIntegration,
+  resolveIntegration,
+} from "../integrations/integration.types.ts";
+import type { SerializeDSL } from "../integrations/serialize/dsl.ts";
 import { createManagedPool, endPool } from "../postgres-config.ts";
 import { sortChanges } from "../sort/sort-changes.ts";
 import type { PgDependRow } from "../sort/types.ts";
@@ -155,23 +152,10 @@ function buildPlanForCatalogs(
     : undefined;
 
   // Build final integration: compile DSL if needed, use functions directly otherwise
-  let finalIntegration: Integration | undefined;
-  if (filterOption || serializeOption) {
-    finalIntegration = {
-      filter:
-        typeof filterOption === "function"
-          ? filterOption
-          : filterDSL
-            ? compileFilterDSL(filterDSL)
-            : undefined,
-      serialize:
-        typeof serializeOption === "function"
-          ? serializeOption
-          : serializeDSL
-            ? compileSerializeDSL(serializeDSL)
-            : undefined,
-    };
-  }
+  const finalIntegration = resolveIntegration({
+    filter: filterOption,
+    serialize: serializeOption,
+  });
 
   // Use filter from final integration
   const filterFn = finalIntegration?.filter;
@@ -317,7 +301,7 @@ function buildPlan(
   options?: CreatePlanOptions,
   filterDSL?: FilterDSL,
   serializeDSL?: SerializeDSL,
-  integration?: Integration,
+  integration?: ResolvedIntegration,
 ): Plan {
   const role = options?.role;
   const statements = generateStatements(changes, {
@@ -350,7 +334,7 @@ function buildPlan(
 function generateStatements(
   changes: Change[],
   options?: {
-    integration?: Integration;
+    integration?: ResolvedIntegration;
     role?: string;
   },
 ): string[] {

--- a/packages/pg-delta/src/core/plan/types.ts
+++ b/packages/pg-delta/src/core/plan/types.ts
@@ -4,10 +4,7 @@
 
 import z from "zod";
 import type { Change } from "../change.types.ts";
-import type { FilterDSL } from "../integrations/filter/dsl.ts";
-import type { ChangeFilter } from "../integrations/filter/filter.types.ts";
-import type { SerializeDSL } from "../integrations/serialize/dsl.ts";
-import type { ChangeSerializer } from "../integrations/serialize/serialize.types.ts";
+import type { Integration } from "../integrations/integration.types.ts";
 
 // ============================================================================
 // Core Types
@@ -157,9 +154,9 @@ export type Plan = z.infer<typeof PlanSchema>;
  */
 export interface CreatePlanOptions {
   /** Filter - either FilterDSL (stored in plan) or ChangeFilter function (not stored) */
-  filter?: FilterDSL | ChangeFilter;
+  filter?: Integration["filter"];
   /** Serialize - either SerializeDSL (stored in plan) or ChangeSerializer function (not stored) */
-  serialize?: SerializeDSL | ChangeSerializer;
+  serialize?: Integration["serialize"];
   /** Role to use when executing the migration (SET ROLE will be added to statements) */
   role?: string;
   /**

--- a/packages/pg-delta/tests/integration/remote-supabase.test.ts
+++ b/packages/pg-delta/tests/integration/remote-supabase.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { diffCatalogs } from "../../src/core/catalog.diff.ts";
 import { extractCatalog } from "../../src/core/catalog.model.ts";
 import type { Change } from "../../src/core/change.types.ts";
-import type { Integration } from "../../src/core/integrations/integration.types.ts";
+import type { ResolvedIntegration } from "../../src/core/integrations/integration.types.ts";
 import { AlterRoleSetOptions } from "../../src/core/objects/role/changes/role.alter.ts";
 import { CreateRole } from "../../src/core/objects/role/changes/role.create.ts";
 import {
@@ -34,7 +34,7 @@ test.skip(
 
     const changes = diffCatalogs(mainCatalog, branchCatalog);
 
-    const options: Integration = {
+    const options: ResolvedIntegration = {
       filter: (change: Change) => {
         // ALTER ROLE postgres WITH NOSUPERUSER;
         const isAlterRolePostgresWithNosuperuser =

--- a/packages/pg-delta/tests/integration/roundtrip.ts
+++ b/packages/pg-delta/tests/integration/roundtrip.ts
@@ -21,7 +21,11 @@ import {
   buildPlanScopeFingerprint,
   hashStableIds,
 } from "../../src/core/fingerprint.ts";
-import type { Integration } from "../../src/core/integrations/integration.types.ts";
+import {
+  type Integration,
+  type ResolvedIntegration,
+  resolveIntegration,
+} from "../../src/core/integrations/integration.types.ts";
 import { applyPlan } from "../../src/core/plan/apply.ts";
 import { createPlan } from "../../src/core/plan/create.ts";
 import { sortChanges } from "../../src/core/sort/sort-changes.ts";
@@ -152,7 +156,10 @@ export async function roundtripFidelityTest(
   }
 
   let { plan, sortedChanges } = planResult;
-  const integrationFilter = integration?.filter;
+  const resolvedIntegration = integration
+    ? resolveIntegration(integration)
+    : {};
+  const integrationFilter = resolvedIntegration?.filter;
 
   // Optional pre-sort for deterministic tie-breaking in tests
   if (sortChangesCallback) {
@@ -314,7 +321,10 @@ export async function testDeclarativeExport(
 
   const { sortedChanges, ctx } = planResult;
   const { branchCatalog } = ctx;
-  const integrationFilter = integration?.filter;
+  const resolvedIntegration = integration
+    ? resolveIntegration(integration)
+    : {};
+  const integrationFilter = resolvedIntegration?.filter;
 
   const output = exportDeclarativeSchema(planResult, {
     integration,
@@ -411,7 +421,7 @@ export async function testDeclarativeExport(
 async function verifyNoRemainingChanges(
   mainSession: Pool,
   branchCatalog: Catalog,
-  integrationFilter: Integration["filter"] | undefined,
+  integrationFilter: ResolvedIntegration["filter"] | undefined,
   migrationScript: string,
 ): Promise<void> {
   debugTest("mainCatalogAfter: ");


### PR DESCRIPTION
## What kind of change does this PR introduce?

Unify Integration input for functions (createPlan / exportDeclarativeSchema)
Allow them both to use either already compiled integration or pure raw DSL.

Splitting both types between `ResolvedIntegration` and `IntegrationDSL` to represent the union with an utils to go from one to another in an unified way.
