### PR TITLE
fix(pg-delta): ipv6 and getaddrinfo

### DIFF
--- a/.changeset/fix-ipv6-bracket-strip.md
+++ b/.changeset/fix-ipv6-bracket-strip.md
@@ -1,0 +1,9 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): strip brackets from IPv6 hosts before handing them to pg so `getaddrinfo` sees a bare address.
+
+The alpha.14 IPv6 fix normalized percent-encoded hosts into the canonical bracketed URL form (`postgresql://user@[2600:...]:5432/db`). That is a valid URL, but `pg-connection-string`'s WHATWG-based parser keeps the brackets on `config.host`, so `pg` passed `[2600:...]` verbatim to `getaddrinfo` and connections failed with `ENOTFOUND [2600:...]`.
+
+`createManagedPool` now expands bracketed-IPv6 URLs into explicit `host` / `port` / `user` / `password` / `database` pool fields (plus any remaining query params like `application_name`) and drops `connectionString` on that path — `pg` merges a parsed `connectionString` on top of user config, so a co-provided `host` would otherwise be clobbered. Non-IPv6 URLs still go through `connectionString` unchanged.

--- a/packages/pg-delta/src/core/postgres-config.test.ts
+++ b/packages/pg-delta/src/core/postgres-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   connectWithRetry,
   isRetryableConnectError,
+  poolConfigFromUrl,
 } from "./postgres-config.ts";
 
 function makeError(message: string, code?: string): Error {
@@ -237,5 +238,99 @@ describe("connectWithRetry", () => {
       }),
     ).rejects.toBe(err);
     expect(attempts).toBe(1);
+  });
+});
+
+describe("poolConfigFromUrl", () => {
+  describe("non-IPv6 URLs pass through as connectionString", () => {
+    test("DNS hostname", () => {
+      const url = "postgresql://user:pass@db.example.com:5432/mydb";
+      expect(poolConfigFromUrl(url)).toEqual({ connectionString: url });
+    });
+
+    test("IPv4 host", () => {
+      const url = "postgresql://user:pass@127.0.0.1:5432/mydb";
+      expect(poolConfigFromUrl(url)).toEqual({ connectionString: url });
+    });
+
+    test("DNS hostname with query params", () => {
+      const url =
+        "postgresql://user:pass@db.example.com:5432/mydb?application_name=test";
+      expect(poolConfigFromUrl(url)).toEqual({ connectionString: url });
+    });
+  });
+
+  describe("bracketed IPv6 URLs expand to explicit fields with no brackets", () => {
+    test("full 8-group IPv6 — host has no brackets and no connectionString", () => {
+      const url =
+        "postgresql://user:pass@[2600:1f16:1cd0:3340:f92e:f4cb:7a52:10a1]:5432/mydb";
+      const config = poolConfigFromUrl(url);
+      expect(config.connectionString).toBeUndefined();
+      expect(config.host).toBe("2600:1f16:1cd0:3340:f92e:f4cb:7a52:10a1");
+      expect(config.port).toBe(5432);
+      expect(config.user).toBe("user");
+      expect(config.password).toBe("pass");
+      expect(config.database).toBe("mydb");
+    });
+
+    test("compressed ::1 form", () => {
+      const url = "postgresql://user:pass@[::1]:5432/mydb";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.port).toBe(5432);
+    });
+
+    test("host bracket strip survives percent-decoded username/password", () => {
+      const url = "postgresql://user:p%40ss%2Fword@[::1]:5432/mydb";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.user).toBe("user");
+      expect(config.password).toBe("p@ss/word");
+    });
+
+    test("works without port", () => {
+      const url = "postgresql://user:pass@[::1]/mydb";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.port).toBeUndefined();
+    });
+
+    test("works without database (pathname='/')", () => {
+      const url = "postgresql://user:pass@[::1]:5432/";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.database).toBeUndefined();
+    });
+
+    test("works without userinfo", () => {
+      const url = "postgresql://[::1]:5432/mydb";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.user).toBeUndefined();
+      expect(config.password).toBeUndefined();
+    });
+
+    test("query params are forwarded as top-level config keys", () => {
+      const url =
+        "postgresql://user:pass@[::1]:5432/mydb?application_name=pgdelta&connect_timeout=5";
+      const config = poolConfigFromUrl(url) as unknown as Record<
+        string,
+        unknown
+      >;
+      expect(config.application_name).toBe("pgdelta");
+      expect(config.connect_timeout).toBe("5");
+      expect(config.host).toBe("::1");
+    });
+
+    test("IPv4-mapped IPv6 is stripped of brackets (WHATWG canonicalisation is fine)", () => {
+      // WHATWG URL canonicalises `::ffff:192.0.2.1` to `::ffff:c000:201`;
+      // either form resolves to the same IPv6 address, and the point of this
+      // test is purely that no brackets escape to pg.
+      const url = "postgresql://user:pass@[::ffff:192.0.2.1]:5432/mydb";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).not.toContain("[");
+      expect(config.host).not.toContain("]");
+      expect(config.host).toBe("::ffff:c000:201");
+    });
   });
 });

