### PR TITLE
fix(pg-delta): normalize function body line endings

### DIFF
--- a/packages/pg-delta/src/core/objects/procedure/procedure.diff.test.ts
+++ b/packages/pg-delta/src/core/objects/procedure/procedure.diff.test.ts
@@ -162,6 +162,63 @@ describe.concurrent("procedure.diff", () => {
     expect((changes[0] as CreateProcedure).orReplace).toBe(true);
   });
 
+  test("does not replace a function when body line endings differ only by CRLF vs LF", () => {
+    const bodyLf = "\nbegin\n  new.updated_at = now();\n  return new;\nend;\n";
+    const bodyCrlf = bodyLf.replace(/\n/g, "\r\n");
+    const definitionLf = `CREATE FUNCTION public.fn1() RETURNS trigger LANGUAGE plpgsql AS $function$${bodyLf}$function$`;
+    const definitionCrlf = definitionLf.replace(/\n/g, "\r\n");
+    const main = new Procedure({
+      ...base,
+      return_type: "trigger",
+      language: "plpgsql",
+      source_code: bodyCrlf,
+      definition: definitionCrlf,
+    });
+    const branch = new Procedure({
+      ...base,
+      return_type: "trigger",
+      language: "plpgsql",
+      source_code: bodyLf,
+      definition: definitionLf,
+    });
+    const changes = diffProcedures(
+      testContext,
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+    expect(changes).toEqual([]);
+  });
+
+  test("body line ending differences do not mask an owner-only function diff", () => {
+    const bodyLf = "\nbegin\n  new.updated_at = now();\n  return new;\nend;\n";
+    const bodyCrlf = bodyLf.replace(/\n/g, "\r\n");
+    const definitionLf = `CREATE FUNCTION public.fn1() RETURNS trigger LANGUAGE plpgsql AS $function$${bodyLf}$function$`;
+    const definitionCrlf = definitionLf.replace(/\n/g, "\r\n");
+    const main = new Procedure({
+      ...base,
+      return_type: "trigger",
+      language: "plpgsql",
+      source_code: bodyCrlf,
+      definition: definitionCrlf,
+      owner: "o1",
+    });
+    const branch = new Procedure({
+      ...base,
+      return_type: "trigger",
+      language: "plpgsql",
+      source_code: bodyLf,
+      definition: definitionLf,
+      owner: "o2",
+    });
+    const changes = diffProcedures(
+      testContext,
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toBeInstanceOf(AlterProcedureChangeOwner);
+  });
+
   test("drop + create when return type changes", () => {
     // `CREATE OR REPLACE FUNCTION` cannot change the return type.
     const main = new Procedure(base);

--- a/packages/pg-delta/src/core/objects/procedure/procedure.diff.ts
+++ b/packages/pg-delta/src/core/objects/procedure/procedure.diff.ts
@@ -32,7 +32,18 @@ import {
   DropSecurityLabelOnProcedure,
 } from "./changes/procedure.security-label.ts";
 import type { ProcedureChange } from "./changes/procedure.types.ts";
-import type { Procedure } from "./procedure.model.ts";
+import {
+  normalizeFunctionLineEndings,
+  type Procedure,
+} from "./procedure.model.ts";
+
+function normalizedFunctionTextEquals(a: unknown, b: unknown): boolean {
+  const normalize = (value: unknown) =>
+    typeof value === "string" || value === null
+      ? normalizeFunctionLineEndings(value)
+      : value;
+  return normalize(a) === normalize(b);
+}
 
 /**
  * Diff two sets of procedures from main and branch catalogs.
@@ -185,6 +196,10 @@ export function diffProcedures(
         mainProcedure,
         branchProcedure,
         OR_REPLACEABLE_NON_ALTERABLE_FIELDS,
+        {
+          source_code: normalizedFunctionTextEquals,
+          sql_body: normalizedFunctionTextEquals,
+        },
       );
 
     if (signatureChanged) {

--- a/packages/pg-delta/src/core/objects/procedure/procedure.model.ts
+++ b/packages/pg-delta/src/core/objects/procedure/procedure.model.ts
@@ -202,6 +202,25 @@ export class Procedure extends BasePgModel {
       security_labels: this.security_labels,
     };
   }
+
+  stableSnapshot() {
+    const data = this.dataFields;
+    return {
+      identity: this.identityFields,
+      data: {
+        ...data,
+        source_code: normalizeFunctionLineEndings(data.source_code),
+        sql_body: normalizeFunctionLineEndings(data.sql_body),
+        definition: normalizeFunctionLineEndings(data.definition),
+      },
+    };
+  }
+}
+
+export function normalizeFunctionLineEndings(
+  value: string | null,
+): string | null {
+  return value?.replace(/\r\n/g, "\n") ?? null;
 }
 
 export async function extractProcedures(


### PR DESCRIPTION
## Summary

- Normalize CRLF/LF differences in `source_code`, `sql_body`, and `definition` when building the procedure stable snapshot.
- Reuse the same line-ending normalization for body-only non-alterable comparisons to avoid false `CREATE OR REPLACE FUNCTION` diffs.
- Add regression coverage showing line-ending-only differences do not produce a diff while owner-only changes are still detected.

Fixes #242.
Replaces #276.

## Tests

- `bun test packages/pg-delta/src/core/objects/procedure/procedure.diff.test.ts`
- `cd packages/pg-delta && bun run check-types`
- `cd packages/pg-delta && bun run format-and-lint`
- `git diff --check origin/main...HEAD`
