### PR TITLE
fix(pg-delta): invalid create or replace trigger

### DIFF
--- a/.changeset/fix-trigger-column-numbers-diff-loop.md
+++ b/.changeset/fix-trigger-column-numbers-diff-loop.md
@@ -1,0 +1,9 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): stop emitting spurious `CREATE OR REPLACE TRIGGER` on logically-identical triggers whose underlying tables have different physical column layouts.
+
+The trigger diff was comparing `pg_trigger.tgattr` (raw physical attnums) as part of its non-alterable fields. When the same logical trigger (e.g. `BEFORE UPDATE OF col_a, col_b ...`) existed on two tables with different physical column layouts — one built via a single `CREATE TABLE`, the other grown via `ALTER TABLE DROP/ADD COLUMN` (which leaves "dead" attnums that are never renumbered) — the attnum vectors diverged while the trigger definition (rendered by `pg_get_triggerdef()` using column names) was byte-identical. The diff kept firing a `ReplaceTrigger` every round, and because `CREATE OR REPLACE TRIGGER` does not renumber the table's physical columns, the loop never converged.
+
+Triggers are now compared by `pg_get_triggerdef()` output (column names) instead of raw `tgattr` attnums, matching the existing `Index` pattern that handles the same class of bug for `indkey`.

--- a/packages/pg-delta/CLAUDE.md
+++ b/packages/pg-delta/CLAUDE.md
@@ -122,6 +122,15 @@ To add a new PostgreSQL object type:
 3. Register in `catalog.model.ts` (Catalog type + extractor).
 4. Register in `catalog.diff.ts` (diff function in `diffCatalogs`).
 
+### Physical attnums vs logical names
+
+Never place raw PostgreSQL attnums (`pg_trigger.tgattr`, `pg_index.indkey`, `pg_constraint.conkey`/`confkey`, `pg_publication_rel.prattrs`, etc.) inside a model's `dataFields()` or `NON_ALTERABLE_FIELDS`. Attnums are **physical** and diverge between logically-identical tables whose column layouts were built differently (`CREATE TABLE` vs `ALTER TABLE DROP/ADD COLUMN`) — dropped columns leave "dead" attnums that are never renumbered, so every subsequent diff would emit a spurious replace and never converge. Compare either:
+
+- the authoritative `pg_get_<obj>def()` output (see `Index` and `Trigger`), or
+- column **names** resolved via `pg_attribute` at extraction time (see `Table.conkey`/`confkey`, `Publication.prattrs`).
+
+Storing the raw attnum array purely for debugging/introspection is fine — just keep it out of equality.
+
 ## Conventions
 
 - TypeScript strict; Biome for format/lint; kebab-case files with `.model.ts`, `.diff.ts`, `.test.ts`.

--- a/packages/pg-delta/src/core/objects/trigger/trigger.diff.ts
+++ b/packages/pg-delta/src/core/objects/trigger/trigger.diff.ts
@@ -67,6 +67,11 @@ export function diffTriggers(
       continue;
     }
 
