### PR TITLE
feat(pg-delta): use VALIDATE CONSTRAINT shortcut for NOT VALID -> validated

### DIFF
--- a/.changeset/feat-validate-constraint-shortcut.md
+++ b/.changeset/feat-validate-constraint-shortcut.md
@@ -1,0 +1,11 @@
+---
+"@supabase/pg-delta": patch
+---
+
+feat(pg-delta): emit `VALIDATE CONSTRAINT` shortcut when only `validated` flips from false to true
+
+When the only difference between main and branch for an existing table constraint is `convalidated` flipping from `false` to `true` (i.e. the user wants to validate a previously `NOT VALID` constraint), pg-delta now emits a single `ALTER TABLE ... VALIDATE CONSTRAINT ...` instead of dropping and re-adding the constraint.
+
+`VALIDATE CONSTRAINT` only takes `SHARE UPDATE EXCLUSIVE` on the table (concurrent reads and writes continue while the row scan runs), whereas drop+add takes `ACCESS EXCLUSIVE` for the duration of the scan. This matches the standard "ADD CONSTRAINT ... NOT VALID; later VALIDATE CONSTRAINT" two-phase safe-migration pattern.
+
+The reverse direction (`validated` → `NOT VALID`) has no equivalent Postgres command, so it still goes through drop+add. Any other field change (expression, key columns, FK target, on_delete, etc.) on top of a `validated` flip also still goes through drop+add — the shortcut applies only when nothing else differs.

--- a/packages/pg-delta/src/core/objects/table/table.diff.test.ts
+++ b/packages/pg-delta/src/core/objects/table/table.diff.test.ts
@@ -150,6 +150,194 @@ describe.concurrent("table.diff", () => {
     );
   });
 
