### PR TITLE
chore(ci): emit coverage-final.json for Fallow runtime coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           name: coverage-pg-delta-unit
           path: packages/pg-delta/.nyc_output/
-          retention-days: 1
+          retention-days: 7
           include-hidden-files: true
 
   pg-delta-integration:
@@ -186,7 +186,7 @@ jobs:
         with:
           name: coverage-integration-pg${{ matrix.postgres_version }}-shard-${{ matrix.shard_index }}
           path: packages/pg-delta/.nyc_output/
-          retention-days: 1
+          retention-days: 7
           include-hidden-files: true
 
   pg-delta-integration-pg15-compat:
@@ -319,7 +319,7 @@ jobs:
         with:
           name: coverage-pg-topo
           path: packages/pg-topo/.nyc_output/
-          retention-days: 1
+          retention-days: 7
           include-hidden-files: true
 
   deno2-library-e2e:

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -3,5 +3,5 @@
   "exclude": ["**/*.test.ts", "**/*.base.ts", "**/debug-visualization.ts"],
   "report-dir": ".coverage-artifacts",
   "temp-dir": ".nyc_output",
-  "reporter": ["lcov", "text", "html", "json-summary"]
+  "reporter": ["lcov", "text", "html", "json-summary", "json"]
 }


### PR DESCRIPTION
## Summary

Two small changes so that CI-produced coverage artifacts become directly consumable by [Fallow's `--runtime-coverage`](https://docs.fallow.tools/analysis/runtime-coverage) (and any other tool that expects a canonical Istanbul coverage map).

- **`.nycrc.json`** — add `"json"` to the `reporter` list. `nyc report` now writes `.coverage-artifacts/coverage-final.json` alongside the existing `lcov`, `html`, `text`, and `json-summary` outputs. Fallow's runtime-coverage flag accepts only V8 dumps or an Istanbul coverage map; the previous artifact set had neither, so today ingesting CI coverage into Fallow requires `gh run download`ing every raw per-shard `.nyc_output` artifact and merging locally (see test plan).
- **`.github/workflows/tests.yml`** — bump `retention-days: 1` → `7` on the three raw `.nyc_output/` upload steps (pg-delta unit, integration shards, pg-topo). The 1-day window made the `gh run download` fallback unusable once a PR sat idle for a day. 7 days keeps storage cost trivial (~11 MB/run) while letting delayed analyses still merge per-shard data.

No changes to published package behavior, so no changeset is included per the workspace "changesets for fix/feat" rule.

## After this merges

Future Fallow runs collapse to:

\`\`\`bash
# Download the long-retention coverage-report artifact (retention-days: 30)
gh run download <RUN_ID> --name coverage-report --dir coverage-report

# Feed the Istanbul map straight to Fallow. Paths in the map are CI-absolute,
# so rebase them to the local repo root first (--coverage-root on fallow health
# currently applies to --coverage CRAP scoring, not --runtime-coverage).
node -e '
const fs = require("fs");
const m = JSON.parse(fs.readFileSync("coverage-report/coverage-final.json"));
const prefix = "/home/runner/work/pg-toolbelt/pg-toolbelt";
const out = {};
for (const [k, v] of Object.entries(m)) {
  const nk = k.startsWith(prefix) ? k.replace(prefix, process.cwd()) : k;
  if (v.path && v.path.startsWith(prefix)) v.path = v.path.replace(prefix, process.cwd());
  out[nk] = v;
}
fs.writeFileSync("coverage-report/coverage-final.local.json", JSON.stringify(out));
'

npx fallow health --runtime-coverage ./coverage-report/coverage-final.local.json
\`\`\`

## Test plan

- [ ] Wait for this PR's own \`Tests\` workflow to complete; open the run in the Actions UI.
- [ ] Confirm the \`coverage-report\` artifact now contains \`coverage-final.json\` (previously it had only \`coverage-summary.json\`, \`lcov.info\`, and HTML).
- [ ] Download \`coverage-report\`, rebase paths (see snippet above), and pipe into \`npx fallow health --runtime-coverage\` to confirm the runtime_coverage section reports real hit counts (not \`0 hit\` as it would with unrebased CI paths).
- [ ] Confirm the three raw \`coverage-pg-topo\`, \`coverage-pg-delta-unit\`, \`coverage-integration-*\` artifacts show the new 7-day retention.