### PR TITLE
fix(pg-delta): recreate policies for column rewrite dependencies

### DIFF
--- a/.changeset/warm-tables-learn.md
+++ b/.changeset/warm-tables-learn.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Recreate RLS policies that depend on rewritten columns.

--- a/packages/pg-delta/src/core/expand-replace-dependencies.test.ts
+++ b/packages/pg-delta/src/core/expand-replace-dependencies.test.ts
@@ -20,7 +20,6 @@ import { diffSequences } from "./objects/sequence/sequence.diff.ts";
 import { Sequence } from "./objects/sequence/sequence.model.ts";
 import {
   AlterTableAlterColumnSetDefault,
-  AlterTableAlterColumnType,
   AlterTableChangeOwner,
   AlterTableDropColumn,
   AlterTableDropConstraint,
@@ -49,12 +48,27 @@ function mockChange(overrides: {
     scope: "object",
     creates,
     drops,
+    invalidates: [],
     requires: [],
     table: { schema: "public", name: "t" },
     serialize: () => [],
     get requiresForDrop(): string[] {
       return [];
     },
+  } as unknown as Change;
+}
+
+function mockInvalidatingChange(invalidates: string[]): Change {
+  return {
+    objectType: "table",
+    operation: "alter",
+    scope: "object",
+    creates: [],
+    drops: [],
+    invalidates,
+    requires: [],
+    table: { schema: "public", name: "t" },
+    serialize: () => "",
   } as unknown as Change;
 }
 
@@ -826,7 +840,7 @@ describe("expandReplaceDependencies", () => {
     ).toBe(true);
   });
 
