### PR TITLE
fix(pg-delta): stop re-validating NOT VALID constraints

### DIFF
--- a/.changeset/feat-validate-constraint-shortcut.md
+++ b/.changeset/feat-validate-constraint-shortcut.md
@@ -1,0 +1,11 @@
+---
+"@supabase/pg-delta": patch
+---
+
+feat(pg-delta): emit `VALIDATE CONSTRAINT` shortcut when only `validated` flips from false to true
+
+When the only difference between main and branch for an existing table constraint is `convalidated` flipping from `false` to `true` (i.e. the user wants to validate a previously `NOT VALID` constraint), pg-delta now emits a single `ALTER TABLE ... VALIDATE CONSTRAINT ...` instead of dropping and re-adding the constraint.
+
+`VALIDATE CONSTRAINT` only takes `SHARE UPDATE EXCLUSIVE` on the table (concurrent reads and writes continue while the row scan runs), whereas drop+add takes `ACCESS EXCLUSIVE` for the duration of the scan. This matches the standard "ADD CONSTRAINT ... NOT VALID; later VALIDATE CONSTRAINT" two-phase safe-migration pattern.
+
+The reverse direction (`validated` → `NOT VALID`) has no equivalent Postgres command, so it still goes through drop+add. Any other field change (expression, key columns, FK target, on_delete, etc.) on top of a `validated` flip also still goes through drop+add — the shortcut applies only when nothing else differs.

--- a/.changeset/fix-not-valid-constraint-convergence.md
+++ b/.changeset/fix-not-valid-constraint-convergence.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): stop re-validating NOT VALID constraints
+
+A NOT VALID constraint was followed by a VALIDATE CONSTRAINT step that flipped it back to validated, so the plan never converged. ADD CONSTRAINT already carries the NOT VALID suffix, so the VALIDATE was redundant. It's now dropped from the create, alter, and table-replacement paths.

--- a/packages/pg-delta/src/core/expand-replace-dependencies.ts
+++ b/packages/pg-delta/src/core/expand-replace-dependencies.ts
@@ -8,10 +8,7 @@ import { CreateMaterializedView } from "./objects/materialized-view/changes/mate
 import { DropMaterializedView } from "./objects/materialized-view/changes/materialized-view.drop.ts";
 import { CreateProcedure } from "./objects/procedure/changes/procedure.create.ts";
 import { DropProcedure } from "./objects/procedure/changes/procedure.drop.ts";
-import {
-  AlterTableAddConstraint,
-  AlterTableValidateConstraint,
-} from "./objects/table/changes/table.alter.ts";
+import { AlterTableAddConstraint } from "./objects/table/changes/table.alter.ts";
 import { CreateCommentOnConstraint } from "./objects/table/changes/table.comment.ts";
 import { CreateTable } from "./objects/table/changes/table.create.ts";
 import { DropTable } from "./objects/table/changes/table.drop.ts";
@@ -455,14 +452,6 @@ function buildReplaceChanges(
                       constraint,
                     }),
                   ];
