### PR TITLE
test(pgdelta): Add tests for CHECK (FALSE) NO INHERIT constraints

### DIFF
--- a/packages/pg-delta/tests/integration/constraint-operations.test.ts
+++ b/packages/pg-delta/tests/integration/constraint-operations.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for PostgreSQL constraint operations.
  */
 
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { POSTGRES_VERSIONS } from "../constants.ts";
 import { withDb, withDbIsolated } from "../utils.ts";
 import { roundtripFidelityTest } from "./roundtrip.ts";
@@ -66,6 +66,73 @@ for (const pgVersion of POSTGRES_VERSIONS) {
           testSql: `
           ALTER TABLE test_schema.products ADD CONSTRAINT products_price_check CHECK (price > 0);
         `,
+        });
+      }),
+    );
+
+    test(
+      "add CHECK (FALSE) NO INHERIT constraint on inheritance parent",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE SCHEMA test_schema;
+        `,
+          testSql: `
+          CREATE TABLE test_schema.parent_base (
+            id uuid PRIMARY KEY,
+            name text NOT NULL,
+            CONSTRAINT no_direct_insert CHECK (FALSE) NO INHERIT
+          );
+        `,
+          assertSqlStatements: (sqlStatements) => {
+            expect(
+              sqlStatements.some((stmt) =>
+                stmt.includes(
+                  "ADD CONSTRAINT no_direct_insert CHECK (false) NO INHERIT",
+                ),
+              ),
+            ).toBe(true);
+          },
+        });
+      }),
+    );
+
+    test(
+      "add CHECK (FALSE) NO INHERIT on parent with INHERITS child",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE SCHEMA test_schema;
+        `,
+          testSql: `
+          CREATE TABLE test_schema.parent_base (
+            id uuid PRIMARY KEY,
+            name text NOT NULL,
+            CONSTRAINT no_direct_insert CHECK (FALSE) NO INHERIT
+          );
+
+          CREATE TABLE test_schema.child (
+            CONSTRAINT child_pkey PRIMARY KEY (id)
+          ) INHERITS (test_schema.parent_base);
+        `,
+          assertSqlStatements: (sqlStatements) => {
+            expect(
+              sqlStatements.some((stmt) =>
+                stmt.includes(
+                  "ADD CONSTRAINT no_direct_insert CHECK (false) NO INHERIT",
+                ),
+              ),
+            ).toBe(true);
+            expect(
+              sqlStatements.some((stmt) =>
+                stmt.includes("INHERITS (test_schema.parent_base)"),
+              ),
+            ).toBe(true);
+          },
         });
       }),
     );


### PR DESCRIPTION
## Summary
Added integration tests to verify proper handling of PostgreSQL `CHECK (FALSE) NO INHERIT` constraints in the constraint operations test suite.

## Key Changes
- Imported `expect` from `bun:test` to enable assertion statements
- Added test case for creating a `CHECK (FALSE) NO INHERIT` constraint on an inheritance parent table
- Added test case for creating a `CHECK (FALSE) NO INHERIT` constraint on a parent table with an inheriting child table
- Both tests verify that the generated SQL statements correctly include the `ADD CONSTRAINT ... CHECK (false) NO INHERIT` syntax
- The second test additionally verifies that the `INHERITS` clause is properly preserved in the generated statements

## Implementation Details
- Tests use the existing `roundtripFidelityTest` helper to validate schema roundtrip consistency
- Both test cases follow the established pattern of using `initialSetup`, `testSql`, and `assertSqlStatements`
- Assertions check for the presence of expected SQL fragments in the generated migration statements
- Tests cover both simple constraint creation and the more complex scenario with table inheritance

https://claude.ai/code/session_01M8bxUZzDHscoM728VFKb8f

Closes: https://github.com/supabase/pg-toolbelt/issues/198