### PR TITLE
fix(pg-delta): handle malformed percent-encoding in connection URLs

### DIFF
--- a/.changeset/fix-uri-error-poolconfig-malformed-percent.md
+++ b/.changeset/fix-uri-error-poolconfig-malformed-percent.md
@@ -1,0 +1,9 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): handle malformed percent-encoding in connection URLs
+
+`poolConfigFromUrl` and `normalizeConnectionUrl` used `decodeURIComponent` directly on the URL's userinfo, database name, and hostname. A bare `%` or a truncated escape like `%x` in any of those fields raised `URIError: URI malformed`, crashing `createManagedPool` before a connection attempt was made (Sentry `SUPABASE-API-7TV`).
+
+Both call sites now route through a new `safeDecodeURIComponent` helper that returns the input unchanged on `URIError`, so connections with a literal `%` in their password proceed to a normal auth/connect outcome instead of a synchronous crash. Valid percent-encoded values continue to decode as before.

--- a/packages/pg-delta/src/core/connection-url.test.ts
+++ b/packages/pg-delta/src/core/connection-url.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { isIPv6, normalizeConnectionUrl } from "./connection-url.ts";
+import {
+  isIPv6,
+  normalizeConnectionUrl,
+  safeDecodeURIComponent,
+} from "./connection-url.ts";
 
 describe("isIPv6", () => {
   describe("accepted", () => {
@@ -138,5 +142,36 @@ describe("normalizeConnectionUrl", () => {
       const input = "postgresql://user:pass@%3A%3Azzz:5432/db";
       expect(normalizeConnectionUrl(input)).toBe(input);
     });
+
+    test("hostname with %3A and a bare % does not throw URIError", () => {
+      // Regression: `decodeURIComponent` would crash on a malformed percent
+      // sequence even when the hostname pre-filter matched `%3A`. Expected
+      // behaviour: swallow the decode failure and leave the URL unchanged,
+      // letting downstream get its usual ENOTFOUND/connect error.
+      const input = "postgresql://user:pass@2406%3Ada18%:5432/db";
+      expect(normalizeConnectionUrl(input)).toBe(input);
+    });
+  });
+});
+
+describe("safeDecodeURIComponent", () => {
+  test("decodes a valid percent-encoded string", () => {
+    expect(safeDecodeURIComponent("p%40ss%2Fword")).toBe("p@ss/word");
+  });
+
+  test("returns a string with a bare % unchanged", () => {
+    expect(safeDecodeURIComponent("pass%word")).toBe("pass%word");
+  });
+
+  test("returns a truncated percent escape unchanged", () => {
+    expect(safeDecodeURIComponent("pa%xx")).toBe("pa%xx");
+  });
+
+  test("returns a trailing bare % unchanged", () => {
+    expect(safeDecodeURIComponent("secret%")).toBe("secret%");
+  });
+
+  test("returns empty string as-is", () => {
+    expect(safeDecodeURIComponent("")).toBe("");
   });
 });

