### PR TITLE
fix(pg-delta): clear connect timeout

### DIFF
--- a/.changeset/fix-connect-timeout-timer-leak.md
+++ b/.changeset/fix-connect-timeout-timer-leak.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): clear the connect-timeout timer when the race settles
+
+`createManagedPool` raced `pool.connect()` against a `setTimeout` rejection but never cleared the timer. When the connect won (the normal, fast case), the pending `setTimeout` kept the event loop alive, so the process hung for the rest of `PGDELTA_CONNECT_TIMEOUT_MS` even though the plan was already done. Raising the timeout for far-away databases made every local run wait that long too. The race now goes through a `connectWithTimeout` helper that clears the timer in a `.finally`.

--- a/packages/pg-delta/src/core/postgres-config.test.ts
+++ b/packages/pg-delta/src/core/postgres-config.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import {
   connectWithRetry,
+  connectWithTimeout,
   isRetryableConnectError,
   poolConfigFromUrl,
 } from "./postgres-config.ts";
@@ -238,6 +239,43 @@ describe("connectWithRetry", () => {
       }),
     ).rejects.toBe(err);
     expect(attempts).toBe(1);
+  });
+});
+
+describe("connectWithTimeout", () => {
+  test("clears the timer when connect resolves before it fires", async () => {
+    const clearSpy = spyOn(globalThis, "clearTimeout");
+    try {
+      const sentinel = { client: true };
+      const result = await connectWithTimeout(
+        () => Promise.resolve(sentinel),
+        60_000,
+        "source",
+      );
+      expect(result).toBe(sentinel);
+      expect(clearSpy).toHaveBeenCalled();
+    } finally {
+      clearSpy.mockRestore();
+    }
+  });
+
+  test("rejects with a timeout error when connect is too slow", async () => {
+    await expect(
+      connectWithTimeout(() => new Promise<never>(() => {}), 5, "target"),
+    ).rejects.toThrow(/timed out after 5ms/);
+  });
+
+  test("clears the timer even when connect rejects", async () => {
+    const clearSpy = spyOn(globalThis, "clearTimeout");
+    try {
+      const boom = new Error("connect ECONNREFUSED");
+      await expect(
+        connectWithTimeout(() => Promise.reject(boom), 60_000, "target"),
+      ).rejects.toBe(boom);
+      expect(clearSpy).toHaveBeenCalled();
+    } finally {
+      clearSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/pg-delta/src/core/postgres-config.ts
+++ b/packages/pg-delta/src/core/postgres-config.ts
@@ -210,6 +210,37 @@ export async function connectWithRetry<T>(opts: {
 }
 
 /**
+ * Race `connect()` against a `timeoutMs` rejection and clear the timer when
+ * either side wins. If the timer is left running after a fast connect, the
+ * pending `setTimeout` keeps the event loop alive and the process hangs for
+ * the rest of `timeoutMs`.
+ */
+export function connectWithTimeout<T>(
+  connect: () => Promise<T>,
+  timeoutMs: number,
+  label: "source" | "target",
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    connect(),
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new Error(
+              `Connection to ${label} database timed out after ${timeoutMs}ms. ` +
+                `The server may require SSL, use an invalid certificate, or be unreachable.`,
+            ),
+          ),
+        timeoutMs,
+      );
+    }),
+  ]).finally(() => {
+    clearTimeout(timer);
+  });
+}
+
+/**
  * Options for creating a Pool with event listeners.
  */
 interface CreatePoolOptions extends Partial<PoolConfig> {
@@ -412,22 +443,7 @@ export async function createManagedPool(
   const timeoutMs = DEFAULT_CONNECT_TIMEOUT_MS;
   try {
     const client = await connectWithRetry({
-      connect: () =>
-        Promise.race([
-          pool.connect(),
-          new Promise<never>((_, reject) =>
-            setTimeout(
-              () =>
-                reject(
-                  new Error(
-                    `Connection to ${label} database timed out after ${timeoutMs}ms. ` +
-                      `The server may require SSL, use an invalid certificate, or be unreachable.`,
-                  ),
-                ),
-              timeoutMs,
-            ),
-          ),
-        ]),
+      connect: () => connectWithTimeout(() => pool.connect(), timeoutMs, label),
     });
     client.release();
   } catch (err) {


### PR DESCRIPTION
The connect process hungs for the duration of PGDELTA_CONNECT_TIMEOUT_MS.

I noticed this issue when I tried to increase the timeout on the [Realtime admin page](https://github.com/supabase/realtime/blob/main/lib/realtime_web/dashboard/tenant_migrations.ex) we use to fix drifted schemas using pgdelta. Increasing to 60s was causing the page to hang for 60s even tho the connection was taking a couple seconds to finish locally.