### PR TITLE
chore(tests): increase timeout and max attempts for integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,8 +160,8 @@ jobs:
       - name: Run integration tests (shard)
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
-          timeout_minutes: 5
-          max_attempts: 2
+          timeout_minutes: 10
+          max_attempts: 3
           command: |
             cd packages/pg-delta
             ALL_FILES=$(find tests/ -name "*.test.ts" | sort)

--- a/packages/pg-delta/tests/constants.ts
+++ b/packages/pg-delta/tests/constants.ts
@@ -1,6 +1,6 @@
 export const POSTGRES_VERSION_TO_SUPABASE_POSTGRES_TAG = {
-  15: "15.14.1.018",
-  17: "17.6.1.018",
+  15: "15.14.1.107",
+  17: "17.6.1.107",
 } as const;
 
 export const POSTGRES_VERSION_TO_ALPINE_POSTGRES_TAG = {

--- a/packages/pg-delta/tests/constants.ts
+++ b/packages/pg-delta/tests/constants.ts
@@ -1,6 +1,6 @@
 export const POSTGRES_VERSION_TO_SUPABASE_POSTGRES_TAG = {
-  15: "15.14.1.107",
-  17: "17.6.1.107",
+  15: "15.14.1.018",
+  17: "17.6.1.018",
 } as const;
 
 export const POSTGRES_VERSION_TO_ALPINE_POSTGRES_TAG = {


### PR DESCRIPTION
Got some flawky faillures on merge-group because of containers killed by timeout.

Also upgrade the supabase images to latests versions we were still on the 700Mo ones. Let's hope this help a bit with performances issues.