+  test("NOT VALID -> validated emits only VALIDATE CONSTRAINT (no drop+add)", () => {
+    const sharedConstraint = {
+      name: "ck_nv",
+      constraint_type: "c" as const,
+      deferrable: false,
+      initially_deferred: false,
+      is_local: true,
+      no_inherit: false,
+      is_temporal: false,
+      is_partition_clone: false,
+      parent_constraint_schema: null,
+      parent_constraint_name: null,
+      parent_table_schema: null,
+      parent_table_name: null,
+      key_columns: [],
+      foreign_key_columns: null,
+      foreign_key_table: null,
+      foreign_key_schema: null,
+      foreign_key_table_is_partition: null,
+      foreign_key_parent_schema: null,
+      foreign_key_parent_table: null,
+      foreign_key_effective_schema: null,
+      foreign_key_effective_table: null,
+      on_update: null,
+      on_delete: null,
+      match_type: null,
+      check_expression: "a > 0",
+      owner: "o1",
+      comment: null,
+    };
+
+    const main = new Table({
+      ...base,
+      name: "t_nv",
+      columns: [
+        {
+          name: "a",
+          position: 1,
+          data_type: "integer",
+          data_type_str: "integer",
+          is_custom_type: false,
+          custom_type_type: null,
+          custom_type_category: null,
+          custom_type_schema: null,
+          custom_type_name: null,
+          not_null: false,
+          is_identity: false,
+          is_identity_always: false,
+          is_generated: false,
+          collation: null,
+          default: null,
+          comment: null,
+        },
+      ],
+      constraints: [
+        {
+          ...sharedConstraint,
+          validated: false,
+          definition: "CHECK (a > 0) NOT VALID",
+        },
+      ],
+    });
+    const branch = new Table({
+      // oxlint-disable-next-line typescript/no-misused-spread
+      ...main,
+      constraints: [
+        {
+          ...sharedConstraint,
+          validated: true,
+          definition: "CHECK (a > 0)",
+        },
+      ],
+    });
+
+    const changes = diffTables(
+      testContext,
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+
+    const validate = changes.find(
+      (c) => c instanceof AlterTableValidateConstraint,
+    );
+    expect(validate).toBeInstanceOf(AlterTableValidateConstraint);
+    expect(validate?.serialize()).toMatchInlineSnapshot(
+      `"ALTER TABLE public.t_nv VALIDATE CONSTRAINT ck_nv"`,
+    );
+
+    expect(changes.some((c) => c instanceof AlterTableDropConstraint)).toBe(
+      false,
+    );
+    expect(changes.some((c) => c instanceof AlterTableAddConstraint)).toBe(
+      false,
+    );
+  });
+
+  test("NOT VALID -> validated + other field change still drops+adds (no shortcut)", () => {
+    const sharedConstraint = {
+      name: "ck_nv",
+      constraint_type: "c" as const,
+      deferrable: false,
+      initially_deferred: false,
+      is_local: true,
+      no_inherit: false,
+      is_temporal: false,
+      is_partition_clone: false,
+      parent_constraint_schema: null,
+      parent_constraint_name: null,
+      parent_table_schema: null,
+      parent_table_name: null,
+      key_columns: [],
+      foreign_key_columns: null,
+      foreign_key_table: null,
+      foreign_key_schema: null,
+      foreign_key_table_is_partition: null,
+      foreign_key_parent_schema: null,
+      foreign_key_parent_table: null,
+      foreign_key_effective_schema: null,
+      foreign_key_effective_table: null,
+      on_update: null,
+      on_delete: null,
+      match_type: null,
+      owner: "o1",
+      comment: null,
+    };
+
+    const main = new Table({
+      ...base,
+      name: "t_nv",
+      columns: [
+        {
+          name: "a",
+          position: 1,
+          data_type: "integer",
+          data_type_str: "integer",
+          is_custom_type: false,
+          custom_type_type: null,
+          custom_type_category: null,
+          custom_type_schema: null,
+          custom_type_name: null,
+          not_null: false,
+          is_identity: false,
+          is_identity_always: false,
+          is_generated: false,
+          collation: null,
+          default: null,
+          comment: null,
+        },
+      ],
+      constraints: [
+        {
+          ...sharedConstraint,
+          validated: false,
+          check_expression: "a > 0",
+          definition: "CHECK (a > 0) NOT VALID",
+        },
+      ],
+    });
+    const branch = new Table({
+      // oxlint-disable-next-line typescript/no-misused-spread
+      ...main,
+      constraints: [
+        {
+          ...sharedConstraint,
+          validated: true,
+          check_expression: "a > 1",
+          definition: "CHECK (a > 1)",
+        },
+      ],
+    });
+
+    const changes = diffTables(
+      testContext,
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+
+    expect(changes.some((c) => c instanceof AlterTableDropConstraint)).toBe(
+      true,
+    );
+    expect(changes.some((c) => c instanceof AlterTableAddConstraint)).toBe(
+      true,
+    );
+    expect(changes.some((c) => c instanceof AlterTableValidateConstraint)).toBe(
+      false,
+    );
+  });
+
   test("alter owner", () => {
     const main = new Table(base);
     const branch = new Table({ ...base, owner: "o2" });

--- a/packages/pg-delta/src/core/objects/table/table.diff.ts
+++ b/packages/pg-delta/src/core/objects/table/table.diff.ts
@@ -31,6 +31,7 @@ import {
   AlterTableSetReplicaIdentity,
   AlterTableSetStorageParams,
   AlterTableSetUnlogged,
+  AlterTableValidateConstraint,
 } from "./changes/table.alter.ts";
 import {
   CreateCommentOnColumn,
@@ -111,7 +112,7 @@ function createAlterConstraintChange(mainTable: Table, branchTable: Table) {
     }
   }
 
-  // Altered constraints -> drop + add
+  // Altered constraints -> drop + add (or VALIDATE-only shortcut)
   for (const [name, mainC] of mainByName) {
     const branchC = branchByName.get(name);
     if (!branchC) continue;
@@ -121,24 +122,66 @@ function createAlterConstraintChange(mainTable: Table, branchTable: Table) {
       continue;
     }
 
+    const fieldsEqualExceptValidated =
+      mainC.constraint_type === branchC.constraint_type &&
+      mainC.deferrable === branchC.deferrable &&
+      mainC.initially_deferred === branchC.initially_deferred &&
+      mainC.is_local === branchC.is_local &&
+      mainC.no_inherit === branchC.no_inherit &&
+      mainC.is_temporal === branchC.is_temporal &&
+      JSON.stringify(mainC.key_columns) ===
+        JSON.stringify(branchC.key_columns) &&
+      JSON.stringify(mainC.foreign_key_columns) ===
+        JSON.stringify(branchC.foreign_key_columns) &&
+      mainC.foreign_key_table === branchC.foreign_key_table &&
+      mainC.foreign_key_schema === branchC.foreign_key_schema &&
+      mainC.on_update === branchC.on_update &&
+      mainC.on_delete === branchC.on_delete &&
+      mainC.match_type === branchC.match_type &&
+      mainC.check_expression === branchC.check_expression;
+
+    // Safe-migration shortcut: when the only difference is `validated`
+    // flipping from false to true, emit a single `ALTER TABLE ... VALIDATE
+    // CONSTRAINT` instead of drop+add. VALIDATE CONSTRAINT only takes
+    // SHARE UPDATE EXCLUSIVE (concurrent reads/writes proceed), whereas
+    // dropping and re-adding takes ACCESS EXCLUSIVE for the entire scan.
+    // Postgres has no reverse command, so `true -> false` must still go
+    // through drop+add below.
+    if (
+      fieldsEqualExceptValidated &&
+      mainC.validated === false &&
+      branchC.validated === true
+    ) {
+      changes.push(
+        new AlterTableValidateConstraint({
+          table: branchTable,
+          constraint: branchC,
+        }),
+      );
+      // VALIDATE preserves the constraint OID, so its comment is preserved
+      // too. Only emit a comment change if it actually differs.
+      if (mainC.comment !== branchC.comment) {
+        if (branchC.comment === null) {
+          changes.push(
+            new DropCommentOnConstraint({
+              table: mainTable,
+              constraint: mainC,
+            }),
+          );
+        } else {
+          changes.push(
+            new CreateCommentOnConstraint({
+              table: branchTable,
+              constraint: branchC,
+            }),
+          );
+        }
+      }
+      continue;
+    }
+
     const changed =
-      mainC.constraint_type !== branchC.constraint_type ||
-      mainC.deferrable !== branchC.deferrable ||
-      mainC.initially_deferred !== branchC.initially_deferred ||
-      mainC.validated !== branchC.validated ||
-      mainC.is_local !== branchC.is_local ||
-      mainC.no_inherit !== branchC.no_inherit ||
-      mainC.is_temporal !== branchC.is_temporal ||
-      JSON.stringify(mainC.key_columns) !==
-        JSON.stringify(branchC.key_columns) ||
-      JSON.stringify(mainC.foreign_key_columns) !==
-        JSON.stringify(branchC.foreign_key_columns) ||
-      mainC.foreign_key_table !== branchC.foreign_key_table ||
-      mainC.foreign_key_schema !== branchC.foreign_key_schema ||
-      mainC.on_update !== branchC.on_update ||
-      mainC.on_delete !== branchC.on_delete ||
-      mainC.match_type !== branchC.match_type ||
-      mainC.check_expression !== branchC.check_expression;
+      mainC.validated !== branchC.validated || !fieldsEqualExceptValidated;
     if (changed) {
       changes.push(
         new AlterTableDropConstraint({

--- a/packages/pg-delta/src/core/objects/table/table.diff.ts
+++ b/packages/pg-delta/src/core/objects/table/table.diff.ts
@@ -122,6 +122,8 @@ function createAlterConstraintChange(mainTable: Table, branchTable: Table) {
       continue;
     }
 
+    // Cheap scalar `===` checks first; only fall through to JSON.stringify
+    // on the array fields when every scalar has already matched.
     const fieldsEqualExceptValidated =
       mainC.constraint_type === branchC.constraint_type &&
       mainC.deferrable === branchC.deferrable &&
@@ -129,16 +131,16 @@ function createAlterConstraintChange(mainTable: Table, branchTable: Table) {
       mainC.is_local === branchC.is_local &&
       mainC.no_inherit === branchC.no_inherit &&
       mainC.is_temporal === branchC.is_temporal &&
-      JSON.stringify(mainC.key_columns) ===
-        JSON.stringify(branchC.key_columns) &&
-      JSON.stringify(mainC.foreign_key_columns) ===
-        JSON.stringify(branchC.foreign_key_columns) &&
       mainC.foreign_key_table === branchC.foreign_key_table &&
       mainC.foreign_key_schema === branchC.foreign_key_schema &&
       mainC.on_update === branchC.on_update &&
       mainC.on_delete === branchC.on_delete &&
       mainC.match_type === branchC.match_type &&
-      mainC.check_expression === branchC.check_expression;
+      mainC.check_expression === branchC.check_expression &&
+      JSON.stringify(mainC.key_columns) ===
+        JSON.stringify(branchC.key_columns) &&
+      JSON.stringify(mainC.foreign_key_columns) ===
+        JSON.stringify(branchC.foreign_key_columns);
 
     // Safe-migration shortcut: when the only difference is `validated`
     // flipping from false to true, emit a single `ALTER TABLE ... VALIDATE

--- a/packages/pg-delta/tests/integration/not-valid-constraint-convergence.test.ts
+++ b/packages/pg-delta/tests/integration/not-valid-constraint-convergence.test.ts
@@ -21,6 +21,24 @@ const assertNoValidate = (sqlStatements: string[]) => {
   );
 };
 
+const assertValidateShortcut = (sqlStatements: string[]) => {
+  const validateCount = sqlStatements.filter((sql) =>
+    /VALIDATE CONSTRAINT/i.test(sql),
+  ).length;
+  expect(validateCount).toBe(1);
+
+  expect(
+    sqlStatements.some((sql) =>
+      /DROP CONSTRAINT\s+messages_payload_exclusive/i.test(sql),
+    ),
+  ).toBe(false);
+  expect(
+    sqlStatements.some((sql) =>
+      /ADD CONSTRAINT\s+messages_payload_exclusive/i.test(sql),
+    ),
+  ).toBe(false);
+};
+
 for (const pgVersion of POSTGRES_VERSIONS) {
   describe(`NOT VALID constraint convergence (pg${pgVersion})`, () => {
     test(
@@ -70,6 +88,31 @@ for (const pgVersion of POSTGRES_VERSIONS) {
               CHECK (payload IS NULL OR binary_payload IS NULL) NOT VALID;
           `,
           assertSqlStatements: assertNoValidate,
+        });
+      }),
+    );
+
+    test(
+      "NOT VALID -> validated drift converges via VALIDATE CONSTRAINT (no drop+add)",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+            CREATE SCHEMA test_schema;
+            CREATE TABLE test_schema.messages (
+              payload jsonb,
+              binary_payload bytea
+            );
+            ALTER TABLE test_schema.messages
+              ADD CONSTRAINT messages_payload_exclusive
+              CHECK (payload IS NULL OR binary_payload IS NULL) NOT VALID;
+          `,
+          testSql: `
+            ALTER TABLE test_schema.messages
+              VALIDATE CONSTRAINT messages_payload_exclusive;
+          `,
+          assertSqlStatements: assertValidateShortcut,
         });
       }),
     );


### PR DESCRIPTION
## Summary

Builds on top of #266. Once the spurious `VALIDATE CONSTRAINT` is removed from the create / alter / table-replacement paths (the fix in #266), the diff still treats every `validated` flip as a full drop+add. That's wasteful — and unsafe — for the most common direction: `NOT VALID → validated`.

This PR adds a narrow shortcut: when the only difference between main and branch for an existing constraint is `convalidated` flipping from `false` to `true`, emit a single `ALTER TABLE ... VALIDATE CONSTRAINT ...` instead of drop+add.

### Why

- **Lock footprint.** `VALIDATE CONSTRAINT` takes only `SHARE UPDATE EXCLUSIVE` on the table — concurrent reads and writes proceed while the row scan runs. Drop+add takes `ACCESS EXCLUSIVE` for the entire scan, blocking everything.
- **Matches Postgres semantics.** This is exactly the canonical "ADD CONSTRAINT ... NOT VALID; later VALIDATE CONSTRAINT" two-phase safe-migration pattern. Going through drop+add silently erases that property for users.
- **Justifies keeping `AlterTableValidateConstraint`.** After #266 the class is production-dead; this PR gives it the one and only emission site it should ever have.

### Asymmetry by design

- `true → false` has no Postgres equivalent ("un-validate" doesn't exist), so that direction still goes through drop+add.
- Any other field change on top of a `validated` flip (expression, key columns, FK target, `on_delete`, etc.) also still goes through drop+add — the shortcut applies only when *nothing else* differs, so no other change can be silently lost.
- Comments are preserved automatically (VALIDATE keeps the constraint OID); if the comment also differs, the appropriate `Create/DropCommentOnConstraint` is emitted alongside the VALIDATE.

### Commits

Per the project's RED → GREEN discipline, the work is split:

1. **`test(pg-delta): failing regression for NOT VALID -> validated shortcut`** — two unit tests pinning the positive shortcut and the negative "other field also changed" guard. Captured RED output is in the commit body.
2. **`feat(pg-delta): emit VALIDATE CONSTRAINT shortcut when only validated flips false->true`** — implementation, integration roundtrip case, and changeset.

## Test plan

- [x] `bun test src/` → 1101 pass, 0 fail
- [x] `bun test tests/integration/not-valid-constraint-convergence.test.ts` on PG 17 (Docker + mirror.gcr.io sandbox setup) — 3 pass, 0 fail
- [x] `bun test tests/integration/{constraint-operations,check-constraint-ordering,fk-constraint-ordering,alter-table-operations}.test.ts` on PG 17 — 45 pass, 0 fail (regression sweep)
- [x] `bun run format-and-lint:fix && bun run check-types && bun run knip --fix` — clean
- [ ] CI: full integration matrix across PG 15 / 17 / 18

## Notes

- Targets `fix/lp-constraint` so it can be merged into #266 before #266 itself lands on `main`. The `AlterTableValidateConstraint` import that #266 removed from `table.diff.ts` is reintroduced here, but only for this narrow shortcut.
- Changeset is a separate file (`feat-validate-constraint-shortcut.md`) so the changelog stays accurate: #266 fixes the convergence bug; this PR introduces the safe-validate shortcut.

https://claude.ai/code/session_01SN9TaNEK9dKwCE38ZqrRCf

---
_Generated by [Claude Code](https://claude.ai/code/session_01SN9TaNEK9dKwCE38ZqrRCf)_