-                  if (!constraint.validated) {
-                    items.push(
-                      new AlterTableValidateConstraint({
-                        table: resolved.branch,
-                        constraint,
-                      }),
-                    );
-                  }
                   if (
                     constraint.comment !== null &&
                     constraint.comment !== undefined

--- a/packages/pg-delta/src/core/objects/table/table.diff.test.ts
+++ b/packages/pg-delta/src/core/objects/table/table.diff.test.ts
@@ -75,7 +75,7 @@ describe.concurrent("table.diff", () => {
     expect(dropped[0]).toBeInstanceOf(DropTable);
   });
 
-  test("created NOT VALID CHECK emits AddConstraint + ValidateConstraint", () => {
+  test("created NOT VALID CHECK emits AddConstraint only (no Validate)", () => {
     const main = new Table({
       ...base,
       name: "t_nv",
@@ -133,7 +133,7 @@ describe.concurrent("table.diff", () => {
           match_type: null,
           check_expression: "a > 0",
           owner: "o1",
-          definition: "CHECK (a > 0)",
+          definition: "CHECK (a > 0) NOT VALID",
         },
       ],
     });
@@ -142,11 +142,11 @@ describe.concurrent("table.diff", () => {
       { [main.stableId]: main },
       { [branch.stableId]: branch },
     );
-    expect(changes.some((c) => c instanceof AlterTableAddConstraint)).toBe(
-      true,
-    );
+    const add = changes.find((c) => c instanceof AlterTableAddConstraint);
+    expect(add).toBeInstanceOf(AlterTableAddConstraint);
+    expect(add?.serialize()).toContain("NOT VALID");
     expect(changes.some((c) => c instanceof AlterTableValidateConstraint)).toBe(
-      true,
+      false,
     );
   });
 
@@ -363,7 +363,7 @@ describe.concurrent("table.diff", () => {
       true,
     );
     expect(created.some((c) => c instanceof AlterTableValidateConstraint)).toBe(
-      true,
+      false,
     );
 
     const dropped = diffTables(
@@ -503,7 +503,7 @@ describe.concurrent("table.diff", () => {
     );
   });
 
-  test("altered foreign key properties triggers drop+add and validate when not validated", () => {
+  test("altered foreign key to NOT VALID triggers drop+add without validate", () => {
     const tMain = new Table({
       ...base,
       name: "t_fk",
@@ -568,6 +568,7 @@ describe.concurrent("table.diff", () => {
           ...(tMain.constraints[0] as (typeof tMain.constraints)[number]),
           on_delete: "c",
           validated: false,
+          definition: "FOREIGN KEY (a) REFERENCES other(a) NOT VALID",
         },
       ],
     });
@@ -609,7 +610,7 @@ describe.concurrent("table.diff", () => {
       true,
     );
     expect(changes.some((c) => c instanceof AlterTableValidateConstraint)).toBe(
-      true,
+      false,
     );
   });
 

--- a/packages/pg-delta/src/core/objects/table/table.diff.test.ts
+++ b/packages/pg-delta/src/core/objects/table/table.diff.test.ts
@@ -150,6 +150,194 @@ describe.concurrent("table.diff", () => {
     );
   });
 
+  test("NOT VALID -> validated emits only VALIDATE CONSTRAINT (no drop+add)", () => {
+    const sharedConstraint = {
+      name: "ck_nv",
+      constraint_type: "c" as const,
+      deferrable: false,
+      initially_deferred: false,
+      is_local: true,
+      no_inherit: false,
+      is_temporal: false,
+      is_partition_clone: false,
+      parent_constraint_schema: null,
+      parent_constraint_name: null,
+      parent_table_schema: null,
+      parent_table_name: null,
+      key_columns: [],
+      foreign_key_columns: null,
+      foreign_key_table: null,
+      foreign_key_schema: null,
+      foreign_key_table_is_partition: null,
+      foreign_key_parent_schema: null,
+      foreign_key_parent_table: null,
+      foreign_key_effective_schema: null,
+      foreign_key_effective_table: null,
+      on_update: null,
+      on_delete: null,
+      match_type: null,
+      check_expression: "a > 0",
+      owner: "o1",
+      comment: null,
+    };
+
+    const main = new Table({
+      ...base,
+      name: "t_nv",
+      columns: [
+        {
+          name: "a",
+          position: 1,
+          data_type: "integer",
+          data_type_str: "integer",
+          is_custom_type: false,
+          custom_type_type: null,
+          custom_type_category: null,
+          custom_type_schema: null,
+          custom_type_name: null,
+          not_null: false,
+          is_identity: false,
+          is_identity_always: false,
+          is_generated: false,
+          collation: null,
+          default: null,
+          comment: null,
+        },
+      ],
+      constraints: [
+        {
+          ...sharedConstraint,
+          validated: false,
+          definition: "CHECK (a > 0) NOT VALID",
+        },
+      ],
+    });
+    const branch = new Table({
+      // oxlint-disable-next-line typescript/no-misused-spread
+      ...main,
+      constraints: [
+        {
+          ...sharedConstraint,
+          validated: true,
+          definition: "CHECK (a > 0)",
+        },
+      ],
+    });
+
+    const changes = diffTables(
+      testContext,
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+
+    const validate = changes.find(
+      (c) => c instanceof AlterTableValidateConstraint,
+    );
+    expect(validate).toBeInstanceOf(AlterTableValidateConstraint);
+    expect(validate?.serialize()).toMatchInlineSnapshot(
+      `"ALTER TABLE public.t_nv VALIDATE CONSTRAINT ck_nv"`,
+    );
+
+    expect(changes.some((c) => c instanceof AlterTableDropConstraint)).toBe(
+      false,
+    );
+    expect(changes.some((c) => c instanceof AlterTableAddConstraint)).toBe(
+      false,
+    );
+  });
+
+  test("NOT VALID -> validated + other field change still drops+adds (no shortcut)", () => {
+    const sharedConstraint = {
+      name: "ck_nv",
+      constraint_type: "c" as const,
+      deferrable: false,
+      initially_deferred: false,
+      is_local: true,
+      no_inherit: false,
+      is_temporal: false,
+      is_partition_clone: false,
+      parent_constraint_schema: null,
+      parent_constraint_name: null,
+      parent_table_schema: null,
+      parent_table_name: null,
+      key_columns: [],
+      foreign_key_columns: null,
+      foreign_key_table: null,
+      foreign_key_schema: null,
+      foreign_key_table_is_partition: null,
+      foreign_key_parent_schema: null,
+      foreign_key_parent_table: null,
+      foreign_key_effective_schema: null,
+      foreign_key_effective_table: null,
+      on_update: null,
+      on_delete: null,
+      match_type: null,
+      owner: "o1",
+      comment: null,
+    };
+
+    const main = new Table({
+      ...base,
+      name: "t_nv",
+      columns: [
+        {
+          name: "a",
+          position: 1,
+          data_type: "integer",
+          data_type_str: "integer",
+          is_custom_type: false,
+          custom_type_type: null,
+          custom_type_category: null,
+          custom_type_schema: null,
+          custom_type_name: null,
+          not_null: false,
+          is_identity: false,
+          is_identity_always: false,
+          is_generated: false,
+          collation: null,
+          default: null,
+          comment: null,
+        },
+      ],
+      constraints: [
+        {
+          ...sharedConstraint,
+          validated: false,
+          check_expression: "a > 0",
+          definition: "CHECK (a > 0) NOT VALID",
+        },
+      ],
+    });
+    const branch = new Table({
+      // oxlint-disable-next-line typescript/no-misused-spread
+      ...main,
+      constraints: [
+        {
+          ...sharedConstraint,
+          validated: true,
+          check_expression: "a > 1",
+          definition: "CHECK (a > 1)",
+        },
+      ],
+    });
+
+    const changes = diffTables(
+      testContext,
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+
+    expect(changes.some((c) => c instanceof AlterTableDropConstraint)).toBe(
+      true,
+    );
+    expect(changes.some((c) => c instanceof AlterTableAddConstraint)).toBe(
+      true,
+    );
+    expect(changes.some((c) => c instanceof AlterTableValidateConstraint)).toBe(
+      false,
+    );
+  });
+
   test("alter owner", () => {
     const main = new Table(base);
     const branch = new Table({ ...base, owner: "o2" });

--- a/packages/pg-delta/src/core/objects/table/table.diff.ts
+++ b/packages/pg-delta/src/core/objects/table/table.diff.ts
@@ -31,7 +31,6 @@ import {
   AlterTableSetReplicaIdentity,
   AlterTableSetStorageParams,
   AlterTableSetUnlogged,
-  AlterTableValidateConstraint,
 } from "./changes/table.alter.ts";
 import {
   CreateCommentOnColumn,
@@ -86,14 +85,6 @@ function createAlterConstraintChange(mainTable: Table, branchTable: Table) {
           constraint: c,
         }),
       );
-      if (!c.validated) {
-        changes.push(
-          new AlterTableValidateConstraint({
-            table: branchTable,
-            constraint: c,
-          }),
-        );
-      }
       // Add comment for newly created constraint
       if (c.comment !== null) {
         changes.push(
@@ -161,14 +152,6 @@ function createAlterConstraintChange(mainTable: Table, branchTable: Table) {
           constraint: branchC,
         }),
       );
-      if (!branchC.validated) {
-        changes.push(
-          new AlterTableValidateConstraint({
-            table: branchTable,
-            constraint: branchC,
-          }),
-        );
-      }
       // Ensure constraint comment is applied after re-creation
       if (branchC.comment !== null) {
         changes.push(

--- a/packages/pg-delta/src/core/objects/table/table.diff.ts
+++ b/packages/pg-delta/src/core/objects/table/table.diff.ts
@@ -31,6 +31,7 @@ import {
   AlterTableSetReplicaIdentity,
   AlterTableSetStorageParams,
   AlterTableSetUnlogged,
+  AlterTableValidateConstraint,
 } from "./changes/table.alter.ts";
 import {
   CreateCommentOnColumn,
@@ -111,7 +112,7 @@ function createAlterConstraintChange(mainTable: Table, branchTable: Table) {
     }
   }
 
-  // Altered constraints -> drop + add
+  // Altered constraints -> drop + add (or VALIDATE-only shortcut)
   for (const [name, mainC] of mainByName) {
     const branchC = branchByName.get(name);
     if (!branchC) continue;
@@ -121,24 +122,68 @@ function createAlterConstraintChange(mainTable: Table, branchTable: Table) {
       continue;
     }
 
+    // Cheap scalar `===` checks first; only fall through to JSON.stringify
+    // on the array fields when every scalar has already matched.
+    const fieldsEqualExceptValidated =
+      mainC.constraint_type === branchC.constraint_type &&
+      mainC.deferrable === branchC.deferrable &&
+      mainC.initially_deferred === branchC.initially_deferred &&
+      mainC.is_local === branchC.is_local &&
+      mainC.no_inherit === branchC.no_inherit &&
+      mainC.is_temporal === branchC.is_temporal &&
+      mainC.foreign_key_table === branchC.foreign_key_table &&
+      mainC.foreign_key_schema === branchC.foreign_key_schema &&
+      mainC.on_update === branchC.on_update &&
+      mainC.on_delete === branchC.on_delete &&
+      mainC.match_type === branchC.match_type &&
+      mainC.check_expression === branchC.check_expression &&
+      JSON.stringify(mainC.key_columns) ===
+        JSON.stringify(branchC.key_columns) &&
+      JSON.stringify(mainC.foreign_key_columns) ===
+        JSON.stringify(branchC.foreign_key_columns);
+
+    // Safe-migration shortcut: when the only difference is `validated`
+    // flipping from false to true, emit a single `ALTER TABLE ... VALIDATE
+    // CONSTRAINT` instead of drop+add. VALIDATE CONSTRAINT only takes
+    // SHARE UPDATE EXCLUSIVE (concurrent reads/writes proceed), whereas
+    // dropping and re-adding takes ACCESS EXCLUSIVE for the entire scan.
+    // Postgres has no reverse command, so `true -> false` must still go
+    // through drop+add below.
+    if (
+      fieldsEqualExceptValidated &&
+      mainC.validated === false &&
+      branchC.validated === true
+    ) {
+      changes.push(
+        new AlterTableValidateConstraint({
+          table: branchTable,
+          constraint: branchC,
+        }),
+      );
+      // VALIDATE preserves the constraint OID, so its comment is preserved
+      // too. Only emit a comment change if it actually differs.
+      if (mainC.comment !== branchC.comment) {
+        if (branchC.comment === null) {
+          changes.push(
+            new DropCommentOnConstraint({
+              table: mainTable,
+              constraint: mainC,
+            }),
+          );
+        } else {
+          changes.push(
+            new CreateCommentOnConstraint({
+              table: branchTable,
+              constraint: branchC,
+            }),
+          );
+        }
+      }
+      continue;
+    }
+
     const changed =
-      mainC.constraint_type !== branchC.constraint_type ||
-      mainC.deferrable !== branchC.deferrable ||
-      mainC.initially_deferred !== branchC.initially_deferred ||
-      mainC.validated !== branchC.validated ||
-      mainC.is_local !== branchC.is_local ||
-      mainC.no_inherit !== branchC.no_inherit ||
-      mainC.is_temporal !== branchC.is_temporal ||
-      JSON.stringify(mainC.key_columns) !==
-        JSON.stringify(branchC.key_columns) ||
-      JSON.stringify(mainC.foreign_key_columns) !==
-        JSON.stringify(branchC.foreign_key_columns) ||
-      mainC.foreign_key_table !== branchC.foreign_key_table ||
-      mainC.foreign_key_schema !== branchC.foreign_key_schema ||
-      mainC.on_update !== branchC.on_update ||
-      mainC.on_delete !== branchC.on_delete ||
-      mainC.match_type !== branchC.match_type ||
-      mainC.check_expression !== branchC.check_expression;
+      mainC.validated !== branchC.validated || !fieldsEqualExceptValidated;
     if (changed) {
       changes.push(
         new AlterTableDropConstraint({

--- a/packages/pg-delta/tests/integration/not-valid-constraint-convergence.test.ts
+++ b/packages/pg-delta/tests/integration/not-valid-constraint-convergence.test.ts
@@ -21,6 +21,24 @@ const assertNoValidate = (sqlStatements: string[]) => {
   );
 };
 
+const assertValidateShortcut = (sqlStatements: string[]) => {
+  const validateCount = sqlStatements.filter((sql) =>
+    /VALIDATE CONSTRAINT/i.test(sql),
+  ).length;
+  expect(validateCount).toBe(1);
+
+  expect(
+    sqlStatements.some((sql) =>
+      /DROP CONSTRAINT\s+messages_payload_exclusive/i.test(sql),
+    ),
+  ).toBe(false);
+  expect(
+    sqlStatements.some((sql) =>
+      /ADD CONSTRAINT\s+messages_payload_exclusive/i.test(sql),
+    ),
+  ).toBe(false);
+};
+
 for (const pgVersion of POSTGRES_VERSIONS) {
   describe(`NOT VALID constraint convergence (pg${pgVersion})`, () => {
     test(
@@ -70,6 +88,31 @@ for (const pgVersion of POSTGRES_VERSIONS) {
               CHECK (payload IS NULL OR binary_payload IS NULL) NOT VALID;
           `,
           assertSqlStatements: assertNoValidate,
+        });
+      }),
+    );
+
+    test(
+      "NOT VALID -> validated drift converges via VALIDATE CONSTRAINT (no drop+add)",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+            CREATE SCHEMA test_schema;
+            CREATE TABLE test_schema.messages (
+              payload jsonb,
+              binary_payload bytea
+            );
+            ALTER TABLE test_schema.messages
+              ADD CONSTRAINT messages_payload_exclusive
+              CHECK (payload IS NULL OR binary_payload IS NULL) NOT VALID;
+          `,
+          testSql: `
+            ALTER TABLE test_schema.messages
+              VALIDATE CONSTRAINT messages_payload_exclusive;
+          `,
+          assertSqlStatements: assertValidateShortcut,
         });
       }),
     );

--- a/packages/pg-delta/tests/integration/not-valid-constraint-convergence.test.ts
+++ b/packages/pg-delta/tests/integration/not-valid-constraint-convergence.test.ts
@@ -1,0 +1,77 @@
+/**
+ * A NOT VALID table constraint must not get a trailing VALIDATE CONSTRAINT
+ * step. AlterTableAddConstraint serializes pg_get_constraintdef as-is, and that
+ * output already includes the NOT VALID suffix, so the ADD on its own matches
+ * the target. A VALIDATE would mark it convalidated = true, the reverse of what
+ * we want, and the plan would loop forever.
+ *
+ * These cases use the realtime.messages.messages_payload_exclusive constraint
+ * from Supabase Realtime, whose baseline records
+ * CHECK (payload IS NULL OR binary_payload IS NULL) NOT VALID.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { POSTGRES_VERSIONS } from "../constants.ts";
+import { withDb } from "../utils.ts";
+import { roundtripFidelityTest } from "./roundtrip.ts";
+
+const assertNoValidate = (sqlStatements: string[]) => {
+  expect(sqlStatements.some((sql) => /VALIDATE CONSTRAINT/i.test(sql))).toBe(
+    false,
+  );
+};
+
+for (const pgVersion of POSTGRES_VERSIONS) {
+  describe(`NOT VALID constraint convergence (pg${pgVersion})`, () => {
+    test(
+      "created NOT VALID check constraint converges without VALIDATE",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+            CREATE SCHEMA test_schema;
+            CREATE TABLE test_schema.messages (
+              payload jsonb,
+              binary_payload bytea
+            );
+          `,
+          testSql: `
+            ALTER TABLE test_schema.messages
+              ADD CONSTRAINT messages_payload_exclusive
+              CHECK (payload IS NULL OR binary_payload IS NULL) NOT VALID;
+          `,
+          assertSqlStatements: assertNoValidate,
+        });
+      }),
+    );
+
+    test(
+      "validated -> NOT VALID drift converges without re-validating",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+            CREATE SCHEMA test_schema;
+            CREATE TABLE test_schema.messages (
+              payload jsonb,
+              binary_payload bytea
+            );
+            ALTER TABLE test_schema.messages
+              ADD CONSTRAINT messages_payload_exclusive
+              CHECK (payload IS NULL OR binary_payload IS NULL);
+          `,
+          testSql: `
+            ALTER TABLE test_schema.messages
+              DROP CONSTRAINT messages_payload_exclusive;
+            ALTER TABLE test_schema.messages
+              ADD CONSTRAINT messages_payload_exclusive
+              CHECK (payload IS NULL OR binary_payload IS NULL) NOT VALID;
+          `,
+          assertSqlStatements: assertNoValidate,
+        });
+      }),
+    );
+  });
+}


### PR DESCRIPTION
Do not place a `VALIDATE CONSTRAINT` after a `ADD CONSTRAINT foo CHECK (...) NOT VALID` because the first already has the validation info and revalidating cause the planner to never converge to the final state.

In Realtime we [added a NOT VALID constraint](https://github.com/supabase/realtime/blob/e5ac7e233f40a6e761d3696ab12dd157a993a628/lib/realtime/tenants/repo/migrations/20260514120000_add_binary_payload_to_messages.ex#L10-L11) and now running pg-delta plan generates:

```
-- Risk: safe
ALTER TABLE realtime.messages DROP CONSTRAINT messages_payload_exclusive;

ALTER TABLE realtime.messages ADD CONSTRAINT messages_payload_exclusive CHECK (payload IS NULL OR binary_payload IS NULL) NOT VALID;

ALTER TABLE realtime.messages VALIDATE CONSTRAINT messages_payload_exclusive;
```

Which never converges because the last statement revert the expected state.