### PR TITLE
fix(pg-delta): use coninhcount to detect partition-cloned constraints

### DIFF
--- a/.changeset/pg-delta-partition-check-constraint-inhcount.md
+++ b/.changeset/pg-delta-partition-check-constraint-inhcount.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): skip redundant `ALTER TABLE … ADD CONSTRAINT` for CHECK constraints inherited by partition children
+
+Previously the inheritance signal used `pg_constraint.conparentid <> 0`, but PostgreSQL only populates `conparentid` for PK / UNIQUE / FK constraints on partitions — CHECK constraints on partitions always have `conparentid = 0`. As a result, pg-delta re-emitted every inherited CHECK constraint against each partition, and apply failed with SQLSTATE 42710 ("constraint already exists") because the constraint had already been auto-created on the partition by Postgres when the parent's constraint or the partition itself was created. The extractor now uses `coninhcount > 0`, the canonical inheritance flag, which covers CHECK and all other constraint kinds uniformly.

--- a/packages/pg-delta/src/core/objects/table/table.model.ts
+++ b/packages/pg-delta/src/core/objects/table/table.model.ts
@@ -341,8 +341,13 @@ select
           'no_inherit', c.connoinherit,
           'is_temporal', coalesce((to_jsonb(c)->>'conperiod')::boolean, false),
 
-          -- NEW: propagated-to-partition tagging (PG15+)
-          'is_partition_clone', (c.conparentid <> 0::oid),
+          -- Inherited from a parent (partition or classical inheritance).
+          -- coninhcount > 0 is the canonical signal across every constraint
+          -- kind. We previously used conparentid <> 0, but PostgreSQL only
+          -- populates conparentid for PK / UNIQUE / FK on partitions; CHECK
+          -- constraints on partitions always have conparentid = 0 and were
+          -- being re-emitted on every child, failing apply with 42710.
+          'is_partition_clone', (c.coninhcount > 0),
           'parent_constraint_schema', case when c.conparentid <> 0::oid then pc.connamespace::regnamespace::text end,
           'parent_constraint_name',   case when c.conparentid <> 0::oid then quote_ident(pc.conname) end,
           'parent_table_schema',      case when c.conparentid <> 0::oid then pc_rel.relnamespace::regnamespace::text end,

--- a/packages/pg-delta/tests/integration/partitioned-table-operations.test.ts
+++ b/packages/pg-delta/tests/integration/partitioned-table-operations.test.ts
@@ -265,6 +265,43 @@ for (const pgVersion of POSTGRES_VERSIONS) {
     );
 
     test(
+      "partitioned table with CHECK constraint on parent",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE SCHEMA test_schema;
+          CREATE TABLE test_schema.documents (
+            document_id uuid NOT NULL,
+            file_name text NOT NULL,
+            tenant_id uuid NOT NULL,
+            PRIMARY KEY (document_id, tenant_id)
+          ) PARTITION BY LIST (tenant_id);
+
+          CREATE TABLE test_schema.documents_default
+            PARTITION OF test_schema.documents DEFAULT;
+
+          CREATE TABLE test_schema.documents_paxafe
+            PARTITION OF test_schema.documents
+            FOR VALUES IN ('019b8184-fa49-4a46-b429-4fe4cd9b1a8a');
+        `,
+          testSql: `
+          -- CHECK constraint on parent should propagate to partitions, not be re-emitted
+          -- against each partition (PostgreSQL auto-creates the inherited constraint when
+          -- the partition itself is created or via the parent ADD CONSTRAINT).
+          ALTER TABLE test_schema.documents
+          ADD CONSTRAINT documents_file_name_check
+          CHECK (char_length(file_name) <= 255);
+        `,
+          expectedSqlTerms: [
+            "ALTER TABLE test_schema.documents ADD CONSTRAINT documents_file_name_check CHECK (char_length(file_name) <= 255)",
+          ],
+        });
+      }),
+    );
+
+    test(
       "partitioned table with unique constraint including partition key",
       withDb(pgVersion, async (db) => {
         await roundtripFidelityTest({


### PR DESCRIPTION
## Summary

Fixed pg-delta incorrectly re-emitting inherited CHECK constraints on partition children, causing apply failures with SQLSTATE 42710 ("constraint already exists").

## Changes

- **Updated constraint inheritance detection** in `table.model.ts`: Changed from using `pg_constraint.conparentid <> 0` to `coninhcount > 0` as the canonical inheritance signal.
  - `conparentid` is only populated by PostgreSQL for PK/UNIQUE/FK constraints on partitions
  - CHECK constraints on partitions always have `conparentid = 0`, causing them to be incorrectly flagged as non-inherited
  - `coninhcount > 0` uniformly covers all constraint kinds and correctly identifies inherited constraints

- **Added integration test** in `partitioned-table-operations.test.ts`: New test case verifying that CHECK constraints added to a partitioned table parent are not re-emitted against partition children.

## Implementation Details

The fix addresses a PostgreSQL catalog quirk where CHECK constraints inherit differently than other constraint types. When a CHECK constraint is added to a partitioned table parent, PostgreSQL automatically creates the inherited constraint on each partition, but only populates `conparentid` for PK/UNIQUE/FK constraints. Using `coninhcount > 0` (the count of inheritance relationships) provides the correct signal across all constraint kinds and prevents redundant DDL generation during apply.

A changeset has been included for the patch version bump.

https://claude.ai/code/session_01TXCL316Mz7dMrRaVcG7yrC