### PR TITLE
test(pg-delta): add regression coverage for role-level GUC and column-type-with-default diffing

### DIFF
--- a/.github/agents/pg-toolbelt.md
+++ b/.github/agents/pg-toolbelt.md
@@ -141,6 +141,11 @@ docs(pg-delta): improve README examples
 
 Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`.
 
+The `Lint Pull Request` CI check (see `.github/workflows/lint-pull-request.yml`) runs `amannn/action-semantic-pull-request` and will fail any PR whose title doesn't match this convention. Two common pitfalls to avoid:
+
+- **Auto-generated PR titles from external tools** (Claude Code web session launcher, GitHub's "compare" UI, the `gh` CLI default, etc.) routinely produce plain English like `Add integration tests for X` or `Update Y`. These will fail lint. Always verify the PR title before considering the PR opened — if it's not `<type>(<scope>): ...`, rename it (e.g. via `mcp__github__update_pull_request` with a new `title`). The first commit's subject is usually a good source since we write those in Conventional Commits already.
+- **`<scope>` should be the package name** (`pg-delta`, `pg-topo`) or a cross-cutting area (`ci`, `docs`, `release`) — not a feature name.
+
 ## CI
 
 - GitHub Actions with `dorny/paths-filter` detects which packages changed

--- a/packages/pg-delta/tests/integration/alter-table-operations.test.ts
+++ b/packages/pg-delta/tests/integration/alter-table-operations.test.ts
@@ -343,5 +343,59 @@ for (const pgVersion of POSTGRES_VERSIONS) {
         });
       }),
     );
+
+    // Regression coverage for CLI-754: widening the type of a column that
+    // already has a default on main must preserve the default.
+    test(
+      "widen column type preserves pre-existing default",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE SCHEMA test_schema;
+          CREATE TABLE test_schema.priced (
+            id integer NOT NULL,
+            price numeric(8,2) DEFAULT 0.00
+          );
+          INSERT INTO test_schema.priced (id) VALUES (1);
+        `,
+          testSql: `
+          ALTER TABLE test_schema.priced ALTER COLUMN price TYPE numeric(12,4);
+        `,
+        });
+      }),
+    );
+
+    // CLI-754: ENUM → text with default. Currently fails because the plan
+    // emits `DROP TYPE test_schema.status` *before* the `ALTER COLUMN TYPE`,
+    // so the drop fails on the remaining column dependency. Leave skipped
+    // until the dependency ordering between AlterColumnType and the dropped
+    // source type is fixed.
+    test.skip(
+      "change column type from enum to text preserves default",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE SCHEMA test_schema;
+          CREATE TYPE test_schema.status AS ENUM ('active', 'inactive');
+          CREATE TABLE test_schema.items (
+            id integer NOT NULL,
+            state test_schema.status DEFAULT 'active'
+          );
+          INSERT INTO test_schema.items (id) VALUES (1);
+        `,
+          testSql: `
+          ALTER TABLE test_schema.items
+            ALTER COLUMN state DROP DEFAULT,
+            ALTER COLUMN state TYPE text USING state::text,
+            ALTER COLUMN state SET DEFAULT 'active';
+          DROP TYPE test_schema.status;
+        `,
+        });
+      }),
+    );
   });
 }

--- a/packages/pg-delta/tests/integration/role-config.test.ts
+++ b/packages/pg-delta/tests/integration/role-config.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Integration tests for role-level GUC (pg_db_role_setting) diffing.
+ *
+ * Regression coverage for CLI-343: commands of the form
+ *   ALTER ROLE authenticator SET pgrst.db_aggregates_enabled = 'true';
+ * live in pg_db_role_setting and must be captured by the diff tool via the
+ * role `config` catalog field + `AlterRoleSetConfig` change.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createPlan } from "../../src/core/plan/create.ts";
+import { POSTGRES_VERSIONS } from "../constants.ts";
+import { withDbIsolated } from "../utils.ts";
+
+for (const pgVersion of POSTGRES_VERSIONS) {
+  describe(`role config GUC (pg${pgVersion})`, () => {
+    test(
+      "diff captures ALTER ROLE ... SET pgrst.db_aggregates_enabled",
+      withDbIsolated(pgVersion, async (db) => {
+        // Same role on both sides; branch has the pgrst GUC set.
+        const setup = `
+          CREATE ROLE authenticator WITH NOLOGIN NOINHERIT;
+        `;
+        await db.main.query(setup);
+        await db.branch.query(setup);
+        await db.branch.query(
+          `ALTER ROLE authenticator SET pgrst.db_aggregates_enabled = 'true'`,
+        );
+
+        const result = await createPlan(db.main, db.branch);
+        expect(result).not.toBeNull();
+        // biome-ignore lint/style/noNonNullAssertion: guarded above
+        const statements = result!.plan.statements;
+
+        const setStatements = statements.filter((s) =>
+          s.includes("pgrst.db_aggregates_enabled"),
+        );
+        expect(setStatements).toHaveLength(1);
+        expect(setStatements[0]).toBe(
+          "ALTER ROLE authenticator SET pgrst.db_aggregates_enabled TO true",
+        );
+
+        // Apply the plan and verify the catalog lines up.
+        const script = statements.join(";\n");
+        await expect(
+          db.main.query(script.endsWith(";") ? script : `${script};`),
+        ).resolves.toBeDefined();
+
+        const replay = await createPlan(db.main, db.branch);
+        expect(replay).toBeNull();
+      }),
+    );
+
+    test(
+      "diff emits RESET for removed setting and SET for added one",
+      withDbIsolated(pgVersion, async (db) => {
+        const setup = `
+          CREATE ROLE api_role WITH NOLOGIN NOINHERIT;
+        `;
+        await db.main.query(setup);
+        await db.branch.query(setup);
+        // Main has statement_timeout; branch has lock_timeout instead.
+        await db.main.query(`ALTER ROLE api_role SET statement_timeout = '3s'`);
+        await db.branch.query(`ALTER ROLE api_role SET lock_timeout = '5s'`);
+
+        const result = await createPlan(db.main, db.branch);
+        expect(result).not.toBeNull();
+        // biome-ignore lint/style/noNonNullAssertion: guarded above
+        const statements = result!.plan.statements;
+
+        const resetStatements = statements.filter(
+          (s) => s === "ALTER ROLE api_role RESET statement_timeout",
+        );
+        const setStatements = statements.filter(
+          (s) => s === "ALTER ROLE api_role SET lock_timeout TO '5s'",
+        );
+        expect(resetStatements).toHaveLength(1);
+        expect(setStatements).toHaveLength(1);
+      }),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive integration test coverage for two important scenarios in the pg-delta diff tool:

1. **Role-level GUC (PostgreSQL configuration) diffing** - Tests for capturing and applying `ALTER ROLE ... SET` statements that configure role-specific settings
2. **Column type widening with defaults** - Tests for preserving column defaults when widening column types

## Key Changes

- **New test file**: `packages/pg-delta/tests/integration/role-config.test.ts`
  - Tests capturing `ALTER ROLE ... SET pgrst.db_aggregates_enabled` statements (regression coverage for CLI-343)
  - Tests handling of role config changes including RESET for removed settings and SET for added ones
  - Verifies plan application and idempotency across PostgreSQL versions

- **Enhanced test file**: `packages/pg-delta/tests/integration/alter-table-operations.test.ts`
  - Added test for widening numeric column type while preserving pre-existing defaults (CLI-754)
  - Added skipped test for ENUM to text type conversion with defaults, documenting a known issue with dependency ordering between `AlterColumnType` and dropped source types

## Notable Implementation Details

- All role config tests use the `withDbIsolated` helper to ensure test isolation across PostgreSQL versions
- The column type widening test uses the existing `roundtripFidelityTest` helper to verify plan idempotency
- The skipped ENUM test documents a specific ordering issue that needs to be resolved: `DROP TYPE` statements are currently emitted before `ALTER COLUMN TYPE`, causing dependency failures

https://claude.ai/code/session_013hSZaMwjid7hR9Z6pUEsKu