### PR TITLE
fix(pg-delta): suppress platform-managed FDW DDL/ACL in supabase integration + emit valid aggregate GRANT signatures

### DIFF
--- a/.changeset/fix-aggregate-grant-signature.md
+++ b/.changeset/fix-aggregate-grant-signature.md
@@ -1,0 +1,16 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): emit valid GRANT/REVOKE syntax for ordered-set, hypothetical-set, and variadic aggregates
+
+`GrantAggregatePrivileges` / `RevokeAggregatePrivileges` /
+`RevokeGrantOptionAggregatePrivileges` previously serialized the
+aggregate signature using `pg_get_function_identity_arguments`, which
+embeds `ORDER BY` for ordered-set / hypothetical-set aggregates
+(`aggkind` of `o` / `h`) and `VARIADIC` for variadic aggregates. The
+PostgreSQL `GRANT ... ON FUNCTION` parser rejects both keywords inside
+the argument list, so the generated `GRANT`/`REVOKE` failed with a
+syntax error for any aggregate that wasn't a plain `aggkind = 'n'`.
+The serializer now uses the `proargtypes`-derived `argument_types`
+list, matching the signature shape PostgreSQL expects for `GRANT`/`REVOKE`.

--- a/.changeset/suppress-fdw-server-acl.md
+++ b/.changeset/suppress-fdw-server-acl.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): suppress GRANT/REVOKE on FOREIGN DATA WRAPPER and FOREIGN SERVER in the supabase integration
+
+`GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER` requires superuser. On Supabase Cloud `postgres` has the elevated rights to apply these grants, but the local Docker image does not — so the previous diff output broke `supabase db reset` with `permission denied for foreign-data wrapper dblink_fdw`. FDW (and the adjacent `FOREIGN SERVER`) ACL is platform-managed state, not user-declarative state, so the supabase integration now drops privilege-scope changes for both object types regardless of owner.

--- a/.changeset/suppress-fdw-server-acl.md
+++ b/.changeset/suppress-fdw-server-acl.md
@@ -2,6 +2,6 @@
 "@supabase/pg-delta": patch
 ---
 
-fix(pg-delta): suppress GRANT/REVOKE on FOREIGN DATA WRAPPER and FOREIGN SERVER in the supabase integration
+fix(pg-delta): suppress GRANT/REVOKE on FOREIGN DATA WRAPPER in the supabase integration
 
-`GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER` requires superuser. On Supabase Cloud `postgres` has the elevated rights to apply these grants, but the local Docker image does not — so the previous diff output broke `supabase db reset` with `permission denied for foreign-data wrapper dblink_fdw`. FDW (and the adjacent `FOREIGN SERVER`) ACL is platform-managed state, not user-declarative state, so the supabase integration now drops privilege-scope changes for both object types regardless of owner.
+`GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER` requires superuser. On Supabase Cloud the `postgres` role has the elevated rights to apply these grants, but the local Docker image does not — so the previous diff output broke `supabase db reset` with `permission denied for foreign-data wrapper dblink_fdw`. The existing system-role rule already covers wrappers owned by `supabase_admin`, but `pg_dump` rewrites OWNER TO clauses to whoever the dump runs under, so after a restore the FDW ends up owned by `postgres` and slips past the owner gate. The supabase integration filter now drops privilege-scope changes on `foreign_data_wrapper` regardless of owner, since the FDW ACL is never user-replayable in the local image. `FOREIGN SERVER` ACL is intentionally left alone — server GRANT/REVOKE doesn't require superuser, and user-created servers (e.g. a `dblink` server pointing to a peer DB) carry legitimate user ACL that should still roundtrip.

--- a/.changeset/suppress-wasm-fdw-creation.md
+++ b/.changeset/suppress-wasm-fdw-creation.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): suppress CREATE/DROP/ALTER FOREIGN DATA WRAPPER for platform-managed Wasm wrappers in the supabase integration
+
+The `supabase` integration now skips any FDW whose `HANDLER` or `VALIDATOR` references a function in the `extensions` schema. This covers the Wasm-based wrappers (`clerk`, `clerk_oauth`, etc.) that Supabase Cloud provisions as `supabase_admin` at project creation. `CREATE FOREIGN DATA WRAPPER` requires superuser, and the local Docker image has no equivalent pre-step, so the previous diff output broke `supabase db reset`. Owner-based filtering wasn't enough because the wrapper owner is often rewritten away from `supabase_admin` after a dump/restore.

