### PR TITLE
fix(ci): skip heavy suite for release PRs in the merge queue

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,6 +1,15 @@
 name: Detect Changes
 description: Detect which packages have changed
 
+inputs:
+  base:
+    description: >-
+      Git base ref/sha to diff against. Leave empty on pull_request events so
+      dorny/paths-filter auto-detects the PR base. On merge_group events pass
+      the merge group base sha so the cumulative queued diff is detected.
+    required: false
+    default: ""
+
 outputs:
   pg-delta:
     description: Whether pg-delta changed
@@ -31,6 +40,7 @@ runs:
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
+        base: ${{ inputs.base }}
         filters: |
           pg-delta:
             - 'packages/pg-delta/**'
@@ -54,6 +64,7 @@ runs:
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: non-release-files
       with:
+        base: ${{ inputs.base }}
         predicate-quantifier: "every"
         filters: |
           non-release-files:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,25 +28,28 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Detect changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed so the merge_group author lookup can read the queued PR's author
+      # (merge_group events carry no pull_request payload).
+      pull-requests: read
     outputs:
       pg-delta: ${{ github.event_name == 'merge_group' && 'true' || steps.changes.outputs.pg-delta }}
       pg-delta-package-json: ${{ github.event_name == 'merge_group' && 'true' || steps.changes.outputs.pg-delta-package-json }}
       pg-topo: ${{ github.event_name == 'merge_group' && 'true' || steps.changes.outputs.pg-topo }}
       pg-topo-package-json: ${{ github.event_name == 'merge_group' && 'true' || steps.changes.outputs.pg-topo-package-json }}
       root: ${{ github.event_name == 'merge_group' && 'true' || steps.changes.outputs.root }}
-      # 'true' only when every changed file is in the release-PR whitelist
-      # (CHANGELOGs, package.json version bumps, .changeset state). Any extra
-      # file flips this back to 'false' so the heavy suite runs and the
-      # unexpected change is caught. We honor this on both the pull_request
-      # event (gated on the changesets release branch) and the merge_group
-      # event (content-only — there is no head_ref in the queue, and a release
-      # batched with a code PR would carry a non-whitelisted file anyway).
+      # 'true' only when the PR is authored by the changesets release bot AND
+      # every changed file is in the release-PR whitelist (CHANGELOGs,
+      # package.json version bumps, .changeset state). Both guards must hold:
+      # the author check stops anyone from bypassing CI with a whitelist-only
+      # PR, and any extra file flips the content check back to 'false' so the
+      # heavy suite runs. Enforced on both the pull_request and merge_group
+      # events (see the release-author step for how the author is resolved in
+      # the queue, which carries no pull_request payload).
       is-release-pr: >-
         ${{
-          (
-            (github.event_name == 'pull_request' && github.head_ref == 'changeset-release/main')
-            || github.event_name == 'merge_group'
-          )
+          steps.release-author.outputs.is-release-author == 'true'
           && steps.changes.outputs.is-release-pr-content == 'true'
         }}
     steps:
@@ -60,6 +63,39 @@ jobs:
           # so diff against the merge group base sha (the cumulative queued
           # diff). Empty on pull_request keeps paths-filter's PR auto-detection.
           base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
