### PR TITLE
fix(pg-delta): coalesce key_columns for expression-only constraints

### DIFF
--- a/.changeset/fix-null-key-columns-expression-exclude.md
+++ b/.changeset/fix-null-key-columns-expression-exclude.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix ZodError when extracting tables with EXCLUDE constraints defined over expressions. PostgreSQL stores `attnum=0` in `pg_constraint.conkey` for expression elements, which never matches `pg_attribute`, so the inner aggregate returned SQL `NULL` and tripped `tablePropsSchema` at `constraints[*].key_columns`. The extractor now coalesces the aggregate to an empty JSON array.

--- a/packages/pg-delta/src/core/objects/table/table.model.ts
+++ b/packages/pg-delta/src/core/objects/table/table.model.ts
@@ -296,13 +296,16 @@ select
 
           'key_columns',
             case
-              when c.conkey is not null then (
-                select json_agg(quote_ident(att.attname) order by pk.ordinality)
-                from unnest(c.conkey) with ordinality as pk(attnum, ordinality)
-                join pg_attribute att
-                  on att.attrelid = c.conrelid
-                and att.attnum = pk.attnum
-                and att.attisdropped = false
+              when c.conkey is not null then coalesce(
+                (
+                  select json_agg(quote_ident(att.attname) order by pk.ordinality)
+                  from unnest(c.conkey) with ordinality as pk(attnum, ordinality)
+                  join pg_attribute att
+                    on att.attrelid = c.conrelid
+                  and att.attnum = pk.attnum
+                  and att.attisdropped = false
+                ),
+                '[]'::json
               )
               else '[]'::json
             end,

--- a/packages/pg-delta/tests/integration/constraint-operations.test.ts
+++ b/packages/pg-delta/tests/integration/constraint-operations.test.ts
@@ -375,6 +375,34 @@ for (const pgVersion of POSTGRES_VERSIONS) {
       120_000,
     );
 
+    test(
+      "extract exclude constraint defined over an expression",
+      withDbIsolated(pgVersion, async (db) => {
+        // Regression: an EXCLUDE constraint whose key is an expression stores
+        // attnum=0 in pg_constraint.conkey, which never matches pg_attribute.
+        // The previous extractor's inner json_agg returned SQL NULL in that
+        // case, which tripped tablePropsSchema with "expected array, received
+        // null" at constraints[*].key_columns. Roundtrip must succeed.
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE EXTENSION IF NOT EXISTS btree_gist;
+          CREATE SCHEMA test_schema;
+          CREATE TABLE test_schema.expr_excl (
+            a integer NOT NULL
+          );
+        `,
+          testSql: `
+          ALTER TABLE test_schema.expr_excl
+            ADD CONSTRAINT expr_excl_check
+            EXCLUDE USING gist ((a + 0) WITH =);
+        `,
+        });
+      }),
+      120_000,
+    );
+
     if (pgVersion === 18) {
       test(
         "convert primary key to temporal primary key",


### PR DESCRIPTION
## Summary
Fixed a bug where extracting tables with EXCLUDE constraints defined over expressions would fail with a ZodError. PostgreSQL stores `attnum=0` in `pg_constraint.conkey` for expression-based constraint elements, which don't correspond to actual table attributes. This caused the constraint extractor's aggregate query to return SQL `NULL`, which violated the `tablePropsSchema` validation expecting an array for `constraints[*].key_columns`.

## Changes
- **table.model.ts**: Updated the `key_columns` extraction logic to coalesce the `json_agg` result to an empty JSON array (`'[]'::json`) when the aggregate returns `NULL`. This handles the case where constraint keys reference expressions (attnum=0) that don't match any `pg_attribute` rows.
- **constraint-operations.test.ts**: Added a regression test that verifies roundtrip fidelity for tables with EXCLUDE constraints defined over expressions (e.g., `EXCLUDE USING gist ((a + 0) WITH =)`).

## Implementation Details
The fix wraps the existing `json_agg` subquery with `coalesce(..., '[]'::json)` to ensure that when no attribute rows match (as with expression-based constraints), an empty array is returned instead of `NULL`. This maintains schema validation compliance while correctly representing constraints that don't have traditional column references.

https://claude.ai/code/session_01E4SZjXbNrH4uHiZP56gS7x