+    // Note: column_numbers is excluded because it contains pg_trigger.tgattr
+    // attnums that differ between databases when physical column layouts
+    // diverge but logical (named) columns match. The definition field
+    // (pg_get_triggerdef) already captures the UPDATE OF column list by name,
+    // so we compare by definition instead.
     const NON_ALTERABLE_FIELDS: Array<keyof Trigger> = [
       "function_schema",
       "function_name",
@@ -76,18 +81,18 @@ export function diffTriggers(
       "deferrable",
       "initially_deferred",
       "argument_count",
-      "column_numbers",
       "arguments",
       "when_condition",
       "old_table",
       "new_table",
       "owner",
+      "definition", // Compare by definition instead of column_numbers (tgattr)
     ];
     const shouldReplace = hasNonAlterableChanges(
       mainTrigger,
       branchTrigger,
       NON_ALTERABLE_FIELDS,
-      { column_numbers: deepEqual, arguments: deepEqual },
+      { arguments: deepEqual },
     );
     if (shouldReplace) {
       const tableStableId = stableId.table(

--- a/packages/pg-delta/src/core/objects/trigger/trigger.model.ts
+++ b/packages/pg-delta/src/core/objects/trigger/trigger.model.ts
@@ -134,7 +134,10 @@ export class Trigger extends BasePgModel {
       deferrable: this.deferrable,
       initially_deferred: this.initially_deferred,
       argument_count: this.argument_count,
-      column_numbers: this.column_numbers,
+      // column_numbers excluded: contains pg_trigger.tgattr attnums that differ
+      // between databases when physical column layouts diverge but logical
+      // (named) columns match. The definition field (pg_get_triggerdef) captures
+      // the UPDATE OF column list by name, so we compare by definition instead.
       arguments: this.arguments,
       when_condition: this.when_condition,
       old_table: this.old_table,
@@ -145,6 +148,7 @@ export class Trigger extends BasePgModel {
       parent_table_name: this.parent_table_name,
       is_on_partitioned_table: this.is_on_partitioned_table,
       owner: this.owner,
+      definition: this.definition,
       comment: this.comment,
     };
   }

--- a/packages/pg-delta/tests/integration/trigger-update-of-column-numbers.test.ts
+++ b/packages/pg-delta/tests/integration/trigger-update-of-column-numbers.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Integration test: minimal reproduction of the "CREATE OR REPLACE TRIGGER"
+ * infinite diff loop.
+ *
+ * Bug summary:
+ *   `Trigger.column_numbers` stores the raw `pg_trigger.tgattr` int2vector,
+ *   i.e. the physical `attnum` of each column referenced by `CREATE TRIGGER
+ *   ... UPDATE OF col_a, col_b, ...`. When the same trigger is created on
+ *   logically-identical tables whose physical column layout differs (because
+ *   one was built with `CREATE TABLE ... (everything)` and the other grew via
+ *   `CREATE TABLE + ALTER TABLE DROP/ADD COLUMN`), the `tgattr` vectors
+ *   disagree even though the column NAMES in the trigger definition match.
+ *
+ *   `pg_get_triggerdef()` renders column names (not attnums), so the
+ *   emitted `CREATE OR REPLACE TRIGGER ...` SQL is functionally correct and
+ *   identical on both sides. However, the catalog diff compares `tgattr`
+ *   through `deepEqual` in `NON_ALTERABLE_FIELDS` and always flags the
+ *   trigger as needing a `ReplaceTrigger`. Because `CREATE OR REPLACE
+ *   TRIGGER` does not renumber the underlying table's columns, re-applying
+ *   the emitted SQL never converges -- every subsequent sync reports the
+ *   same phantom change.
+ *
+ * This test reproduces the behavior with the smallest possible setup so the
+ * regression signal is easy to interpret.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { diffCatalogs } from "../../src/core/catalog.diff.ts";
+import { extractCatalog } from "../../src/core/catalog.model.ts";
+import { ReplaceTrigger } from "../../src/core/objects/trigger/changes/trigger.alter.ts";
+import { POSTGRES_VERSIONS } from "../constants.ts";
+import { withDbIsolated } from "../utils.ts";
+
+const TRIGGER_FUNCTION_SQL = `
+  CREATE FUNCTION public.trg_fn() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+  BEGIN
+    RETURN NEW;
+  END;
+  $$;
+`;
+
+const TRIGGER_SQL = `
+  CREATE TRIGGER trg
+    BEFORE UPDATE OF a, b, d
+    ON public.t
+    FOR EACH ROW
+    EXECUTE FUNCTION public.trg_fn();
+`;
+
+for (const pgVersion of POSTGRES_VERSIONS) {
+  describe(`trigger UPDATE OF column-number diff loop (pg${pgVersion})`, () => {
+    test(
+      "same-named columns on tables with different physical attnums must not produce a trigger diff",
+      withDbIsolated(pgVersion, async (db) => {
+        // main: built with a single CREATE TABLE -- columns a, b, d get
+        // consecutive attnums 1, 2, 3.
+        await db.main.query(`
+          CREATE TABLE public.t (
+            a int,
+            b int,
+            d int
+          );
+        `);
+        await db.main.query(TRIGGER_FUNCTION_SQL);
+        await db.main.query(TRIGGER_SQL);
+
+        // branch: same logical columns, but grown via ALTER TABLE so that the
+        // physical attnums of a, b, d differ from main (in particular, b was
+        // dropped and re-added, and d was added after c was dropped -- so
+        // tgattr on branch will contain sparse, larger attnums).
+        await db.branch.query(`
+          CREATE TABLE public.t (
+            a int,
+            b int,
+            c int
+          );
+          ALTER TABLE public.t DROP COLUMN b;
+          ALTER TABLE public.t DROP COLUMN c;
+          ALTER TABLE public.t ADD COLUMN b int;
+          ALTER TABLE public.t ADD COLUMN d int;
+        `);
+        await db.branch.query(TRIGGER_FUNCTION_SQL);
+        await db.branch.query(TRIGGER_SQL);
+
+        // Sanity check: the two trigger definitions as rendered by
+        // pg_get_triggerdef() should be identical (column NAMES match). This
+        // confirms the emitted SQL is semantically equivalent -- only the
+        // physical attnums differ.
+        const mainDef = await db.main.query<{ def: string }>(
+          `SELECT pg_get_triggerdef(oid) AS def FROM pg_trigger WHERE tgname = 'trg' AND NOT tgisinternal`,
+        );
+        const branchDef = await db.branch.query<{ def: string }>(
+          `SELECT pg_get_triggerdef(oid) AS def FROM pg_trigger WHERE tgname = 'trg' AND NOT tgisinternal`,
+        );
+        expect(mainDef.rows[0].def).toBe(branchDef.rows[0].def);
+
+        // Extract catalogs and diff. With the current bug, the diff emits a
+        // ReplaceTrigger because `column_numbers` (tgattr) differs between
+        // main and branch even though the logical trigger is identical.
+        const mainCatalog = await extractCatalog(db.main);
+        const branchCatalog = await extractCatalog(db.branch);
+        const firstChanges = diffCatalogs(mainCatalog, branchCatalog);
+        const firstTriggerReplaces = firstChanges.filter(
+          (c): c is ReplaceTrigger => c instanceof ReplaceTrigger,
+        );
+
+        if (firstTriggerReplaces.length > 0) {
+          console.error(
+            `[trigger-update-of-column-numbers] first-pass spurious ReplaceTrigger:\n${firstTriggerReplaces
+              .map((c) => c.serialize())
+              .join(";\n")}`,
+          );
+        }
+
+        // Expected behavior: zero trigger diffs because the triggers are
+        // logically identical. With the current bug this assertion fails.
+        expect(firstTriggerReplaces).toHaveLength(0);
+
+        // Second part of the bug: even if we apply the (semantically
+        // identical) CREATE OR REPLACE TRIGGER SQL that the diff emits, the
+        // next sync still reports the same phantom change because
+        // CREATE OR REPLACE TRIGGER does not move the table's column
+        // attnums. Demonstrate the non-converging loop.
+        //
+        // Force-run a ReplaceTrigger against main (even if the first check
+        // passed we still want to confirm idempotency under the worst case)
+        // to guarantee this branch is exercised independently of the fix.
+        const branchTrigger = Object.values(branchCatalog.triggers)[0];
+        if (!branchTrigger) {
+          throw new Error(
+            "expected a trigger on branch for the non-convergence check",
+          );
+        }
+        const replace = new ReplaceTrigger({ trigger: branchTrigger });
+        await db.main.query(replace.serialize());
+
+        const mainCatalogAfter = await extractCatalog(db.main);
+        const secondChanges = diffCatalogs(mainCatalogAfter, branchCatalog);
+        const secondTriggerReplaces = secondChanges.filter(
+          (c): c is ReplaceTrigger => c instanceof ReplaceTrigger,
+        );
+
+        if (secondTriggerReplaces.length > 0) {
+          console.error(
+            `[trigger-update-of-column-numbers] second-pass non-convergence:\n${secondTriggerReplaces
+              .map((c) => c.serialize())
+              .join(";\n")}`,
+          );
+        }
+
+        expect(secondTriggerReplaces).toHaveLength(0);
+      }),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fix a spurious `CREATE OR REPLACE TRIGGER` diff loop that `pg-delta` emits on every sync when a trigger (`BEFORE/AFTER UPDATE OF col_a, col_b, …`) exists on two logically-identical tables whose **physical** column layouts differ — e.g. one built with a single `CREATE TABLE (a, b, d)` and the other grown via `ALTER TABLE DROP/ADD COLUMN`. Because `CREATE OR REPLACE TRIGGER` does not renumber the table's physical columns, the loop never converges.

## Root cause

`Trigger` stored `pg_trigger.tgattr` as `column_numbers` (raw physical attnums) and compared it inside `NON_ALTERABLE_FIELDS` via `deepEqual`:

```ts
// packages/pg-delta/src/core/objects/trigger/trigger.diff.ts (before)
const NON_ALTERABLE_FIELDS: Array<keyof Trigger> = [
  /* … */ "column_numbers", /* … */
];
const shouldReplace = hasNonAlterableChanges(
  mainTrigger, branchTrigger, NON_ALTERABLE_FIELDS,
  { column_numbers: deepEqual, arguments: deepEqual },
);
```

- Dropped columns leave "dead" attnums that PostgreSQL never renumbers (`ALTER TABLE DROP COLUMN` just marks them `attisdropped`).
- So `main.tgattr = [25, 4, 13, 30]` and `branch.tgattr = [40, 4, 13, 48]` for the same logical columns.
- `pg_get_triggerdef()` renders column **names**, so the emitted SQL is byte-identical and semantically correct — but the catalog diff keeps reporting a change.
- Running the emitted `CREATE OR REPLACE TRIGGER` doesn't change the table's physical attnums, so the next sync reports the same phantom diff. Infinite loop.

## Fix

Follow the existing precedent set by the `Index` model, which solves this exact class of bug for `pg_index.indkey`: keep the raw attnum array on the model for debugging/introspection, but **exclude it from equality** and compare `pg_get_<obj>def()` output instead.

- [`packages/pg-delta/src/core/objects/trigger/trigger.model.ts`](packages/pg-delta/src/core/objects/trigger/trigger.model.ts): remove `column_numbers` from `dataFields()`, add `definition` (from `pg_get_triggerdef`).
- [`packages/pg-delta/src/core/objects/trigger/trigger.diff.ts`](packages/pg-delta/src/core/objects/trigger/trigger.diff.ts): drop `"column_numbers"` from `NON_ALTERABLE_FIELDS` and its `deepEqual` comparator; add `"definition"` (compared with default `===`, since `pg_get_triggerdef` is deterministic on a given PG version).
- The `column_numbers` property, zod schema entry, and constructor assignment stay on the class — matching how `Index.key_columns` is retained purely for introspection.

## Are other objects affected?

Grepped every catalog model touching `attnum` / `indkey` / `conkey` / `confkey` / `prattrs` / `adnum`:

| Model | Status |
|---|---|
| `trigger.model.ts` | **Fixed by this PR** |
| `index.model.ts` | Already mitigated — `key_columns` excluded from `dataFields`, `definition` compared instead |
| `table.model.ts` | Safe — `conkey`/`confkey` resolved to names via `unnest … join pg_attribute` at extraction time |
| `publication.model.ts` | Safe — `prattrs` resolved to names the same way |
| `foreign-table.model.ts`, `view.model.ts`, `materialized-view.model.ts`, `composite-type.model.ts` | Safe — `attnum` only used for ordering the emitted column list |
| `sequence.model.ts`, `rule.model.ts`, `extension.model.ts` | Safe — `attnum` only used for catalog joins, never diff-compared |

To prevent the bug class from returning, [`packages/pg-delta/CLAUDE.md`](packages/pg-delta/CLAUDE.md) now has a **"Physical attnums vs logical names"** subsection under *Working with Database Objects* that tells future catalog models to compare either `pg_get_<obj>def()` output or name-resolved arrays, never raw attnums.

## Test plan

- [x] New integration repro [`tests/integration/trigger-update-of-column-numbers.test.ts`](packages/pg-delta/tests/integration/trigger-update-of-column-numbers.test.ts) asserts:
  1. First-pass diff between two logically-identical-but-physically-different tables yields **zero** `ReplaceTrigger` changes.
  2. Even after a forced `ReplaceTrigger` is applied, the next diff still yields zero changes (convergence).
- [x] `bun test src/` — **979 pass, 0 fail** (no fixture rename required; every existing fixture set `column_numbers: null`).
- [x] `bun test tests/integration/trigger-operations.test.ts tests/integration/trigger-update-of-column-numbers.test.ts tests/integration/declarative-apply.test.ts tests/integration/declarative-schema-export.test.ts` — **32 pass, 0 fail**.
- [x] `bun run check-types` — clean.

## Why not resolve `tgattr` into column names at extraction time?

Considered and rejected: would require a new SQL `unnest … join pg_attribute` lateral, a field rename (`column_numbers` → `column_names`) propagated across 6 files + fixtures, and it has no precedent in the codebase. `Index` already chose the "trust `pg_get_<obj>def()`" approach; keeping parity with it is simpler and has identical correctness.


Related: https://github.com/supabase/cli/issues/5094