+      - name: Resolve release-PR author
+        id: release-author
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          # Externally influenced values are passed via env (never interpolated
+          # into the script body) to avoid shell injection from branch names.
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          # merge_group head ref looks like
+          # refs/heads/gh-readonly-queue/main/pr-271-<base_sha>; the PR number
+          # is the only author signal available in the queue.
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          RELEASE_BOT="supabase-releaser[bot]"
+          AUTHOR=""
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            # Defense in depth: require both the release branch and the bot.
+            if [ "$PR_HEAD_REF" = "changeset-release/main" ]; then
+              AUTHOR="$PR_AUTHOR"
+            fi
+          elif [ "$EVENT_NAME" = "merge_group" ]; then
+            PR_NUMBER=$(printf '%s' "$MERGE_GROUP_HEAD_REF" | sed -n 's#.*/pr-\([0-9]\{1,\}\)-.*#\1#p')
+            if [ -n "$PR_NUMBER" ]; then
+              AUTHOR=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.user.login' 2>/dev/null || echo "")
+            fi
+          fi
+          if [ "$AUTHOR" = "$RELEASE_BOT" ]; then
+            echo "is-release-author=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-release-author=false" >> "$GITHUB_OUTPUT"
+          fi
 
   check-types:
     if: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,30 +34,37 @@ jobs:
       pg-topo: ${{ github.event_name == 'merge_group' && 'true' || steps.changes.outputs.pg-topo }}
       pg-topo-package-json: ${{ github.event_name == 'merge_group' && 'true' || steps.changes.outputs.pg-topo-package-json }}
       root: ${{ github.event_name == 'merge_group' && 'true' || steps.changes.outputs.root }}