--- a/packages/pg-delta/src/core/connection-url.ts
+++ b/packages/pg-delta/src/core/connection-url.ts
@@ -44,6 +44,25 @@ export function isIPv6(value: string): boolean {
 }
 
 /**
+ * `decodeURIComponent` that returns the input unchanged when the value
+ * contains a malformed percent sequence (bare `%` or truncated escape like
+ * `%x`). Any other error is rethrown.
+ *
+ * Connection URLs emitted by managed Postgres providers occasionally carry a
+ * literal `%` in the password without properly escaping it as `%25`, and the
+ * built-in `decodeURIComponent` throws `URIError` in that case, which used to
+ * crash `poolConfigFromUrl` before any connection attempt was made.
+ */
+export function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch (err) {
+    if (err instanceof URIError) return value;
+    throw err;
+  }
+}
+
+/**
  * Normalize a PostgreSQL connection URL so IPv6 hosts reach pg in the
  * canonical bracketed form.
  *
@@ -62,7 +81,7 @@ export function normalizeConnectionUrl(url: string): string {
   // percent-encoded colon. Anything else is left entirely untouched.
   if (!/%3[aA]/.test(urlObj.hostname)) return url;
 
-  const decodedHost = decodeURIComponent(urlObj.hostname);
+  const decodedHost = safeDecodeURIComponent(urlObj.hostname);
   // Authoritative validation: only normalize when the decoded string is a
   // real IPv6 literal. Rejects partial fragments, random hostnames that
   // happen to contain `%3A`, and any malformed input.

--- a/packages/pg-delta/src/core/postgres-config.test.ts
+++ b/packages/pg-delta/src/core/postgres-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { normalizeConnectionUrl } from "./connection-url.ts";
 import {
   connectWithRetry,
   isRetryableConnectError,
@@ -367,6 +368,26 @@ describe("poolConfigFromUrl", () => {
       const config = poolConfigFromUrl(url);
       expect(config.host).toBe("::1");
       expect(config.database).toBe("my%db");
+    });
+
+    test("end-to-end pipeline with Supabase-shaped URL (percent-encoded IPv6 host + bare % password)", () => {
+      // Exact URL shape observed in production: hostname percent-encoded, but
+      // the password carries a literal `%` unencoded. `psql` rejects this as
+      // `invalid percent-encoded token`; pg-delta forgives it and passes the
+      // raw bytes to pg so the connection can succeed against a server whose
+      // real password contains that `%`.
+      const input =
+        "postgres://postgres:Passw0%rd1234****@2a05%3Ad014%3A119b%3Aec52%3A76dc%3A0000%3A7742%3A3c67:5432/postgres";
+      const normalized = normalizeConnectionUrl(input);
+      expect(normalized).toBe(
+        "postgres://postgres:Passw0%rd1234****@[2a05:d014:119b:ec52:76dc:0000:7742:3c67]:5432/postgres",
+      );
+      const config = poolConfigFromUrl(normalized);
+      expect(config.host).toBe("2a05:d014:119b:ec52:76dc:0:7742:3c67");
+      expect(config.port).toBe(5432);
+      expect(config.user).toBe("postgres");
+      expect(config.password).toBe("Passw0%rd1234****");
+      expect(config.database).toBe("postgres");
     });
   });
 });

--- a/packages/pg-delta/src/core/postgres-config.test.ts
+++ b/packages/pg-delta/src/core/postgres-config.test.ts
@@ -333,4 +333,40 @@ describe("poolConfigFromUrl", () => {
       expect(config.host).toBe("::ffff:c000:201");
     });
   });
+
+  describe("malformed percent-encoding in userinfo/database", () => {
+    // Regression for SUPABASE-API-7TV (alpha.16): `decodeURIComponent` on a
+    // password/username/database containing a bare `%` or truncated escape
+    // threw `URIError: URI malformed` from `poolConfigFromUrl`, crashing
+    // `createManagedPool` before any connection attempt.
+    test("bare % in password does not throw (Sentry MRE)", () => {
+      const url = "postgresql://postgres:pass%word@[::1]:5432/db";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.user).toBe("postgres");
+      expect(config.password).toBe("pass%word");
+      expect(config.database).toBe("db");
+    });
+
+    test("truncated percent escape in password does not throw", () => {
+      const url = "postgresql://postgres:pa%xx@[::1]:5432/db";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.password).toBe("pa%xx");
+    });
+
+    test("bare % in username does not throw", () => {
+      const url = "postgresql://us%er:pass@[::1]:5432/db";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.user).toBe("us%er");
+    });
+
+    test("bare % in database name does not throw", () => {
+      const url = "postgresql://user:pass@[::1]:5432/my%db";
+      const config = poolConfigFromUrl(url);
+      expect(config.host).toBe("::1");
+      expect(config.database).toBe("my%db");
+    });
+  });
 });

--- a/packages/pg-delta/src/core/postgres-config.ts
+++ b/packages/pg-delta/src/core/postgres-config.ts
@@ -4,7 +4,10 @@
 
 import type { ClientBase, PoolClient, PoolConfig } from "pg";
 import { escapeIdentifier, Pool, types } from "pg";
-import { normalizeConnectionUrl } from "./connection-url.ts";
+import {
+  normalizeConnectionUrl,
+  safeDecodeURIComponent,
+} from "./connection-url.ts";
 import { parseSslConfig } from "./plan/ssl-config.ts";
 
 // ============================================================================
@@ -340,10 +343,11 @@ export function poolConfigFromUrl(cleanedUrl: string): PoolConfig {
     host: urlObj.hostname.slice(1, -1),
   };
   if (urlObj.port) config.port = Number(urlObj.port);
-  if (urlObj.username) config.user = decodeURIComponent(urlObj.username);
-  if (urlObj.password) config.password = decodeURIComponent(urlObj.password);
+  if (urlObj.username) config.user = safeDecodeURIComponent(urlObj.username);
+  if (urlObj.password)
+    config.password = safeDecodeURIComponent(urlObj.password);
   if (urlObj.pathname.length > 1) {
-    config.database = decodeURIComponent(urlObj.pathname.slice(1));
+    config.database = safeDecodeURIComponent(urlObj.pathname.slice(1));
   }
   for (const [key, value] of urlObj.searchParams) {
     config[key] = value;


### PR DESCRIPTION
## Summary

Fixes `URIError: URI malformed` crash in `poolConfigFromUrl` (Sentry [SUPABASE-API-7TV](https://supabase.sentry.io/issues/SUPABASE-API-7TV), 20+ events on `@supabase/pg-delta@1.0.0-alpha.16`). Connection URLs whose userinfo, database, or hostname contain a bare `%` or a truncated escape like `%x` crashed `createManagedPool` synchronously before any connection attempt.

## Fix

- Introduce `safeDecodeURIComponent` in `packages/pg-delta/src/core/connection-url.ts` — wraps `decodeURIComponent` and returns the input unchanged on `URIError` (rethrows anything else).
- Apply it at the three call sites in `poolConfigFromUrl` (`postgres-config.ts:343-346`) and the one in `normalizeConnectionUrl` (`connection-url.ts:65`).
- Non-IPv6 URLs still go through `pg-connection-string` (which has its own `%` workaround), unchanged.

## Reproduction

Full production stack trace reproduced locally with a percent-encoded IPv6 host + bare `%` password:

```
URIError: URI error
  at decodeURIComponent (unknown)
  at poolConfigFromUrl (postgres-config.ts:344:42)
  at createManagedPool (postgres-config.ts:389:28)
```

After the fix, the same invocation proceeds past URL parsing and surfaces a normal network/auth outcome instead.

## Test plan

- [x] 4 regression tests in `postgres-config.test.ts` (`malformed percent-encoding in userinfo/database`) flip from red to green
- [x] Existing `"host bracket strip survives percent-decoded username/password"` still green
- [x] 5 new `safeDecodeURIComponent` unit tests
- [x] 1 new `normalizeConnectionUrl` regression (hostname `%3A` + bare `%`)
- [x] Live end-to-end reproduction against a Supabase IPv6 URL: `URIError` before fix, normal network outcome after
- [x] `bun run format-and-lint`, `bun run check-types`, `bun run knip` all clean

https://claude.ai/code/session_015VxiD6vQzGnvVXKE3zMpTH