### PR TITLE
fix(pg-delta): recreate policies for replaced function dependencies

### DIFF
--- a/.changeset/kind-times-deny.md
+++ b/.changeset/kind-times-deny.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Recreate RLS policies that depend on replaced functions.

--- a/packages/pg-delta/src/core/expand-replace-dependencies.test.ts
+++ b/packages/pg-delta/src/core/expand-replace-dependencies.test.ts
@@ -6,6 +6,10 @@ import { DefaultPrivilegeState } from "./objects/base.default-privileges.ts";
 import { CreateProcedure } from "./objects/procedure/changes/procedure.create.ts";
 import { DropProcedure } from "./objects/procedure/changes/procedure.drop.ts";
 import { Procedure } from "./objects/procedure/procedure.model.ts";
+import { CreateCommentOnRlsPolicy } from "./objects/rls-policy/changes/rls-policy.comment.ts";
+import { CreateRlsPolicy } from "./objects/rls-policy/changes/rls-policy.create.ts";
+import { DropRlsPolicy } from "./objects/rls-policy/changes/rls-policy.drop.ts";
+import { RlsPolicy } from "./objects/rls-policy/rls-policy.model.ts";
 import { CreateSequence } from "./objects/sequence/changes/sequence.create.ts";
 import { DropSequence } from "./objects/sequence/changes/sequence.drop.ts";
 import { diffSequences } from "./objects/sequence/sequence.diff.ts";
@@ -694,5 +698,126 @@ describe("expandReplaceDependencies", () => {
     });
 
     expect(expanded.changes.some((c) => c instanceof DropView)).toBe(true);
+  });
+
+  test("promotes dependent RLS policy when a procedure's signature changes", async () => {
+    const baseline = await createEmptyCatalog(170000, "postgres");
+    const procedureBase = {
+      schema: "public",
+      name: "check_role",
+      kind: "f" as const,
+      return_type: "boolean",
+      return_type_schema: "pg_catalog",
+      language: "plpgsql",
+      security_definer: false,
+      volatility: "v" as const,
+      parallel_safety: "u" as const,
+      execution_cost: 100,
+      result_rows: 0,
+      is_strict: false,
+      leakproof: false,
+      returns_set: false,
+      argument_names: ["id", "role"],
+      all_argument_types: null,
+      argument_modes: null,
+      source_code: "BEGIN RETURN true; END;",
+      binary_path: null,
+      sql_body: null,
+      config: null,
+      owner: "postgres",
+      comment: null,
+      privileges: [],
+    };
+    const mainProcedure = new Procedure({
+      ...procedureBase,
+      argument_count: 2,
+      argument_default_count: 0,
+      argument_types: ["uuid", "text"],
+      argument_defaults: null,
+      definition:
+        "CREATE FUNCTION public.check_role(id uuid, role text) RETURNS boolean ...",
+    });
+    const branchProcedure = new Procedure({
+      ...procedureBase,
+      argument_count: 3,
+      argument_default_count: 1,
+      argument_names: ["id", "role", "extra"],
+      argument_types: ["uuid", "text", "text"],
+      argument_defaults: "'default'::text",
+      definition:
+        "CREATE FUNCTION public.check_role(id uuid, role text, extra text DEFAULT 'default'::text) RETURNS boolean ...",
+    });
+    const policyBase = {
+      schema: "public",
+      table_name: "profiles",
+      name: "check_role_policy",
+      command: "r" as const,
+      permissive: true,
+      roles: ["public"],
+      using_expression: "public.check_role(id, role)",
+      with_check_expression: null,
+      owner: "postgres",
+      comment: "policy comment",
+      referenced_relations: [],
+    };
+    const mainPolicy = new RlsPolicy({
+      ...policyBase,
+      referenced_procedures: [
+        {
+          schema: "public",
+          name: "check_role",
+          argument_types: ["uuid", "text"],
+        },
+      ],
+    });
+    const branchPolicy = new RlsPolicy({
+      ...policyBase,
+      referenced_procedures: [
+        {
+          schema: "public",
+          name: "check_role",
+          argument_types: ["uuid", "text", "text"],
+        },
+      ],
+    });
+
+    const changes: Change[] = [
+      new DropProcedure({ procedure: mainProcedure }),
+      new CreateProcedure({ procedure: branchProcedure }),
+    ];
+    const mainCatalog = new Catalog({
+      // oxlint-disable-next-line typescript/no-misused-spread
+      ...baseline,
+      procedures: { [mainProcedure.stableId]: mainProcedure },
+      rlsPolicies: { [mainPolicy.stableId]: mainPolicy },
+      depends: [
+        {
+          dependent_stable_id: mainPolicy.stableId,
+          referenced_stable_id: mainProcedure.stableId,
+          deptype: "n",
+        },
+      ],
+    });
+    const branchCatalog = new Catalog({
+      // oxlint-disable-next-line typescript/no-misused-spread
+      ...baseline,
+      procedures: { [branchProcedure.stableId]: branchProcedure },
+      rlsPolicies: { [branchPolicy.stableId]: branchPolicy },
+      depends: [],
+    });
+
+    const expanded = expandReplaceDependencies({
+      changes,
+      mainCatalog,
+      branchCatalog,
+    });
+
+    expect(expanded.changes.some((c) => c instanceof DropRlsPolicy)).toBe(true);
+    expect(expanded.changes.some((c) => c instanceof CreateRlsPolicy)).toBe(
+      true,
+    );
+    expect(
+      expanded.changes.some((c) => c instanceof CreateCommentOnRlsPolicy),
+    ).toBe(true);
   });
 });