-  test("promotes dependent RLS policy when a referenced column is rewritten", async () => {
+  test("promotes dependent RLS policy when a referenced column is invalidated", async () => {
     const baseline = await createEmptyCatalog(170000, "postgres");
     const columnTemplate = {
       position: 1,
@@ -922,11 +936,9 @@ describe("expandReplaceDependencies", () => {
       withCheckExpression: branchPolicy.with_check_expression,
     });
     const changes: Change[] = [
-      new AlterTableAlterColumnType({
-        table: branchTable,
-        column: branchRoleColumn,
-        previousColumn: mainRoleColumn,
-      }),
+      mockInvalidatingChange([
+        "column:public.solution_categories_with_policy.role",
+      ]),
       alterUsing,
       alterWithCheck,
     ];

--- a/packages/pg-delta/src/core/expand-replace-dependencies.test.ts
+++ b/packages/pg-delta/src/core/expand-replace-dependencies.test.ts
@@ -6,6 +6,10 @@ import { DefaultPrivilegeState } from "./objects/base.default-privileges.ts";
 import { CreateProcedure } from "./objects/procedure/changes/procedure.create.ts";
 import { DropProcedure } from "./objects/procedure/changes/procedure.drop.ts";
 import { Procedure } from "./objects/procedure/procedure.model.ts";
+import {
+  AlterRlsPolicySetUsingExpression,
+  AlterRlsPolicySetWithCheckExpression,
+} from "./objects/rls-policy/changes/rls-policy.alter.ts";
 import { CreateCommentOnRlsPolicy } from "./objects/rls-policy/changes/rls-policy.comment.ts";
 import { CreateRlsPolicy } from "./objects/rls-policy/changes/rls-policy.create.ts";
 import { DropRlsPolicy } from "./objects/rls-policy/changes/rls-policy.drop.ts";
@@ -16,6 +20,7 @@ import { diffSequences } from "./objects/sequence/sequence.diff.ts";
 import { Sequence } from "./objects/sequence/sequence.model.ts";
 import {
   AlterTableAlterColumnSetDefault,
+  AlterTableAlterColumnType,
   AlterTableChangeOwner,
   AlterTableDropColumn,
   AlterTableDropConstraint,
@@ -819,5 +824,145 @@ describe("expandReplaceDependencies", () => {
     expect(
       expanded.changes.some((c) => c instanceof CreateCommentOnRlsPolicy),
     ).toBe(true);
+  });
+
+  test("promotes dependent RLS policy when a referenced column is rewritten", async () => {
+    const baseline = await createEmptyCatalog(170000, "postgres");
+    const columnTemplate = {
+      position: 1,
+      data_type: "text",
+      data_type_str: "text",
+      is_custom_type: false,
+      custom_type_type: null,
+      custom_type_category: null,
+      custom_type_schema: null,
+      custom_type_name: null,
+      not_null: true,
+      is_identity: false,
+      is_identity_always: false,
+      is_generated: false,
+      collation: null,
+      default: null,
+      comment: null,
+    };
+    const tableBase = {
+      schema: "public",
+      name: "solution_categories_with_policy",
+      persistence: "p" as const,
+      row_security: true,
+      force_row_security: false,
+      has_indexes: false,
+      has_rules: false,
+      has_triggers: false,
+      has_subclasses: false,
+      is_populated: true,
+      replica_identity: "d" as const,
+      is_partition: false,
+      options: null,
+      partition_bound: null,
+      partition_by: null,
+      owner: "postgres",
+      comment: null,
+      parent_schema: null,
+      parent_name: null,
+      constraints: [],
+      privileges: [],
+    };
+    const mainRoleColumn = {
+      ...columnTemplate,
+      name: "role",
+    };
+    const branchRoleColumn = {
+      ...columnTemplate,
+      name: "role",
+      data_type: "user_role_enum",
+      data_type_str: "public.user_role_enum",
+      is_custom_type: true,
+      custom_type_type: "e",
+      custom_type_category: "E",
+      custom_type_schema: "public",
+      custom_type_name: "user_role_enum",
+    };
+    const mainTable = new Table({
+      ...tableBase,
+      columns: [mainRoleColumn],
+    });
+    const branchTable = new Table({
+      ...tableBase,
+      columns: [branchRoleColumn],
+    });
+    const policyBase = {
+      schema: "public",
+      table_name: "solution_categories_with_policy",
+      name: "categories_admin_manage",
+      command: "*" as const,
+      permissive: true,
+      roles: ["public"],
+      owner: "postgres",
+      comment: null,
+      referenced_relations: [],
+      referenced_procedures: [],
+    };
+    const mainPolicy = new RlsPolicy({
+      ...policyBase,
+      using_expression: "role = 'admin'",
+      with_check_expression: "role = 'admin'",
+    });
+    const branchPolicy = new RlsPolicy({
+      ...policyBase,
+      using_expression: "role = 'admin'::public.user_role_enum",
+      with_check_expression: "role = 'admin'::public.user_role_enum",
+    });
+    const alterUsing = new AlterRlsPolicySetUsingExpression({
+      policy: mainPolicy,
+      usingExpression: branchPolicy.using_expression,
+    });
+    const alterWithCheck = new AlterRlsPolicySetWithCheckExpression({
+      policy: mainPolicy,
+      withCheckExpression: branchPolicy.with_check_expression,
+    });
+    const changes: Change[] = [
+      new AlterTableAlterColumnType({
+        table: branchTable,
+        column: branchRoleColumn,
+        previousColumn: mainRoleColumn,
+      }),
+      alterUsing,
+      alterWithCheck,
+    ];
+    const mainCatalog = new Catalog({
+      // oxlint-disable-next-line typescript/no-misused-spread
+      ...baseline,
+      tables: { [mainTable.stableId]: mainTable },
+      rlsPolicies: { [mainPolicy.stableId]: mainPolicy },
+      depends: [
+        {
+          dependent_stable_id: mainPolicy.stableId,
+          referenced_stable_id:
+            "column:public.solution_categories_with_policy.role",
+          deptype: "n",
+        },
+      ],
+    });
+    const branchCatalog = new Catalog({
+      // oxlint-disable-next-line typescript/no-misused-spread
+      ...baseline,
+      tables: { [branchTable.stableId]: branchTable },
+      rlsPolicies: { [branchPolicy.stableId]: branchPolicy },
+      depends: [],
+    });
+
+    const expanded = expandReplaceDependencies({
+      changes,
+      mainCatalog,
+      branchCatalog,
+    });
+
+    expect(expanded.changes.some((c) => c instanceof DropRlsPolicy)).toBe(true);
+    expect(expanded.changes.some((c) => c instanceof CreateRlsPolicy)).toBe(
+      true,
+    );
+    expect(expanded.changes).not.toContain(alterUsing);
+    expect(expanded.changes).not.toContain(alterWithCheck);
   });
 });

--- a/packages/pg-delta/src/core/expand-replace-dependencies.ts
+++ b/packages/pg-delta/src/core/expand-replace-dependencies.ts
@@ -13,10 +13,7 @@ import { DropProcedure } from "./objects/procedure/changes/procedure.drop.ts";
 import { CreateCommentOnRlsPolicy } from "./objects/rls-policy/changes/rls-policy.comment.ts";
 import { CreateRlsPolicy } from "./objects/rls-policy/changes/rls-policy.create.ts";
 import { DropRlsPolicy } from "./objects/rls-policy/changes/rls-policy.drop.ts";
-import {
-  AlterTableAddConstraint,
-  AlterTableAlterColumnType,
-} from "./objects/table/changes/table.alter.ts";
+import { AlterTableAddConstraint } from "./objects/table/changes/table.alter.ts";
 import { CreateCommentOnConstraint } from "./objects/table/changes/table.comment.ts";
 import { CreateTable } from "./objects/table/changes/table.create.ts";
 import { DropTable } from "./objects/table/changes/table.drop.ts";
@@ -127,7 +124,7 @@ export function expandReplaceDependencies({
   }
 
   const promotedRlsPolicyIds = new Set<string>();
-  const additions: Change[] = collectColumnRewritePolicyReplacements({
+  const additions: Change[] = collectInvalidatedRlsPolicyReplacements({
     changes,
     mainCatalog,
     branchCatalog,
@@ -304,7 +301,7 @@ export function expandReplaceDependencies({
   };
 }
 
-function collectColumnRewritePolicyReplacements({
+function collectInvalidatedRlsPolicyReplacements({
   changes,
   mainCatalog,
   branchCatalog,
@@ -319,22 +316,22 @@ function collectColumnRewritePolicyReplacements({
   droppedIds: Set<string>;
   promotedRlsPolicyIds: Set<string>;
 }): Change[] {
-  const rewrittenColumnIds = new Set<string>();
+  // In-place rewrites report stable ids through `invalidates`: the referenced
+  // object keeps its identity, but dependents bound to the old definition must
+  // be torn down first. RLS policy expressions are tracked in pg_depend, so use
+  // those catalog edges to promote only policies that depend on an invalidated
+  // id, without coupling this expansion pass to a concrete table-change class.
+  const invalidatedIds = new Set<string>();
   for (const change of changes) {
-    if (!(change instanceof AlterTableAlterColumnType)) continue;
-    rewrittenColumnIds.add(
-      stableId.column(
-        change.table.schema,
-        change.table.name,
-        change.column.name,
-      ),
-    );
+    for (const invalidatedId of change.invalidates) {
+      invalidatedIds.add(invalidatedId);
+    }
   }
-  if (rewrittenColumnIds.size === 0) return [];
+  if (invalidatedIds.size === 0) return [];
 
   const replacements: Change[] = [];
   for (const dep of mainCatalog.depends) {
-    if (!rewrittenColumnIds.has(dep.referenced_stable_id)) continue;
+    if (!invalidatedIds.has(dep.referenced_stable_id)) continue;
 
     const targetId = normalizeDependentId(dep.dependent_stable_id);
     if (!targetId?.startsWith("rlsPolicy:")) continue;

--- a/packages/pg-delta/src/core/expand-replace-dependencies.ts
+++ b/packages/pg-delta/src/core/expand-replace-dependencies.ts
@@ -13,7 +13,10 @@ import { DropProcedure } from "./objects/procedure/changes/procedure.drop.ts";
 import { CreateCommentOnRlsPolicy } from "./objects/rls-policy/changes/rls-policy.comment.ts";
 import { CreateRlsPolicy } from "./objects/rls-policy/changes/rls-policy.create.ts";
 import { DropRlsPolicy } from "./objects/rls-policy/changes/rls-policy.drop.ts";
-import { AlterTableAddConstraint } from "./objects/table/changes/table.alter.ts";
+import {
+  AlterTableAddConstraint,
+  AlterTableAlterColumnType,
+} from "./objects/table/changes/table.alter.ts";
 import { CreateCommentOnConstraint } from "./objects/table/changes/table.comment.ts";
 import { CreateTable } from "./objects/table/changes/table.create.ts";
 import { DropTable } from "./objects/table/changes/table.drop.ts";
@@ -123,6 +126,16 @@ export function expandReplaceDependencies({
     }
   }
 
+  const promotedRlsPolicyIds = new Set<string>();
+  const additions: Change[] = collectColumnRewritePolicyReplacements({
+    changes,
+    mainCatalog,
+    branchCatalog,
+    createdIds,
+    droppedIds,
+    promotedRlsPolicyIds,
+  });
+
   // Procedure stableIds are signature-qualified
   // (`procedure:schema.name(argtypes)`), so a function whose parameter types
   // change has different ids in `createdIds` and `droppedIds` and would not
@@ -166,7 +179,7 @@ export function expandReplaceDependencies({
     }
   }
 
-  if (replaceRoots.size === 0) {
+  if (replaceRoots.size === 0 && additions.length === 0) {
     return {
       changes,
       replacedTableIds: new Set<string>(),
@@ -184,7 +197,6 @@ export function expandReplaceDependencies({
     list.add(dep.dependent_stable_id);
   }
 
-  const additions: Change[] = [];
   const visitedTargets = new Set<string>();
   const visitedRefs = new Set<string>(replaceRoots);
   const queue: string[] = [...replaceRoots];
@@ -257,6 +269,9 @@ export function expandReplaceDependencies({
       if (!replacementChanges) continue;
 
       additions.push(...replacementChanges);
+      if (resolved.kind === "rls_policy") {
+        promotedRlsPolicyIds.add(targetId);
+      }
 
       // If we added a DropTable(T) for an existing table, mark T so any
       // pre-existing object-scope AlterTable*(T) changes get dropped below —
@@ -281,9 +296,88 @@ export function expandReplaceDependencies({
   }
 
   return {
-    changes: [...changes, ...additions],
+    changes: [
+      ...removeSupersededRlsPolicyAlters(changes, promotedRlsPolicyIds),
+      ...additions,
+    ],
     replacedTableIds: tablesReplacedByExpansion,
   };
+}
+
+function collectColumnRewritePolicyReplacements({
+  changes,
+  mainCatalog,
+  branchCatalog,
+  createdIds,
+  droppedIds,
+  promotedRlsPolicyIds,
+}: {
+  changes: Change[];
+  mainCatalog: Catalog;
+  branchCatalog: Catalog;
+  createdIds: Set<string>;
+  droppedIds: Set<string>;
+  promotedRlsPolicyIds: Set<string>;
+}): Change[] {
+  const rewrittenColumnIds = new Set<string>();
+  for (const change of changes) {
+    if (!(change instanceof AlterTableAlterColumnType)) continue;
+    rewrittenColumnIds.add(
+      stableId.column(
+        change.table.schema,
+        change.table.name,
+        change.column.name,
+      ),
+    );
+  }
+  if (rewrittenColumnIds.size === 0) return [];
+
+  const replacements: Change[] = [];
+  for (const dep of mainCatalog.depends) {
+    if (!rewrittenColumnIds.has(dep.referenced_stable_id)) continue;
+
+    const targetId = normalizeDependentId(dep.dependent_stable_id);
+    if (!targetId?.startsWith("rlsPolicy:")) continue;
+    if (promotedRlsPolicyIds.has(targetId)) continue;
+    if (createdIds.has(targetId) && droppedIds.has(targetId)) continue;
+
+    const resolved = resolveObjectForStableId(
+      targetId,
+      mainCatalog,
+      branchCatalog,
+    );
+    if (!resolved || resolved.kind !== "rls_policy") continue;
+
+    const addDrop = !droppedIds.has(targetId);
+    const addCreate = !createdIds.has(targetId);
+    const replacementChanges = buildReplaceChanges(resolved, {
+      addDrop,
+      addCreate,
+    });
+    if (!replacementChanges) continue;
+
+    replacements.push(...replacementChanges);
+    promotedRlsPolicyIds.add(targetId);
+    for (const change of replacementChanges) {
+      for (const id of change.creates ?? []) createdIds.add(id);
+      for (const id of change.drops ?? []) droppedIds.add(id);
+    }
+  }
+
+  return replacements;
+}
+
+function removeSupersededRlsPolicyAlters(
+  changes: Change[],
+  promotedRlsPolicyIds: ReadonlySet<string>,
+): Change[] {
+  if (promotedRlsPolicyIds.size === 0) return changes;
+  return changes.filter((change) => {
+    if (change.objectType !== "rls_policy" || change.operation !== "alter") {
+      return true;
+    }
+    return !promotedRlsPolicyIds.has(change.policy.stableId);
+  });
 }
 
 function isOwnedSequenceColumnDependency(

--- a/packages/pg-delta/tests/integration/policy-dependencies.test.ts
+++ b/packages/pg-delta/tests/integration/policy-dependencies.test.ts
@@ -357,5 +357,50 @@ for (const pgVersion of POSTGRES_VERSIONS) {
         });
       }),
     );
+
+    test(
+      "policy depending on a column type rewrite is dropped and recreated",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE TYPE public.user_role_enum AS ENUM ('admin', 'user', 'guest');
+
+          CREATE TABLE public.solution_categories_with_policy (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            name text NOT NULL,
+            role text NOT NULL
+          );
+
+          ALTER TABLE public.solution_categories_with_policy ENABLE ROW LEVEL SECURITY;
+
+          CREATE POLICY "categories_admin_manage" ON public.solution_categories_with_policy
+            FOR ALL
+            TO public
+            USING (role = 'admin')
+            WITH CHECK (role = 'admin');
+        `,
+          testSql: `
+          DROP POLICY "categories_admin_manage" ON public.solution_categories_with_policy;
+
+          ALTER TABLE public.solution_categories_with_policy
+            ALTER COLUMN role TYPE public.user_role_enum USING role::public.user_role_enum;
+
+          CREATE POLICY "categories_admin_manage" ON public.solution_categories_with_policy
+            FOR ALL TO public
+            USING (role = 'admin'::public.user_role_enum)
+            WITH CHECK (role = 'admin'::public.user_role_enum);
+        `,
+          assertSqlStatements: (statements) => {
+            expect(statements.join(";\n")).toMatchInlineSnapshot(`
+              "DROP POLICY categories_admin_manage ON public.solution_categories_with_policy;
+              ALTER TABLE public.solution_categories_with_policy ALTER COLUMN role TYPE user_role_enum USING role::user_role_enum;
+              CREATE POLICY categories_admin_manage ON public.solution_categories_with_policy USING ((role = 'admin'::user_role_enum)) WITH CHECK ((role = 'admin'::user_role_enum))"
+            `);
+          },
+        });
+      }),
+    );
   });
 }


### PR DESCRIPTION
Refs #263

This is the third incremental fix for issue #263, scoped to Case 1: `ALTER TABLE ... ALTER COLUMN ... TYPE` fails when an existing RLS policy still depends on the rewritten column.

## What changed

For this case, pg-delta was producing the right table rewrite but the wrong policy handling:

1. `diffRlsPolicies` saw the policy expression text change after the column type changed from `text` to an enum, so it emitted `ALTER POLICY ... USING` and `ALTER POLICY ... WITH CHECK`.
2. PostgreSQL does not allow `ALTER COLUMN TYPE` while the old policy definition still depends on that column, so the policy must be fully dropped before the rewrite and recreated after it.
3. The table rewrite is an in-place mutation. After #273, these changes expose the affected stable ids through `BaseChange.invalidates` rather than adding concrete subtype checks to generic expansion/sorting code.

This PR now builds on #273's `invalidates` primitive:

- collect invalidated stable ids from `change.invalidates`;
- use `mainCatalog.depends` to find surviving `rlsPolicy:*` objects whose policy expressions depend on those ids;
- add `DropRlsPolicy` / `CreateRlsPolicy` for those policies;
- remove same-policy `ALTER POLICY` changes that are superseded by the replacement.

The fix stays within existing pg_catalog/pg_depend metadata and does not parse policy SQL or couple `expandReplaceDependencies` to `AlterTableAlterColumnType`.

## RED evidence

- Initial focused unit regression failed because `expandReplaceDependencies` did not add `DropRlsPolicy` for a policy whose `pg_depend` row referenced the rewritten column.
- Initial focused PG17 integration regression failed because generated SQL had `ALTER TABLE ... ALTER COLUMN role TYPE ...` followed by `ALTER POLICY ... USING` / `ALTER POLICY ... WITH CHECK`, with no `DROP POLICY` / `CREATE POLICY` around the column rewrite.
- Manual apply reproduced PostgreSQL `0A000: cannot alter type of a column used in a policy definition`.
- After rebasing onto #273, I added a design regression using a generic invalidating change. RED before the refactor: `expand-replace-dependencies.test.ts` failed with `Expected: true / Received: false` for `DropRlsPolicy` because the helper still checked `AlterTableAlterColumnType` directly.

## Local validation

- Unit-only focused invalidates regression: `1 pass / 0 fail`.
- Full `expand-replace-dependencies.test.ts`: `9 pass / 0 fail`.
- PG17 focused integration for `policy depending on a column type rewrite is dropped and recreated`: `1 pass / 0 fail`.
- Full PG17 `policy-dependencies.test.ts`: `9 pass / 0 fail` (one connection timeout retried by the test runner; final result was green).
- `./node_modules/.bin/bun run format-and-lint:fix`: passed.
- `./node_modules/.bin/bun run check-types`: passed.
- `./node_modules/.bin/bun run knip --fix`: passed; knip only reported existing configuration hints.

Local integration validation used `PGDELTA_SKIP_DUMMY_SECLABEL_BUILD=1` to avoid rebuilding the local dummy security-label image; CI should keep security-label coverage enabled.