-      # 'true' only when this is a PR from changesets' release branch AND every
-      # changed file is in the release-PR whitelist (CHANGELOGs, package.json
-      # version bumps, .changeset state). Any extra file flips this back to
-      # 'false' so the heavy suite runs and the unexpected change is caught.
+      # 'true' only when every changed file is in the release-PR whitelist
+      # (CHANGELOGs, package.json version bumps, .changeset state). Any extra
+      # file flips this back to 'false' so the heavy suite runs and the
+      # unexpected change is caught. We honor this on both the pull_request
+      # event (gated on the changesets release branch) and the merge_group
+      # event (content-only — there is no head_ref in the queue, and a release
+      # batched with a code PR would carry a non-whitelisted file anyway).
       is-release-pr: >-
         ${{
-          github.event_name == 'pull_request'
-          && github.head_ref == 'changeset-release/main'
+          (
+            (github.event_name == 'pull_request' && github.head_ref == 'changeset-release/main')
+            || github.event_name == 'merge_group'
+          )
           && steps.changes.outputs.is-release-pr-content == 'true'
         }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Detect changes
-        if: github.event_name != 'merge_group'
         id: changes
         uses: ./.github/actions/detect-changes
+        with:
+          # On merge_group there is no PR base for paths-filter to auto-detect,
+          # so diff against the merge group base sha (the cumulative queued
+          # diff). Empty on pull_request keeps paths-filter's PR auto-detection.
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
 
   check-types:
     if: >-
-      github.event_name != 'pull_request' || (
-        github.event.pull_request.draft == false &&
-        needs.detect-changes.outputs.is-release-pr != 'true'
-      )
+      needs.detect-changes.outputs.is-release-pr != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     needs: detect-changes
     name: Check types
     runs-on: ubuntu-latest
@@ -75,10 +82,8 @@ jobs:
 
   format-and-lint:
     if: >-
-      github.event_name != 'pull_request' || (
-        github.event.pull_request.draft == false &&
-        needs.detect-changes.outputs.is-release-pr != 'true'
-      )
+      needs.detect-changes.outputs.is-release-pr != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     needs: detect-changes
     name: Format and lint
     runs-on: ubuntu-latest
@@ -92,10 +97,8 @@ jobs:
 
   knip:
     if: >-
-      github.event_name != 'pull_request' || (
-        github.event.pull_request.draft == false &&
-        needs.detect-changes.outputs.is-release-pr != 'true'
-      )
+      needs.detect-changes.outputs.is-release-pr != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     needs: detect-changes
     name: Knip
     runs-on: ubuntu-latest
@@ -113,12 +116,8 @@ jobs:
 
   pg-delta-unit:
     if: >-
-      (
-        github.event_name != 'pull_request' || (
-          github.event.pull_request.draft == false &&
-          needs.detect-changes.outputs.is-release-pr != 'true'
-        )
-      ) &&
+      needs.detect-changes.outputs.is-release-pr != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true')
     needs: detect-changes
     name: "pg-delta: Unit tests"
@@ -146,12 +145,8 @@ jobs:
 
   pg-delta-test-image-hash:
     if: >-
-      (
-        github.event_name != 'pull_request' || (
-          github.event.pull_request.draft == false &&
-          needs.detect-changes.outputs.is-release-pr != 'true'
-        )
-      ) &&
+      needs.detect-changes.outputs.is-release-pr != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true')
     needs: detect-changes
     name: "pg-delta: Compute test image hash"
@@ -265,12 +260,8 @@ jobs:
 
   pg-delta-integration:
     if: >-
-      (
-        github.event_name != 'pull_request' || (
-          github.event.pull_request.draft == false &&
-          github.event.pull_request.user.login != 'supabase-releaser[bot]'
-        )
-      ) &&
+      needs.detect-changes.outputs.is-release-pr != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true') &&
       !cancelled() &&
       (
@@ -487,12 +478,8 @@ jobs:
 
   pg-topo-tests:
     if: >-
-      (
-        github.event_name != 'pull_request' || (
-          github.event.pull_request.draft == false &&
-          needs.detect-changes.outputs.is-release-pr != 'true'
-        )
-      ) &&
+      needs.detect-changes.outputs.is-release-pr != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true')
     needs: detect-changes
     name: "pg-topo: Tests"
@@ -520,12 +507,8 @@ jobs:
 
   deno2-library-e2e:
     if: >-
-      (
-        github.event_name != 'pull_request' || (
-          github.event.pull_request.draft == false &&
-          needs.detect-changes.outputs.is-release-pr != 'true'
-        )
-      ) &&
+      needs.detect-changes.outputs.is-release-pr != 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (
         needs.detect-changes.outputs.pg-delta-package-json == 'true' ||
         needs.detect-changes.outputs.pg-topo-package-json == 'true'
@@ -548,6 +531,7 @@ jobs:
 
   release-preview:
     needs:
+      - detect-changes
       - check-types
       - format-and-lint
       - knip
@@ -556,7 +540,7 @@ jobs:
       - pg-delta-integration-pg17-compat
       - pg-topo-tests
       - deno2-library-e2e
-    if: always() && !cancelled()
+    if: always() && !cancelled() && needs.detect-changes.outputs.is-release-pr != 'true'
     name: Release preview
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Extends the CI workflow to properly handle GitHub's `merge_group` event (used in merge queues) alongside the existing `pull_request` event. This ensures that release PRs are correctly identified and heavy test suites are skipped appropriately in both contexts.

## Key Changes

- **Release PR detection**: Updated `is-release-pr` output logic to recognize release PRs in both `pull_request` events (gated on the `changeset-release/main` branch) and `merge_group` events (content-only validation)
- **detect-changes action**: Added `base` input parameter to support explicit git base ref/sha specification, required for `merge_group` events where `paths-filter` cannot auto-detect the PR base
- **Workflow conditionals**: Simplified and standardized job conditionals across `check-types`, `format-and-lint`, `knip`, `pg-delta-unit`, `pg-delta-test-image-hash`, `pg-delta-integration`, `pg-topo-tests`, and `deno2-library-e2e` jobs to consistently check `is-release-pr != 'true'` first
- **release-preview job**: Added `detect-changes` to dependencies and gated execution on `is-release-pr != 'true'` to prevent unnecessary preview runs
- **Removed conditional skip**: Deleted the `if: github.event_name != 'merge_group'` guard on the `detect-changes` step since the action now handles both event types via the `base` parameter

## Implementation Details

- On `merge_group` events, the workflow passes `github.event.merge_group.base_sha` as the base for change detection, enabling `paths-filter` to diff against the cumulative queued changes
- On `pull_request` events, the `base` parameter is left empty to preserve `paths-filter`'s automatic PR base detection
- The release PR whitelist validation (CHANGELOGs, package.json version bumps, .changeset state) now applies uniformly to both event types, ensuring consistent behavior in merge queues

https://claude.ai/code/session_01MEhFXBBfpL9jhvZP5rGVja