--- a/packages/pg-delta/src/core/expand-replace-dependencies.ts
+++ b/packages/pg-delta/src/core/expand-replace-dependencies.ts
@@ -8,6 +8,9 @@ import { CreateMaterializedView } from "./objects/materialized-view/changes/mate
 import { DropMaterializedView } from "./objects/materialized-view/changes/materialized-view.drop.ts";
 import { CreateProcedure } from "./objects/procedure/changes/procedure.create.ts";
 import { DropProcedure } from "./objects/procedure/changes/procedure.drop.ts";
+import { CreateCommentOnRlsPolicy } from "./objects/rls-policy/changes/rls-policy.comment.ts";
+import { CreateRlsPolicy } from "./objects/rls-policy/changes/rls-policy.create.ts";
+import { DropRlsPolicy } from "./objects/rls-policy/changes/rls-policy.drop.ts";
 import { AlterTableAddConstraint } from "./objects/table/changes/table.alter.ts";
 import { CreateCommentOnConstraint } from "./objects/table/changes/table.comment.ts";
 import { CreateTable } from "./objects/table/changes/table.create.ts";
@@ -48,6 +51,11 @@ type ResolvedObject =
       kind: "procedure";
       main: Catalog["procedures"][string];
       branch: Catalog["procedures"][string];
+    }
+  | {
+      kind: "rls_policy";
+      main: Catalog["rlsPolicies"][string];
+      branch: Catalog["rlsPolicies"][string];
     }
   | {
       kind: "enum";
@@ -395,6 +403,12 @@ function resolveObjectForStableId(
     return main && branch ? { kind: "procedure", main, branch } : null;
   }
 
+  if (stableId.startsWith("rlsPolicy:")) {
+    const main = mainCatalog.rlsPolicies[stableId];
+    const branch = branchCatalog.rlsPolicies[stableId];
+    return main && branch ? { kind: "rls_policy", main, branch } : null;
+  }
+
   if (stableId.startsWith("domain:")) {
     const main = mainCatalog.domains[stableId];
     const branch = branchCatalog.domains[stableId];
@@ -517,6 +531,18 @@ function buildReplaceChanges(
         ...(addDrop ? [new DropProcedure({ procedure: resolved.main })] : []),
         ...(addCreate
           ? [new CreateProcedure({ procedure: resolved.branch })]
+          : []),
+      ];
+    case "rls_policy":
+      return [
+        ...(addDrop ? [new DropRlsPolicy({ policy: resolved.main })] : []),
+        ...(addCreate
+          ? [
+              new CreateRlsPolicy({ policy: resolved.branch }),
+              ...(resolved.branch.comment !== null
+                ? [new CreateCommentOnRlsPolicy({ policy: resolved.branch })]
+                : []),
+            ]
           : []),
       ];
     case "enum":

--- a/packages/pg-delta/tests/integration/policy-dependencies.test.ts
+++ b/packages/pg-delta/tests/integration/policy-dependencies.test.ts
@@ -280,5 +280,82 @@ for (const pgVersion of POSTGRES_VERSIONS) {
         });
       }),
     );