--- a/packages/pg-delta/src/core/postgres-config.ts
+++ b/packages/pg-delta/src/core/postgres-config.ts
@@ -225,14 +225,20 @@ interface CreatePoolOptions extends Partial<PoolConfig> {
 
 /**
  * Create a Pool with custom type handlers and optional event listeners.
+ *
+ * `connectionString` may be `undefined` when the caller needs pg to rely on
+ * explicit `host`/`port`/`user`/... fields from `options` instead — notably
+ * the bracketed-IPv6 workaround in {@link poolConfigFromUrl}, where passing
+ * the connection string would cause `pg-connection-string` to re-inject the
+ * bracketed host that breaks `getaddrinfo`.
  */
 export function createPool(
-  connectionString: string,
+  connectionString: string | undefined,
   options?: CreatePoolOptions,
 ): Pool {
   const { onConnect, onError, onAcquire, onRemove, ...config } = options ?? {};
   const pool = new Pool({
-    connectionString,
+    ...(connectionString ? { connectionString } : {}),
     max: DEFAULT_POOL_MAX,
     connectionTimeoutMillis: DEFAULT_CONNECTION_TIMEOUT_MS,
     ...config,
@@ -302,6 +308,50 @@ export function createPool(
 }
 
 /**
+ * Build a pg {@link PoolConfig} from a cleaned connection URL.
+ *
+ * For most URLs this just returns `{ connectionString }` and pg does its
+ * normal parsing. But for URLs whose hostname is a bracketed IPv6 literal
+ * (e.g. `postgresql://user@[::1]:5432/db`, as produced by
+ * {@link normalizeConnectionUrl}), we expand the URL into explicit
+ * `host`/`port`/`user`/`password`/`database` fields with a **bare** IPv6
+ * host — no brackets.
+ *
+ * This works around a `pg-connection-string` quirk: its parser sets
+ * `config.host` to the WHATWG `URL.hostname`, which keeps the surrounding
+ * `[...]` for IPv6 literals. That bracketed value is then passed verbatim to
+ * `getaddrinfo`, which rejects it with `ENOTFOUND`. Since
+ * `pg`'s connection-parameters module does
+ * `Object.assign({}, config, parse(connectionString))`, any `host` we pass
+ * alongside `connectionString` gets clobbered — so we drop `connectionString`
+ * entirely on this path and hand pg the parsed fields directly.
+ *
+ * Remaining query parameters (e.g. `application_name`, `options`,
+ * `connect_timeout`) are forwarded as top-level config keys, mirroring how
+ * `pg-connection-string` would normally surface them.
+ */
+export function poolConfigFromUrl(cleanedUrl: string): PoolConfig {
+  const urlObj = new URL(cleanedUrl);
+  if (!urlObj.hostname.startsWith("[")) {
+    return { connectionString: cleanedUrl };
+  }
+
+  const config: Record<string, unknown> = {
+    host: urlObj.hostname.slice(1, -1),
+  };
+  if (urlObj.port) config.port = Number(urlObj.port);
+  if (urlObj.username) config.user = decodeURIComponent(urlObj.username);
+  if (urlObj.password) config.password = decodeURIComponent(urlObj.password);
+  if (urlObj.pathname.length > 1) {
+    config.database = decodeURIComponent(urlObj.pathname.slice(1));
+  }
+  for (const [key, value] of urlObj.searchParams) {
+    config[key] = value;
+  }
+  return config as PoolConfig;
+}
+
+/**
  * End a pool and wait for all client sockets to fully close.
  *
  * pg-pool's `pool.end()` resolves once clients are removed from its
@@ -334,7 +384,11 @@ export async function createManagedPool(
     normalizedUrl,
     options?.label ?? "target",
   );
-  const pool = createPool(sslConfig.cleanedUrl, {
+  // Expand bracketed-IPv6 URLs into explicit pg fields so the brackets never
+  // reach `getaddrinfo` — see `poolConfigFromUrl` for the full rationale.
+  const connectionConfig = poolConfigFromUrl(sslConfig.cleanedUrl);
+  const pool = createPool(connectionConfig.connectionString, {
+    ...connectionConfig,
     ...(sslConfig.ssl !== undefined ? { ssl: sslConfig.ssl } : {}),
     onError: (err: Error & { code?: string }) => {
       if (err.code !== "57P01") {


### PR DESCRIPTION
## What kind of change does this PR introduce?

## Root cause

The alpha.14 fix correctly decoded `%3A` and bracketed the IPv6 host (`[2600:...]`) to produce a WHATWG-valid URL. But when that URL hit `pg`/`pg-connection-string`, its parser used `new URL(...).hostname`, which **retains** the brackets on IPv6 literals. The bracketed string got handed to `getaddrinfo` verbatim → `ENOTFOUND [2600:...]`.

I confirmed this experimentally against `pg-connection-string@2.12.0`:

```js
parse("postgresql://user:pass@[::1]:5432/db")
// → { ..., host: "[::1]", port: "5432", database: "db" }
```

## Why the suggested one-liner isn't quite enough

The note suggested `parsedHost.replace(/^\[|\]$/g, '')` after decoding. Inside `createManagedPool`, though, we hand pg a **`connectionString`** (not a parsed host), and pg's `connection-parameters` does:

```js
config = Object.assign({}, config, parse(config.connectionString))
```

So any `host` we pass alongside `connectionString` gets clobbered by the parsed-bracket version. The connection string has to be dropped entirely on the IPv6 path.



## Testing locally:
With:

```
docker run -d --rm --name pg-ipv6-test \
  -e POSTGRES_PASSWORD=postgres \
  -p '[::1]:54329:5432' \
  -p '127.0.0.1:54329:5432' \
  postgres:17-alpine

until docker exec pg-ipv6-test pg_isready -U postgres >/dev/null 2>&1; do sleep 0.5; done

cd packages/pg-delta
bun -e '
import { createManagedPool } from "./src/core/postgres-config.ts";
const url = "postgresql://postgres:postgres@%3A%3A1:54329/postgres";
const { pool, close } = await createManagedPool(url);
const r = await pool.query("SELECT 1+1 AS result, inet_server_addr() AS server_addr");
console.log("PASS: connected via IPv6 ->", r.rows[0]);
await close();
'

docker stop pg-ipv6-test
```

Without this change I get:

```
➜  pg-delta git:(main) bun -e '
import { createManagedPool } from "./src/core/postgres-config.ts";
const url = "postgresql://postgres:postgres@%3A%3A1:54329/postgres";
const { pool, close } = await createManagedPool(url);
const r = await pool.query("SELECT 1+1 AS result, inet_server_addr() AS server_addr");
console.log("PASS: connected via IPv6 ->", r.rows[0]);
await close();
'
40 |     res = resolve
41 |     rej = reject
42 |   }).catch((err) => {
43 |     // replace the stack trace that leads to `TCP.onStreamRead` with one that leads back to the
44 |     // application that created the query
45 |     Error.captureStackTrace(err)
               ^
DNSException: getaddrinfo ENOTFOUND
 syscall: "getaddrinfo",
   errno: 4,
    code: "ENOTFOUND"

      at <anonymous> (/Users/avallete/Documents/Programming/pg-toolbelt/node_modules/.bun/pg-pool@3.13.0+52bd52a0bccfa6a2/node_modules/pg-pool/index.js:45:11)

Bun v1.3.10 (macOS arm64)
````

With this change:

```
➜  pg-delta git:(fix/ipv6-connection) bun -e '
import { createManagedPool } from "./src/core/postgres-config.ts";
const url = "postgresql://postgres:postgres@%3A%3A1:54329/postgres";
const { pool, close } = await createManagedPool(url);
const r = await pool.query("SELECT 1+1 AS result, inet_server_addr() AS server_addr");
console.log("PASS: connected via IPv6 ->", r.rows[0]);
await close();
'
PASS: connected via IPv6 -> {
  result: 2,
  server_addr: "192.168.215.2",
}
```