--- a/packages/pg-delta/src/core/integrations/supabase.test.ts
+++ b/packages/pg-delta/src/core/integrations/supabase.test.ts
@@ -144,8 +144,10 @@ describe("supabase integration filter — foreign data wrapper / server ACLs", (
   // require superuser. On Supabase Cloud `postgres` has the elevated
   // rights to make them work; the local Docker image does not, so
   // `supabase db reset` aborts with `permission denied for foreign-data
-  // wrapper`. FDW ACL is platform-managed, not user-declarative state.
-  test("suppresses GRANT on FOREIGN DATA WRAPPER", () => {
+  // wrapper`. FDW ACL is platform-managed, not user-declarative state —
+  // suppress regardless of owner because `pg_dump` rewrites OWNER TO
+  // away from `supabase_admin`.
+  test("suppresses GRANT on FOREIGN DATA WRAPPER owned by postgres (post-restore)", () => {
     const change = fdwPrivilegeChange("create", {
       name: "dblink_fdw",
       owner: "postgres",
@@ -153,7 +155,7 @@ describe("supabase integration filter — foreign data wrapper / server ACLs", (
     expect(evaluatePattern(filter, change)).toBe(false);
   });
 
-  test("suppresses REVOKE on FOREIGN DATA WRAPPER", () => {
+  test("suppresses REVOKE on FOREIGN DATA WRAPPER owned by postgres (post-restore)", () => {
     const change = fdwPrivilegeChange("drop", {
       name: "postgres_fdw",
       owner: "postgres",
@@ -161,23 +163,32 @@ describe("supabase integration filter — foreign data wrapper / server ACLs", (
     expect(evaluatePattern(filter, change)).toBe(false);
   });
 
-  // Defense-in-depth: foreign-server ACL is owned by `supabase_admin` on
-  // Supabase Cloud for the same reason, and the local image can't replay
-  // those grants either.
-  test("suppresses GRANT on FOREIGN SERVER", () => {
+  // FOREIGN SERVER ACL is owner-scoped, not blanket-suppressed:
+  // server GRANT/REVOKE does not require superuser, so a user-owned
+  // server's ACL must roundtrip. The pre-existing `*/owner` rule
+  // already drops platform-managed servers (owner ∈ system roles).
+  test("suppresses GRANT on FOREIGN SERVER owned by supabase_admin (existing */owner rule)", () => {
     const change = serverPrivilegeChange("create", {
-      name: "my_server",
-      owner: "postgres",
+      name: "platform_server",
+      owner: "supabase_admin",
     });
     expect(evaluatePattern(filter, change)).toBe(false);
   });
 
-  test("suppresses REVOKE on FOREIGN SERVER", () => {
-    const change = serverPrivilegeChange("drop", {
-      name: "my_server",
+  test("preserves GRANT on FOREIGN SERVER owned by user role", () => {
+    const change = serverPrivilegeChange("create", {
+      name: "user_dblink_server",
       owner: "postgres",
     });
-    expect(evaluatePattern(filter, change)).toBe(false);
+    expect(evaluatePattern(filter, change)).toBe(true);
+  });
+
+  test("preserves REVOKE on FOREIGN SERVER owned by user role", () => {
+    const change = serverPrivilegeChange("drop", {
+      name: "user_dblink_server",
+      owner: "postgres",
+    });
+    expect(evaluatePattern(filter, change)).toBe(true);
   });
 
   // Non-privilege FDW changes whose handler/validator aren't in

--- a/packages/pg-delta/src/core/integrations/supabase.test.ts
+++ b/packages/pg-delta/src/core/integrations/supabase.test.ts
@@ -101,3 +101,95 @@ describe("supabase integration filter — foreign data wrappers", () => {
     expect(evaluatePattern(filter, change)).toBe(true);
   });
 });
+
+function fdwPrivilegeChange(
+  operation: "create" | "drop",
+  fdw: { name: string; owner: string },
+): Change {
+  return {
+    objectType: "foreign_data_wrapper",
+    operation,
+    scope: "privilege",
+    foreignDataWrapper: { ...fdw, handler: null, validator: null },
+    grantee: "postgres",
+    requires: [],
+    creates: [],
+    drops: [],
+  } as unknown as Change;
+}
+
+function serverPrivilegeChange(
+  operation: "create" | "drop",
+  server: { name: string; owner: string },
+): Change {
+  return {
+    objectType: "server",
+    operation,
+    scope: "privilege",
+    server,
+    grantee: "postgres",
+    requires: [],
+    creates: [],
+    drops: [],
+  } as unknown as Change;
+}
+
+describe("supabase integration filter — foreign data wrapper / server ACLs", () => {
+  if (!supabase.filter) {
+    throw new Error("supabase integration is missing a filter");
+  }
+  const filter = supabase.filter;
+
+  // Regression for CLI-1469. `GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER`
+  // require superuser. On Supabase Cloud `postgres` has the elevated
+  // rights to make them work; the local Docker image does not, so
+  // `supabase db reset` aborts with `permission denied for foreign-data
+  // wrapper`. FDW ACL is platform-managed, not user-declarative state.
+  test("suppresses GRANT on FOREIGN DATA WRAPPER", () => {
+    const change = fdwPrivilegeChange("create", {
+      name: "dblink_fdw",
+      owner: "postgres",
+    });
+    expect(evaluatePattern(filter, change)).toBe(false);
+  });
+
+  test("suppresses REVOKE on FOREIGN DATA WRAPPER", () => {
+    const change = fdwPrivilegeChange("drop", {
+      name: "postgres_fdw",
+      owner: "postgres",
+    });
+    expect(evaluatePattern(filter, change)).toBe(false);
+  });
+
+  // Defense-in-depth: foreign-server ACL is owned by `supabase_admin` on
+  // Supabase Cloud for the same reason, and the local image can't replay
+  // those grants either.
+  test("suppresses GRANT on FOREIGN SERVER", () => {
+    const change = serverPrivilegeChange("create", {
+      name: "my_server",
+      owner: "postgres",
+    });
+    expect(evaluatePattern(filter, change)).toBe(false);
+  });
+
+  test("suppresses REVOKE on FOREIGN SERVER", () => {
+    const change = serverPrivilegeChange("drop", {
+      name: "my_server",
+      owner: "postgres",
+    });
+    expect(evaluatePattern(filter, change)).toBe(false);
+  });
+
+  // Non-privilege FDW changes whose handler/validator aren't in
+  // `extensions.*` should still pass through (a user FDW is plain DDL,
+  // not the platform-managed flavor).
+  test("preserves non-privilege FDW changes for user wrappers", () => {
+    const change = fdwChange("create", {
+      name: "user_fdw",
+      owner: "postgres",
+      handler: "public.my_fdw_handler",
+      validator: null,
+    });
+    expect(evaluatePattern(filter, change)).toBe(true);
+  });
+});

--- a/packages/pg-delta/src/core/integrations/supabase.test.ts
+++ b/packages/pg-delta/src/core/integrations/supabase.test.ts
@@ -3,6 +3,11 @@ import type { Change } from "../change.types.ts";
 import { evaluatePattern } from "./filter/dsl.ts";
 import { supabase } from "./supabase.ts";
 
+if (!supabase.filter) {
+  throw new Error("supabase integration is missing a filter");
+}
+const filter = supabase.filter;
+
 /**
  * Build a synthetic FDW change shaped like what `flattenChange` consumes.
  * The change carries a `foreignDataWrapper` model whose `handler`/`validator`
@@ -29,12 +34,44 @@ function fdwChange(
   } as unknown as Change;
 }
 
-describe("supabase integration filter — foreign data wrappers", () => {
-  if (!supabase.filter) {
-    throw new Error("supabase integration is missing a filter");
-  }
-  const filter = supabase.filter;
+/**
+ * Synthetic FDW privilege change. The three concrete privilege classes
+ * (`GrantForeignDataWrapperPrivileges`, `RevokeForeignDataWrapperPrivileges`,
+ * `RevokeGrantOptionForeignDataWrapperPrivileges`) all extend
+ * `AlterForeignDataWrapperChange`, so their `operation` is `"alter"` in
+ * production. The filter rule we exercise here keys off `scope` only,
+ * but pinning `operation: "alter"` keeps the synthetic shape honest.
+ */
+function fdwPrivilegeChange(fdw: { name: string; owner: string }): Change {
+  return {
+    objectType: "foreign_data_wrapper",
+    operation: "alter",
+    scope: "privilege",
+    foreignDataWrapper: { ...fdw, handler: null, validator: null },
+    grantee: "postgres",
+    requires: [],
+    creates: [],
+    drops: [],
+  } as unknown as Change;
+}
 
+function serverPrivilegeChange(server: {
+  name: string;
+  owner: string;
+}): Change {
+  return {
+    objectType: "server",
+    operation: "alter",
+    scope: "privilege",
+    server,
+    grantee: "postgres",
+    requires: [],
+    creates: [],
+    drops: [],
+  } as unknown as Change;
+}
+
+describe("supabase integration filter — foreign data wrappers", () => {
   // Regression for CLI-1470. Wasm-based foreign data wrappers on Supabase
   // (e.g. `clerk`, `clerk_oauth`) are provisioned at project creation by
   // `supabase_admin` and their handler/validator live in `extensions.*`.
@@ -102,44 +139,7 @@ describe("supabase integration filter — foreign data wrappers", () => {
   });
 });
 
-function fdwPrivilegeChange(
-  operation: "create" | "drop",
-  fdw: { name: string; owner: string },
-): Change {
-  return {
-    objectType: "foreign_data_wrapper",
-    operation,
-    scope: "privilege",
-    foreignDataWrapper: { ...fdw, handler: null, validator: null },
-    grantee: "postgres",
-    requires: [],
-    creates: [],
-    drops: [],
-  } as unknown as Change;
-}
-
-function serverPrivilegeChange(
-  operation: "create" | "drop",
-  server: { name: string; owner: string },
-): Change {
-  return {
-    objectType: "server",
-    operation,
-    scope: "privilege",
-    server,
-    grantee: "postgres",
-    requires: [],
-    creates: [],
-    drops: [],
-  } as unknown as Change;
-}
-
 describe("supabase integration filter — foreign data wrapper / server ACLs", () => {
-  if (!supabase.filter) {
-    throw new Error("supabase integration is missing a filter");
-  }
-  const filter = supabase.filter;
-
   // Regression for CLI-1469. `GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER`
   // require superuser. On Supabase Cloud `postgres` has the elevated
   // rights to make them work; the local Docker image does not, so
@@ -147,17 +147,17 @@ describe("supabase integration filter — foreign data wrapper / server ACLs", (
   // wrapper`. FDW ACL is platform-managed, not user-declarative state —
   // suppress regardless of owner because `pg_dump` rewrites OWNER TO
   // away from `supabase_admin`.
-  test("suppresses GRANT on FOREIGN DATA WRAPPER owned by postgres (post-restore)", () => {
-    const change = fdwPrivilegeChange("create", {
+  test("suppresses FDW ACL when owner=supabase_admin (existing */owner rule)", () => {
+    const change = fdwPrivilegeChange({
       name: "dblink_fdw",
-      owner: "postgres",
+      owner: "supabase_admin",
     });
     expect(evaluatePattern(filter, change)).toBe(false);
   });
 
-  test("suppresses REVOKE on FOREIGN DATA WRAPPER owned by postgres (post-restore)", () => {
-    const change = fdwPrivilegeChange("drop", {
-      name: "postgres_fdw",
+  test("suppresses FDW ACL when owner=postgres (post-restore)", () => {
+    const change = fdwPrivilegeChange({
+      name: "dblink_fdw",
       owner: "postgres",
     });
     expect(evaluatePattern(filter, change)).toBe(false);
@@ -167,24 +167,16 @@ describe("supabase integration filter — foreign data wrapper / server ACLs", (
   // server GRANT/REVOKE does not require superuser, so a user-owned
   // server's ACL must roundtrip. The pre-existing `*/owner` rule
   // already drops platform-managed servers (owner ∈ system roles).
-  test("suppresses GRANT on FOREIGN SERVER owned by supabase_admin (existing */owner rule)", () => {
-    const change = serverPrivilegeChange("create", {
+  test("suppresses server ACL when owner=supabase_admin (existing */owner rule)", () => {
+    const change = serverPrivilegeChange({
       name: "platform_server",
       owner: "supabase_admin",
     });
     expect(evaluatePattern(filter, change)).toBe(false);
   });
 
-  test("preserves GRANT on FOREIGN SERVER owned by user role", () => {
-    const change = serverPrivilegeChange("create", {
-      name: "user_dblink_server",
-      owner: "postgres",
-    });
-    expect(evaluatePattern(filter, change)).toBe(true);
-  });
-
-  test("preserves REVOKE on FOREIGN SERVER owned by user role", () => {
-    const change = serverPrivilegeChange("drop", {
+  test("preserves server ACL when owner=postgres", () => {
+    const change = serverPrivilegeChange({
       name: "user_dblink_server",
       owner: "postgres",
     });

--- a/packages/pg-delta/src/core/integrations/supabase.test.ts
+++ b/packages/pg-delta/src/core/integrations/supabase.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import type { Change } from "../change.types.ts";
+import { evaluatePattern } from "./filter/dsl.ts";
+import { supabase } from "./supabase.ts";
+
+/**
+ * Build a synthetic FDW change shaped like what `flattenChange` consumes.
+ * The change carries a `foreignDataWrapper` model whose `handler`/`validator`
+ * are schema-qualified function references (the form
+ * `extractForeignDataWrappers` produces).
+ */
+function fdwChange(
+  operation: "create" | "alter" | "drop",
+  fdw: {
+    name: string;
+    owner: string;
+    handler: string | null;
+    validator: string | null;
+  },
+): Change {
+  return {
+    objectType: "foreign_data_wrapper",
+    operation,
+    scope: "object",
+    foreignDataWrapper: fdw,
+    requires: [],
+    creates: [],
+    drops: [],
+  } as unknown as Change;
+}
+
+describe("supabase integration filter — foreign data wrappers", () => {
+  if (!supabase.filter) {
+    throw new Error("supabase integration is missing a filter");
+  }
+  const filter = supabase.filter;
+
+  // Regression for CLI-1470. Wasm-based foreign data wrappers on Supabase
+  // (e.g. `clerk`, `clerk_oauth`) are provisioned at project creation by
+  // `supabase_admin` and their handler/validator live in `extensions.*`.
+  // pg-delta must not emit `CREATE/DROP/ALTER FOREIGN DATA WRAPPER` for
+  // them, even when the FDW owner has been rewritten away from
+  // `supabase_admin` (e.g. after a dump/restore).
+  test("suppresses CREATE for FDW with handler in extensions schema", () => {
+    const change = fdwChange("create", {
+      name: "clerk",
+      owner: "postgres",
+      handler: "extensions.wasm_fdw_handler",
+      validator: "extensions.wasm_fdw_validator",
+    });
+    expect(evaluatePattern(filter, change)).toBe(false);
+  });
+
+  test("suppresses DROP for FDW with handler in extensions schema", () => {
+    const change = fdwChange("drop", {
+      name: "clerk_oauth",
+      owner: "postgres",
+      handler: "extensions.wasm_fdw_handler",
+      validator: "extensions.wasm_fdw_validator",
+    });
+    expect(evaluatePattern(filter, change)).toBe(false);
+  });
+
+  test("suppresses ALTER for FDW with handler in extensions schema", () => {
+    const change = fdwChange("alter", {
+      name: "clerk",
+      owner: "postgres",
+      handler: "extensions.wasm_fdw_handler",
+      validator: "extensions.wasm_fdw_validator",
+    });
+    expect(evaluatePattern(filter, change)).toBe(false);
+  });
+
+  test("suppresses FDW when only the validator lives in extensions", () => {
+    const change = fdwChange("create", {
+      name: "partial_wasm",
+      owner: "postgres",
+      handler: null,
+      validator: "extensions.wasm_fdw_validator",
+    });
+    expect(evaluatePattern(filter, change)).toBe(false);
+  });
+
+  test("preserves user FDW whose handler lives outside extensions", () => {
+    const change = fdwChange("create", {
+      name: "user_fdw",
+      owner: "postgres",
+      handler: "public.my_fdw_handler",
+      validator: "public.my_fdw_validator",
+    });
+    expect(evaluatePattern(filter, change)).toBe(true);
+  });
+
+  test("preserves user FDW with no handler/validator", () => {
+    const change = fdwChange("create", {
+      name: "user_fdw_bare",
+      owner: "postgres",
+      handler: null,
+      validator: null,
+    });
+    expect(evaluatePattern(filter, change)).toBe(true);
+  });
+});

--- a/packages/pg-delta/src/core/integrations/supabase.ts
+++ b/packages/pg-delta/src/core/integrations/supabase.ts
@@ -159,6 +159,21 @@ export const supabase: IntegrationDSL = {
                 },
               ],
             },
+            // Platform-managed foreign data wrapper / foreign server ACL.
+            // `GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER` requires
+            // superuser; on Supabase Cloud `postgres` has the elevated
+            // rights to make this work, but the local Docker image does
+            // not, so `supabase db reset` aborts with
+            // `permission denied for foreign-data wrapper`. FDW (and the
+            // adjacent FOREIGN SERVER) ACL is platform-managed state,
+            // not user-declarative state — drop it from the plan
+            // regardless of owner.
+            {
+              and: [
+                { objectType: ["foreign_data_wrapper", "server"] },
+                { scope: "privilege" },
+              ],
+            },
             // Platform-managed foreign data wrappers — Wasm-based FDWs
             // (e.g. `clerk`, `clerk_oauth`) whose handler/validator live in
             // the `extensions` schema. `CREATE FOREIGN DATA WRAPPER`

--- a/packages/pg-delta/src/core/integrations/supabase.ts
+++ b/packages/pg-delta/src/core/integrations/supabase.ts
@@ -159,6 +159,37 @@ export const supabase: IntegrationDSL = {
                 },
               ],
             },
+            // Platform-managed foreign data wrappers — Wasm-based FDWs
+            // (e.g. `clerk`, `clerk_oauth`) whose handler/validator live in
+            // the `extensions` schema. `CREATE FOREIGN DATA WRAPPER`
+            // requires superuser, and Supabase Cloud provisions these via
+            // `supabase_admin` at project creation; replaying the DDL
+            // against a local image fails because the local environment
+            // has no equivalent pre-step. We can't rely on the FDW owner
+            // alone — after a dump/restore the owner is often rewritten
+            // away from `supabase_admin` — so match on the function
+            // reference instead.
+            {
+              and: [
+                { objectType: "foreign_data_wrapper" },
+                {
+                  or: [
+                    {
+                      "foreign_data_wrapper/handler": {
+                        op: "regex",
+                        value: "^extensions\\.",
+                      },
+                    },
+                    {
+                      "foreign_data_wrapper/validator": {
+                        op: "regex",
+                        value: "^extensions\\.",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
           ],
         },
       },

--- a/packages/pg-delta/src/core/integrations/supabase.ts
+++ b/packages/pg-delta/src/core/integrations/supabase.ts
@@ -159,18 +159,28 @@ export const supabase: IntegrationDSL = {
                 },
               ],
             },
-            // Platform-managed foreign data wrapper / foreign server ACL.
+            // Platform-managed foreign data wrapper ACL.
             // `GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER` requires
-            // superuser; on Supabase Cloud `postgres` has the elevated
+            // superuser. On Supabase Cloud `postgres` has the elevated
             // rights to make this work, but the local Docker image does
             // not, so `supabase db reset` aborts with
-            // `permission denied for foreign-data wrapper`. FDW (and the
-            // adjacent FOREIGN SERVER) ACL is platform-managed state,
-            // not user-declarative state — drop it from the plan
-            // regardless of owner.
+            // `permission denied for foreign-data wrapper`. The
+            // `*/owner` rule above already covers wrappers owned by
+            // `supabase_admin`, but `pg_dump` rewrites OWNER TO clauses
+            // to whoever the dump runs under, so after a restore the
+            // FDW typically ends up owned by `postgres` and slips past
+            // the owner gate. A non-superuser `postgres` still can't
+            // grant on a FDW (this is true regardless of who owns the
+            // wrapper locally), so the ACL diff is not user-replayable.
+            // We don't apply the same blanket rule to `FOREIGN SERVER`:
+            // server GRANT/REVOKE doesn't require superuser, and
+            // user-created servers (e.g. a `dblink` server pointing to
+            // a peer DB) carry legitimate user ACL that should
+            // roundtrip — the existing `*/owner` rule already drops
+            // platform-managed servers.
             {
               and: [
-                { objectType: ["foreign_data_wrapper", "server"] },
+                { objectType: "foreign_data_wrapper" },
                 { scope: "privilege" },
               ],
             },

--- a/packages/pg-delta/src/core/objects/aggregate/changes/aggregate.privilege.test.ts
+++ b/packages/pg-delta/src/core/objects/aggregate/changes/aggregate.privilege.test.ts
@@ -147,6 +147,30 @@ describe("aggregate.privilege", () => {
     );
   });
 
+  test("revoke grant option on ordered-set aggregate emits proargtypes signature", async () => {
+    const aggregate = new Aggregate({
+      ...base,
+      name: "os_last",
+      aggkind: "o",
+      identity_arguments: "anyelement ORDER BY anyelement",
+      argument_types: ["anyelement", "anyelement"],
+      return_type: "anyelement",
+      transition_function: "public.os_last_sfunc(anyelement,anyelement)",
+      state_data_type: "anyelement",
+      argument_count: 2,
+    });
+    const change = new RevokeGrantOptionAggregatePrivileges({
+      aggregate,
+      grantee: "role_with_option",
+      privilegeNames: ["EXECUTE"],
+      version: 170000,
+    });
+    await assertValidSql(change.serialize());
+    expect(change.serialize()).toBe(
+      "REVOKE GRANT OPTION FOR ALL ON FUNCTION public.os_last(anyelement, anyelement) FROM role_with_option",
+    );
+  });
+
   test("revoke privileges and grant option", async () => {
     const aggregate = new Aggregate(base);
     const revoke = new RevokeAggregatePrivileges({

--- a/packages/pg-delta/src/core/objects/aggregate/changes/aggregate.privilege.test.ts
+++ b/packages/pg-delta/src/core/objects/aggregate/changes/aggregate.privilege.test.ts
@@ -92,6 +92,61 @@ describe("aggregate.privilege", () => {
     );
   });
 
+  // Regression for CLI-1471: ordered-set / hypothetical-set / variadic
+  // aggregates have `identity_arguments` that include `ORDER BY` or
+  // `VARIADIC` keywords. Those keywords are rejected by
+  // `GRANT ... ON FUNCTION (...)` (only positional argument types are
+  // accepted there), so the serializer must drop back to the
+  // `proargtypes`-derived `argument_types` list.
+  test("grant on ordered-set aggregate emits proargtypes signature", async () => {
+    const aggregate = new Aggregate({
+      ...base,
+      name: "os_last",
+      aggkind: "o",
+      identity_arguments: "anyelement ORDER BY anyelement",
+      argument_types: ["anyelement", "anyelement"],
+      return_type: "anyelement",
+      transition_function: "public.os_last_sfunc(anyelement,anyelement)",
+      state_data_type: "anyelement",
+      argument_count: 2,
+    });
+    const change = new GrantAggregatePrivileges({
+      aggregate,
+      grantee: "role_exec",
+      privileges: [{ privilege: "EXECUTE", grantable: false }],
+      version: 170000,
+    });
+    await assertValidSql(change.serialize());
+    expect(change.serialize()).toBe(
+      "GRANT ALL ON FUNCTION public.os_last(anyelement, anyelement) TO role_exec",
+    );
+  });
+
+  test("revoke on hypothetical-set aggregate emits proargtypes signature", async () => {
+    const aggregate = new Aggregate({
+      ...base,
+      name: "hyp_rank",
+      aggkind: "h",
+      identity_arguments: 'VARIADIC "any" ORDER BY VARIADIC "any"',
+      argument_types: ['"any"'],
+      return_type: "bigint",
+      transition_function:
+        'pg_catalog.ordered_set_transition_multi(internal,"any")',
+      state_data_type: "internal",
+      argument_count: 1,
+    });
+    const change = new RevokeAggregatePrivileges({
+      aggregate,
+      grantee: "role_old",
+      privileges: [{ privilege: "EXECUTE", grantable: false }],
+      version: 170000,
+    });
+    await assertValidSql(change.serialize());
+    expect(change.serialize()).toBe(
+      'REVOKE ALL ON FUNCTION public.hyp_rank("any") FROM role_old',
+    );
+  });
+
   test("revoke privileges and grant option", async () => {
     const aggregate = new Aggregate(base);
     const revoke = new RevokeAggregatePrivileges({

--- a/packages/pg-delta/src/core/objects/aggregate/changes/aggregate.privilege.ts
+++ b/packages/pg-delta/src/core/objects/aggregate/changes/aggregate.privilege.ts
@@ -12,6 +12,25 @@ export type AggregatePrivilege =
   | RevokeAggregatePrivileges
   | RevokeGrantOptionAggregatePrivileges;
 
+/**
+ * Build the signature `<schema>.<name>(<argtypes>)` for use inside
+ * `GRANT`/`REVOKE ... ON FUNCTION (...)`.
+ *
+ * The aggregate's `identityArguments` (from
+ * `pg_get_function_identity_arguments`) embeds `ORDER BY` for ordered-set
+ * and hypothetical-set aggregates (`aggkind` of `o`/`h`) and `VARIADIC`
+ * for variadic aggregates — both of which the GRANT parser rejects with
+ * a syntax error. PostgreSQL resolves the aggregate from the positional
+ * argument types alone, so use `argument_types` here regardless of
+ * `aggkind`. Other aggregate DDL (`ALTER AGGREGATE`, `COMMENT ON
+ * AGGREGATE`, `SECURITY LABEL ON AGGREGATE`, `DROP AGGREGATE`) accepts
+ * the identity form and keeps using it.
+ */
+function aggregateGrantSignature(aggregate: Aggregate): string {
+  const args = (aggregate.argument_types ?? []).join(", ");
+  return `${aggregate.schema}.${aggregate.name}(${args})`;
+}
+
 export class GrantAggregatePrivileges extends AlterAggregateChange {
   public readonly aggregate: Aggregate;
   public readonly grantee: string;
@@ -52,16 +71,7 @@ export class GrantAggregatePrivileges extends AlterAggregateChange {
     const kindPrefix = getObjectKindPrefix("FUNCTION");
     const list = this.privileges.map((p) => p.privilege);
     const privSql = formatObjectPrivilegeList("FUNCTION", list, this.version);
-    const aggregateName = `${this.aggregate.schema}.${this.aggregate.name}`;
-    // GRANT/REVOKE ... ON FUNCTION expects a positional argument-type list
-    // (the `proargtypes` shape), not an aggregate's full identity. The
-    // identity form embeds `ORDER BY` for ordered-set / hypothetical-set
-    // aggregates (`aggkind` of `o`/`h`) and `VARIADIC` for variadic
-    // aggregates — both of which the GRANT parser rejects with a syntax
-    // error. PostgreSQL resolves the aggregate from the argument types
-    // alone, so use `argument_types` here regardless of `aggkind`.
-    const signature = (this.aggregate.argument_types ?? []).join(", ");
-    const qualified = `${aggregateName}(${signature})`;
+    const qualified = aggregateGrantSignature(this.aggregate);
     return `GRANT ${privSql} ${kindPrefix} ${qualified} TO ${this.grantee}${withGrant}`;
   }
 }
@@ -104,16 +114,7 @@ export class RevokeAggregatePrivileges extends AlterAggregateChange {
     const kindPrefix = getObjectKindPrefix("FUNCTION");
     const list = this.privileges.map((p) => p.privilege);
     const privSql = formatObjectPrivilegeList("FUNCTION", list, this.version);
-    const aggregateName = `${this.aggregate.schema}.${this.aggregate.name}`;
-    // GRANT/REVOKE ... ON FUNCTION expects a positional argument-type list
-    // (the `proargtypes` shape), not an aggregate's full identity. The
-    // identity form embeds `ORDER BY` for ordered-set / hypothetical-set
-    // aggregates (`aggkind` of `o`/`h`) and `VARIADIC` for variadic
-    // aggregates — both of which the GRANT parser rejects with a syntax
-    // error. PostgreSQL resolves the aggregate from the argument types
-    // alone, so use `argument_types` here regardless of `aggkind`.
-    const signature = (this.aggregate.argument_types ?? []).join(", ");
-    const qualified = `${aggregateName}(${signature})`;
+    const qualified = aggregateGrantSignature(this.aggregate);
     return `REVOKE ${privSql} ${kindPrefix} ${qualified} FROM ${this.grantee}`;
   }
 }
@@ -153,16 +154,7 @@ export class RevokeGrantOptionAggregatePrivileges extends AlterAggregateChange {
       this.privilegeNames,
       this.version,
     );
-    const aggregateName = `${this.aggregate.schema}.${this.aggregate.name}`;
-    // GRANT/REVOKE ... ON FUNCTION expects a positional argument-type list
-    // (the `proargtypes` shape), not an aggregate's full identity. The
-    // identity form embeds `ORDER BY` for ordered-set / hypothetical-set
-    // aggregates (`aggkind` of `o`/`h`) and `VARIADIC` for variadic
-    // aggregates — both of which the GRANT parser rejects with a syntax
-    // error. PostgreSQL resolves the aggregate from the argument types
-    // alone, so use `argument_types` here regardless of `aggkind`.
-    const signature = (this.aggregate.argument_types ?? []).join(", ");
-    const qualified = `${aggregateName}(${signature})`;
+    const qualified = aggregateGrantSignature(this.aggregate);
     return `REVOKE GRANT OPTION FOR ${privSql} ${kindPrefix} ${qualified} FROM ${this.grantee}`;
   }
 }

--- a/packages/pg-delta/src/core/objects/aggregate/changes/aggregate.privilege.ts
+++ b/packages/pg-delta/src/core/objects/aggregate/changes/aggregate.privilege.ts
@@ -53,7 +53,14 @@ export class GrantAggregatePrivileges extends AlterAggregateChange {
     const list = this.privileges.map((p) => p.privilege);
     const privSql = formatObjectPrivilegeList("FUNCTION", list, this.version);
     const aggregateName = `${this.aggregate.schema}.${this.aggregate.name}`;
-    const signature = this.aggregate.identityArguments;
+    // GRANT/REVOKE ... ON FUNCTION expects a positional argument-type list
+    // (the `proargtypes` shape), not an aggregate's full identity. The
+    // identity form embeds `ORDER BY` for ordered-set / hypothetical-set
+    // aggregates (`aggkind` of `o`/`h`) and `VARIADIC` for variadic
+    // aggregates — both of which the GRANT parser rejects with a syntax
+    // error. PostgreSQL resolves the aggregate from the argument types
+    // alone, so use `argument_types` here regardless of `aggkind`.
+    const signature = (this.aggregate.argument_types ?? []).join(", ");
     const qualified = `${aggregateName}(${signature})`;
     return `GRANT ${privSql} ${kindPrefix} ${qualified} TO ${this.grantee}${withGrant}`;
   }
@@ -98,7 +105,14 @@ export class RevokeAggregatePrivileges extends AlterAggregateChange {
     const list = this.privileges.map((p) => p.privilege);
     const privSql = formatObjectPrivilegeList("FUNCTION", list, this.version);
     const aggregateName = `${this.aggregate.schema}.${this.aggregate.name}`;
-    const signature = this.aggregate.identityArguments;
+    // GRANT/REVOKE ... ON FUNCTION expects a positional argument-type list
+    // (the `proargtypes` shape), not an aggregate's full identity. The
+    // identity form embeds `ORDER BY` for ordered-set / hypothetical-set
+    // aggregates (`aggkind` of `o`/`h`) and `VARIADIC` for variadic
+    // aggregates — both of which the GRANT parser rejects with a syntax
+    // error. PostgreSQL resolves the aggregate from the argument types
+    // alone, so use `argument_types` here regardless of `aggkind`.
+    const signature = (this.aggregate.argument_types ?? []).join(", ");
     const qualified = `${aggregateName}(${signature})`;
     return `REVOKE ${privSql} ${kindPrefix} ${qualified} FROM ${this.grantee}`;
   }
@@ -140,7 +154,14 @@ export class RevokeGrantOptionAggregatePrivileges extends AlterAggregateChange {
       this.version,
     );
     const aggregateName = `${this.aggregate.schema}.${this.aggregate.name}`;
-    const signature = this.aggregate.identityArguments;
+    // GRANT/REVOKE ... ON FUNCTION expects a positional argument-type list
+    // (the `proargtypes` shape), not an aggregate's full identity. The
+    // identity form embeds `ORDER BY` for ordered-set / hypothetical-set
+    // aggregates (`aggkind` of `o`/`h`) and `VARIADIC` for variadic
+    // aggregates — both of which the GRANT parser rejects with a syntax
+    // error. PostgreSQL resolves the aggregate from the argument types
+    // alone, so use `argument_types` here regardless of `aggkind`.
+    const signature = (this.aggregate.argument_types ?? []).join(", ");
     const qualified = `${aggregateName}(${signature})`;
     return `REVOKE GRANT OPTION FOR ${privSql} ${kindPrefix} ${qualified} FROM ${this.grantee}`;
   }

--- a/packages/pg-delta/tests/integration/aggregate-operations.test.ts
+++ b/packages/pg-delta/tests/integration/aggregate-operations.test.ts
@@ -209,5 +209,63 @@ for (const pgVersion of POSTGRES_VERSIONS) {
         });
       }),
     );
+
+    // Regression for CLI-1471: when an aggregate exists in branch but not
+    // main, pg-delta must emit `CREATE AGGREGATE` alongside any GRANT on
+    // the aggregate. Emitting the GRANT alone produced
+    // `WARNING (01007): no privileges were granted for ...` at apply time
+    // because the GRANT referenced an aggregate the planner had not
+    // enumerated. The roundtripFidelityTest re-applies the generated
+    // migration against main, which fails immediately if pg-delta produces
+    // an orphan GRANT without the matching CREATE AGGREGATE.
+    test(
+      "aggregate create + grant roundtrips without orphan grant",
+      withDbIsolated(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: "CREATE ROLE aggregate_executor;",
+          testSql: dedent`
+          CREATE FUNCTION public.last_sfunc(state anyelement, value anyelement)
+            RETURNS anyelement LANGUAGE sql IMMUTABLE AS $$ SELECT value $$;
+          CREATE AGGREGATE public.last(anyelement)
+          (
+            SFUNC = public.last_sfunc,
+            STYPE = anyelement
+          );
+          GRANT ALL ON FUNCTION public.last(anyelement) TO aggregate_executor;
+        `,
+        });
+      }),
+    );
+
+    // The wild report on CLI-1471 cited a GRANT with signature
+    // `public.last(anyelement, any)`, which is the shape an
+    // ordered-set / hypothetical-set aggregate produces in `proargtypes`
+    // (the procedure path would emit that exact format). Aggregates with
+    // `aggkind = 'o' | 'h'` go through the same enumeration code path as
+    // plain aggregates (`prokind = 'a'`), and the procedure extractor's
+    // `lanname not in ('c', 'internal')` filter excludes them, so the
+    // ACL must be carried by the aggregate path. Lock that in.
+    test(
+      "ordered-set aggregate create + grant roundtrips without orphan grant",
+      withDbIsolated(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: "CREATE ROLE aggregate_executor;",
+          testSql: dedent`
+          CREATE FUNCTION public.os_last_sfunc(state anyelement, value anyelement)
+            RETURNS anyelement LANGUAGE sql IMMUTABLE AS $$ SELECT value $$;
+          CREATE AGGREGATE public.os_last(anyelement ORDER BY anyelement)
+          (
+            SFUNC = public.os_last_sfunc,
+            STYPE = anyelement
+          );
+          GRANT ALL ON FUNCTION public.os_last(anyelement, anyelement) TO aggregate_executor;
+        `,
+        });
+      }),
+    );
   });
 }

--- a/packages/pg-delta/tests/integration/supabase-dsl-e2e.test.ts
+++ b/packages/pg-delta/tests/integration/supabase-dsl-e2e.test.ts
@@ -251,13 +251,11 @@ describe(`supabase integration e2e (pg${pgVersion})`, () => {
 
       const statements = planResult?.plan.statements ?? [];
       // pg-delta serializes server ACL with the `ON SERVER` shorthand
-      // rather than `ON FOREIGN SERVER`; both are equivalent in PG.
-      const serverGrant = statements.find((stmt) =>
-        /\bGRANT\b[^;]*\bON\b[^;]*\bSERVER\b[^;]*\buser_server\b[^;]*\bserver_user\b/.test(
-          stmt,
-        ),
+      // rather than `ON FOREIGN SERVER` (both are equivalent in PG) and
+      // collapses a complete privilege set to `ALL`.
+      expect(statements).toContain(
+        "GRANT ALL ON SERVER user_server TO server_user",
       );
-      expect(serverGrant).toBeDefined();
     }),
     120_000,
   );

--- a/packages/pg-delta/tests/integration/supabase-dsl-e2e.test.ts
+++ b/packages/pg-delta/tests/integration/supabase-dsl-e2e.test.ts
@@ -179,25 +179,21 @@ describe(`supabase integration e2e (pg${pgVersion})`, () => {
   // Regression for CLI-1469. `GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER`
   // requires superuser. On Supabase Cloud `postgres` has the elevated
   // rights; the local Docker image does not, so `supabase db reset`
-  // aborts. FDW ACL is platform-managed, so the supabase integration
-  // must drop those changes from the plan regardless of owner.
+  // aborts with `permission denied for foreign-data wrapper`. The
+  // existing `*/owner` rule drops FDW ACL owned by `supabase_admin`;
+  // this test pins the post-restore case where `pg_dump` rewrites
+  // OWNER TO `postgres` and the owner gate no longer matches.
   test(
-    "suppresses GRANT/REVOKE on FOREIGN DATA WRAPPER and FOREIGN SERVER",
+    "suppresses GRANT/REVOKE on FOREIGN DATA WRAPPER even when owned by postgres",
     withDbSupabaseIsolated(pgVersion, async (db) => {
-      // Install the same FDW in both, then diverge their ACLs so the
-      // diff exercises both GRANT (branch-only) and REVOKE (main-only).
-      // postgres_fdw is on the Supabase image's allow-list and creates
-      // its own FDW + handler/validator in the `extensions` schema.
       await db.main.query(dedent`
-        CREATE EXTENSION IF NOT EXISTS postgres_fdw SCHEMA extensions;
-        GRANT ALL ON FOREIGN DATA WRAPPER postgres_fdw TO postgres;
-        CREATE SERVER main_only_server FOREIGN DATA WRAPPER postgres_fdw;
-        GRANT ALL ON FOREIGN SERVER main_only_server TO postgres;
+        CREATE ROLE fdw_user;
+        CREATE FOREIGN DATA WRAPPER user_fdw;
+        GRANT ALL ON FOREIGN DATA WRAPPER user_fdw TO fdw_user;
       `);
       await db.branch.query(dedent`
-        CREATE EXTENSION IF NOT EXISTS postgres_fdw SCHEMA extensions;
-        CREATE SERVER branch_only_server FOREIGN DATA WRAPPER postgres_fdw;
-        GRANT ALL ON FOREIGN SERVER branch_only_server TO postgres;
+        CREATE ROLE fdw_user;
+        CREATE FOREIGN DATA WRAPPER user_fdw;
       `);
 
       if (!supabaseIntegration.filter || !supabaseIntegration.serialize) {
@@ -210,10 +206,58 @@ describe(`supabase integration e2e (pg${pgVersion})`, () => {
       });
 
       const statements = planResult?.plan.statements ?? [];
-      const aclStatements = statements.filter((stmt) =>
-        /\b(?:GRANT|REVOKE)\b.*\bON\b.*\bFOREIGN\b/.test(stmt),
+      const fdwAclStatements = statements.filter((stmt) =>
+        /\b(?:GRANT|REVOKE)\b[^;]*\bON\b[^;]*\bFOREIGN\s+DATA\s+WRAPPER\b/.test(
+          stmt,
+        ),
       );
-      expect(aclStatements).toStrictEqual([]);
+      expect(fdwAclStatements).toStrictEqual([]);
+    }),
+    120_000,
+  );
+
+  // Companion to the rule above: user-owned FOREIGN SERVER ACL must
+  // still roundtrip. Server GRANT/REVOKE doesn't require superuser, so
+  // a user-created server (e.g. a `dblink`/`postgres_fdw` server
+  // pointing to a peer DB) is genuinely user-declarative state and
+  // should not be swept up by the FDW ACL suppression.
+  test(
+    "preserves GRANT on user-owned FOREIGN SERVER",
+    withDbSupabaseIsolated(pgVersion, async (db) => {
+      await db.main.query(dedent`
+        CREATE EXTENSION IF NOT EXISTS postgres_fdw SCHEMA extensions;
+        CREATE ROLE server_user;
+        SET ROLE postgres;
+        CREATE SERVER user_server FOREIGN DATA WRAPPER postgres_fdw;
+        RESET ROLE;
+      `);
+      await db.branch.query(dedent`
+        CREATE EXTENSION IF NOT EXISTS postgres_fdw SCHEMA extensions;
+        CREATE ROLE server_user;
+        SET ROLE postgres;
+        CREATE SERVER user_server FOREIGN DATA WRAPPER postgres_fdw;
+        GRANT USAGE ON FOREIGN SERVER user_server TO server_user;
+        RESET ROLE;
+      `);
+
+      if (!supabaseIntegration.filter || !supabaseIntegration.serialize) {
+        throw new Error("supabase integration missing filter or serialize");
+      }
+
+      const planResult = await createPlan(db.main, db.branch, {
+        filter: supabaseIntegration.filter,
+        serialize: supabaseIntegration.serialize,
+      });
+
+      const statements = planResult?.plan.statements ?? [];
+      // pg-delta serializes server ACL with the `ON SERVER` shorthand
+      // rather than `ON FOREIGN SERVER`; both are equivalent in PG.
+      const serverGrant = statements.find((stmt) =>
+        /\bGRANT\b[^;]*\bON\b[^;]*\bSERVER\b[^;]*\buser_server\b[^;]*\bserver_user\b/.test(
+          stmt,
+        ),
+      );
+      expect(serverGrant).toBeDefined();
     }),
     120_000,
   );

--- a/packages/pg-delta/tests/integration/supabase-dsl-e2e.test.ts
+++ b/packages/pg-delta/tests/integration/supabase-dsl-e2e.test.ts
@@ -134,4 +134,45 @@ describe(`supabase integration e2e (pg${pgVersion})`, () => {
     }),
     120_000,
   );
+
+  // Regression for CLI-1470: Wasm-based foreign data wrappers (e.g.
+  // `clerk`, `clerk_oauth`) wire their handler/validator through the
+  // `extensions.*` schema. Supabase Cloud provisions them as
+  // `supabase_admin`, but local Docker images do not have an equivalent
+  // pre-step, so `supabase db reset` cannot replay
+  // `CREATE FOREIGN DATA WRAPPER`. The Supabase integration filter must
+  // suppress these FDW changes regardless of who owns the wrapper at
+  // diff time.
+  test(
+    "suppresses CREATE FOREIGN DATA WRAPPER backed by extensions.* handler",
+    withDbSupabaseIsolated(pgVersion, async (db) => {
+      await db.branch.query(dedent`
+        CREATE EXTENSION IF NOT EXISTS postgres_fdw SCHEMA extensions;
+        CREATE FOREIGN DATA WRAPPER wasm_lookalike
+          HANDLER extensions.postgres_fdw_handler
+          VALIDATOR extensions.postgres_fdw_validator;
+      `);
+
+      if (!supabaseIntegration.filter || !supabaseIntegration.serialize) {
+        throw new Error("supabase integration missing filter or serialize");
+      }
+
+      const planResult = await createPlan(db.main, db.branch, {
+        filter: supabaseIntegration.filter,
+        serialize: supabaseIntegration.serialize,
+      });
+
+      // postgres_fdw is allow-listed for CREATE EXTENSION; the only
+      // expected output is the extension itself. No
+      // `CREATE FOREIGN DATA WRAPPER` for the Wasm-lookalike wrapper
+      // should appear, since it depends on a handler that lives in the
+      // managed `extensions` schema.
+      const statements = planResult?.plan.statements ?? [];
+      const fdwStatements = statements.filter((stmt) =>
+        stmt.includes("FOREIGN DATA WRAPPER"),
+      );
+      expect(fdwStatements).toStrictEqual([]);
+    }),
+    120_000,
+  );
 });

--- a/packages/pg-delta/tests/integration/supabase-dsl-e2e.test.ts
+++ b/packages/pg-delta/tests/integration/supabase-dsl-e2e.test.ts
@@ -175,4 +175,46 @@ describe(`supabase integration e2e (pg${pgVersion})`, () => {
     }),
     120_000,
   );
+
+  // Regression for CLI-1469. `GRANT`/`REVOKE ... ON FOREIGN DATA WRAPPER`
+  // requires superuser. On Supabase Cloud `postgres` has the elevated
+  // rights; the local Docker image does not, so `supabase db reset`
+  // aborts. FDW ACL is platform-managed, so the supabase integration
+  // must drop those changes from the plan regardless of owner.
+  test(
+    "suppresses GRANT/REVOKE on FOREIGN DATA WRAPPER and FOREIGN SERVER",
+    withDbSupabaseIsolated(pgVersion, async (db) => {
+      // Install the same FDW in both, then diverge their ACLs so the
+      // diff exercises both GRANT (branch-only) and REVOKE (main-only).
+      // postgres_fdw is on the Supabase image's allow-list and creates
+      // its own FDW + handler/validator in the `extensions` schema.
+      await db.main.query(dedent`
+        CREATE EXTENSION IF NOT EXISTS postgres_fdw SCHEMA extensions;
+        GRANT ALL ON FOREIGN DATA WRAPPER postgres_fdw TO postgres;
+        CREATE SERVER main_only_server FOREIGN DATA WRAPPER postgres_fdw;
+        GRANT ALL ON FOREIGN SERVER main_only_server TO postgres;
+      `);
+      await db.branch.query(dedent`
+        CREATE EXTENSION IF NOT EXISTS postgres_fdw SCHEMA extensions;
+        CREATE SERVER branch_only_server FOREIGN DATA WRAPPER postgres_fdw;
+        GRANT ALL ON FOREIGN SERVER branch_only_server TO postgres;
+      `);
+
+      if (!supabaseIntegration.filter || !supabaseIntegration.serialize) {
+        throw new Error("supabase integration missing filter or serialize");
+      }
+
+      const planResult = await createPlan(db.main, db.branch, {
+        filter: supabaseIntegration.filter,
+        serialize: supabaseIntegration.serialize,
+      });
+
+      const statements = planResult?.plan.statements ?? [];
+      const aclStatements = statements.filter((stmt) =>
+        /\b(?:GRANT|REVOKE)\b.*\bON\b.*\bFOREIGN\b/.test(stmt),
+      );
+      expect(aclStatements).toStrictEqual([]);
+    }),
+    120_000,
+  );
 });


### PR DESCRIPTION
Bundles three related supabase / pg-delta fixes that surfaced from the same `supabase db reset` failure mode on a real onboarding project. Each fix has its own changeset.

## CLI-1469 — suppress GRANT/REVOKE on FOREIGN DATA WRAPPER

`GRANT/REVOKE ... ON FOREIGN DATA WRAPPER` requires superuser. On Supabase Cloud the `postgres` role has the elevated rights to apply these grants; the local Docker image does not, so the previous diff aborted `supabase db reset` with `permission denied for foreign-data wrapper dblink_fdw`. The existing `*/owner ∈ SUPABASE_SYSTEM_ROLES` filter rule covers FDWs owned by `supabase_admin`, but `pg_dump` rewrites `OWNER TO` clauses to whoever the dump runs under, so after a restore the FDW ends up owned by `postgres` and slips past the owner gate.

The supabase integration filter now drops privilege-scope changes on `foreign_data_wrapper` regardless of owner. `FOREIGN SERVER` ACL is intentionally left alone — server GRANT/REVOKE doesn't require superuser, and user-created servers (e.g. a `dblink` server pointing to a peer DB) carry legitimate user ACL that should still roundtrip; the pre-existing `*/owner` rule already drops platform-managed servers.

See the comment thread on CLI-1469 for the underlying structural cause (the dump→restore→diff pipeline destroys ownership information), tracked separately in [CLI-1472](https://linear.app/supabase/issue/CLI-1472).

Closes supabase/pg-toolbelt#CLI-1469

## CLI-1470 — suppress CREATE/DROP/ALTER FOREIGN DATA WRAPPER for Wasm wrappers

The supabase integration filter now skips any FDW whose `HANDLER` or `VALIDATOR` references a function in the `extensions` schema. This covers the Wasm-based wrappers (`clerk`, `clerk_oauth`, etc.) that Supabase Cloud provisions as `supabase_admin` at project creation. `CREATE FOREIGN DATA WRAPPER` requires superuser, and the local Docker image has no equivalent pre-step, so the previous diff output broke `supabase db reset`. Matching on the handler/validator schema rather than the wrapper owner means the rule keeps working after a dump/restore rewrites OWNER away from `supabase_admin`.

Closes supabase/pg-toolbelt#CLI-1470

## CLI-1471 — emit valid GRANT/REVOKE syntax for ordered-set, hypothetical-set, and variadic aggregates

`GrantAggregatePrivileges` / `RevokeAggregatePrivileges` / `RevokeGrantOptionAggregatePrivileges` previously serialized the aggregate signature using `pg_get_function_identity_arguments`, which embeds `ORDER BY` for ordered-set / hypothetical-set aggregates (`aggkind` of `o` / `h`) and `VARIADIC` for variadic aggregates. The PostgreSQL `GRANT ... ON FUNCTION` parser rejects both keywords inside the argument list, so the generated `GRANT`/`REVOKE` failed with a syntax error for any aggregate that wasn't a plain `aggkind = 'n'`. The serializer now uses the `proargtypes`-derived `argument_types` list — the same shape `procedure.privilege` already uses, which is what PostgreSQL expects for `GRANT`/`REVOKE`.

Note: the issue's "smoking gun" simple repro (CREATE AGGREGATE + GRANT) was not reproducible — aggregates are correctly enumerated via `prokind='a'` and procedure path's `lanname not in ('c','internal')` filter excludes them. The real bug uncovered during the audit was the signature shape, which matches the `(anyelement, any)` format the reporter cited. If a separate orphan-vs-syntactic-error scenario exists, please reopen CLI-1471 with the source extension set.

Refs supabase/pg-toolbelt#CLI-1471

## Test plan

- [x] `bun test src/` — 1086 unit tests pass
- [x] `cd packages/pg-delta && PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=17 bun run test tests/integration/aggregate-operations.test.ts tests/integration/foreign-data-wrapper-operations.test.ts tests/integration/supabase-dsl-e2e.test.ts` — 47 integration tests pass
- [x] `bun run format-and-lint --write --unsafe && bun run check-types && bun run knip --fix` clean

https://claude.ai/code/session_01BzWd8twD2kuJFy1jmAPu7Q