+
+    test(
+      "policy depending on a replaced function is dropped and recreated",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE TABLE public.alter_function_sign_policy_dependent_profiles (
+            id uuid PRIMARY KEY,
+            role text
+          );
+
+          ALTER TABLE public.alter_function_sign_policy_dependent_profiles ENABLE ROW LEVEL SECURITY;
+
+          CREATE OR REPLACE FUNCTION public.alter_function_sign_policy_dependent_check_role(
+            _id uuid, _role text
+          ) RETURNS boolean AS $$
+          BEGIN RETURN true; END;
+          $$ LANGUAGE plpgsql;
+
+          CREATE POLICY alter_function_sign_policy_dependent_check_role_policy
+            ON public.alter_function_sign_policy_dependent_profiles
+            FOR SELECT USING (
+              public.alter_function_sign_policy_dependent_check_role(id, role)
+            );
+        `,
+          testSql: `
+          DROP POLICY alter_function_sign_policy_dependent_check_role_policy
+            ON public.alter_function_sign_policy_dependent_profiles;
+
+          DROP FUNCTION public.alter_function_sign_policy_dependent_check_role(uuid, text);
+
+          CREATE OR REPLACE FUNCTION public.alter_function_sign_policy_dependent_check_role(
+            _id uuid, _role text, _extra text DEFAULT 'default'::text
+          ) RETURNS boolean AS $$
+          BEGIN RETURN true; END;
+          $$ LANGUAGE plpgsql;
+
+          CREATE POLICY alter_function_sign_policy_dependent_check_role_policy
+            ON public.alter_function_sign_policy_dependent_profiles
+            FOR SELECT USING (
+              public.alter_function_sign_policy_dependent_check_role(id, role)
+            );
+        `,
+          assertSqlStatements: (statements) => {
+            const dropPolicyIdx = statements.findIndex((s) =>
+              s.includes(
+                "DROP POLICY alter_function_sign_policy_dependent_check_role_policy",
+              ),
+            );
+            const dropFunctionIdx = statements.findIndex((s) =>
+              s.includes(
+                "DROP FUNCTION public.alter_function_sign_policy_dependent_check_role",
+              ),
+            );
+            const createFunctionIdx = statements.findIndex((s) =>
+              s.includes(
+                "CREATE FUNCTION public.alter_function_sign_policy_dependent_check_role",
+              ),
+            );
+            const createPolicyIdx = statements.findIndex((s) =>
+              s.includes(
+                "CREATE POLICY alter_function_sign_policy_dependent_check_role_policy",
+              ),
+            );
+
+            expect(dropPolicyIdx).toBeGreaterThanOrEqual(0);
+            expect(dropFunctionIdx).toBeGreaterThanOrEqual(0);
+            expect(createFunctionIdx).toBeGreaterThanOrEqual(0);
+            expect(createPolicyIdx).toBeGreaterThanOrEqual(0);
+            expect(dropPolicyIdx).toBeLessThan(dropFunctionIdx);
+            expect(createFunctionIdx).toBeLessThan(createPolicyIdx);
+          },
+        });
+      }),
+    );
   });
 }


### PR DESCRIPTION
## Summary

Refs #263.

This PR fixes the first, isolated failure from #263: replacing a function signature that is referenced by an RLS policy. The old plan dropped the function before recreating the dependent policy, so PostgreSQL rejected the migration with `2BP01` because the existing policy still depended on the old function signature.

The catalog already extracts the authoritative dependency from `pg_depend` into `catalog.depends`; the missing piece was that `expandReplaceDependencies` did not know how to promote RLS policies into the replacement cascade. This change adds RLS policy handling there, so a dependent policy is dropped before the old function and recreated after the new function. Unchanged policy comments are recreated too, matching the existing comment-preservation behavior for other replaced objects.

This intentionally does not address the column rewrite / view ordering cases from #263. Those need a separate follow-up so the replace cascade and in-place column alter ordering can be handled without widening this PR.

## RED evidence

Manual reproduction of the function/policy case on current `main` generated only:

- `DROP FUNCTION public.alter_function_sign_policy_dependent_check_role(uuid, text)`
- `CREATE FUNCTION public.alter_function_sign_policy_dependent_check_role(uuid, text, text DEFAULT 'default'::text)`

Applying that plan failed with:

```text
2BP01: cannot drop function public.alter_function_sign_policy_dependent_check_role(uuid,text) because other objects depend on it
detail: policy alter_function_sign_policy_dependent_check_role_policy on table public.alter_function_sign_policy_dependent_profiles depends on function public.alter_function_sign_policy_dependent_check_role(uuid,text)
```

The new integration regression also failed before the fix because no `DROP POLICY` statement was generated (`dropPolicyIdx === -1`).

## Validation

- `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=17 TESTCONTAINERS_RYUK_DISABLED=true ../../node_modules/.bin/bun run test src/core/expand-replace-dependencies.test.ts`
- `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=17 TESTCONTAINERS_RYUK_DISABLED=true ../../node_modules/.bin/bun run test --test-name-pattern "policy depending on a replaced function" tests/integration/policy-dependencies.test.ts`
- `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=17 TESTCONTAINERS_RYUK_DISABLED=true ../../node_modules/.bin/bun run test tests/integration/policy-dependencies.test.ts`
- `./node_modules/.bin/bun run format-and-lint:fix`
- `./node_modules/.bin/bun run check-types`
- `./node_modules/.bin/bun run knip --fix`
- `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=17 TESTCONTAINERS_RYUK_DISABLED=true ./node_modules/.bin/bun run test:pg-delta`
  - Result: 1605 pass, 24 skip, 1 todo, 1 fail. The single failure was `dbdev declarative roundtrip (pg15)` with a PostgreSQL connection timeout.
- Focused rerun of the failed case after explicitly pulling the missing local image `postgres:15.14-alpine`:
  - `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1 PGDELTA_TEST_POSTGRES_VERSIONS=15 TESTCONTAINERS_RYUK_DISABLED=true ../../node_modules/.bin/bun run test --test-name-pattern "exported schema roundtrips to 0 remaining changes with supabase integration" tests/integration/dbdev-roundtrip.test.ts`
  - Result: 1 pass, 0 fail.

`PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1` was used only for local sandbox execution, so security-label-specific tests were skipped locally as documented in `AGENTS.md`.
