### PR TITLE
fix(pg-topo): order alter table expression functions

### DIFF
--- a/.changeset/purple-guests-grow.md
+++ b/.changeset/purple-guests-grow.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-topo": patch
+---
+
+Track function dependencies in ALTER TABLE expression subcommands.

--- a/packages/pg-topo/src/extract/extract-dependencies.ts
+++ b/packages/pg-topo/src/extract/extract-dependencies.ts
@@ -163,7 +163,6 @@ const addConstraintExpressionDependencies = (
   }
   for (const expressionNode of [
     constraint.raw_expr,
-    constraint.cooked_expr,
     constraint.exclusions,
     constraint.where_clause,
   ]) {
@@ -213,11 +212,35 @@ const extractAlterTableDependencies = (
     if (columnDefinition?.raw_default) {
       addExpressionDependencies(columnDefinition.raw_default, requires);
     }
+    const typeRef = typeFromTypeNameNode(columnDefinition?.typeName);
+    if (typeRef) {
+      requires.push(typeRef);
+    }
     const columnConstraints = Array.isArray(columnDefinition?.constraints)
       ? columnDefinition.constraints
       : [];
     for (const constraintItem of columnConstraints) {
       const columnConstraint = asRecord(asRecord(constraintItem)?.Constraint);
+      if (columnConstraint?.contype === "CONSTR_FOREIGN") {
+        addForeignConstraintDependencies(columnConstraint, requires);
+      }
+      if (
+        relationTableRef &&
+        (columnConstraint?.contype === "CONSTR_PRIMARY" ||
+          columnConstraint?.contype === "CONSTR_UNIQUE")
+      ) {
+        const columnName =
+          typeof columnDefinition?.colname === "string"
+            ? columnDefinition.colname
+            : undefined;
+        const providedKey = keyRefForTableColumns(
+          relationTableRef,
+          constraintKeyColumns(columnConstraint, columnName),
+        );
+        if (providedKey) {
+          provides.push(providedKey);
+        }
+      }
       addConstraintExpressionDependencies(columnConstraint, requires);
     }
 

--- a/packages/pg-topo/src/extract/extract-dependencies.ts
+++ b/packages/pg-topo/src/extract/extract-dependencies.ts
@@ -172,6 +172,7 @@ const extractAlterTableDependencies = (
   for (const commandNode of commands) {
     const command = asRecord(asRecord(commandNode)?.AlterTableCmd);
     const constraint = asRecord(asRecord(command?.def)?.Constraint);
+    const columnDefinition = asRecord(asRecord(command?.def)?.ColumnDef);
     if (constraint?.contype === "CONSTR_FOREIGN") {
       addForeignConstraintDependencies(constraint, requires);
     }
@@ -187,6 +188,26 @@ const extractAlterTableDependencies = (
       if (providedKey) {
         provides.push(providedKey);
       }
+    }
+    if (constraint?.raw_expr) {
+      addExpressionDependencies(constraint.raw_expr, requires);
+    }
+
+    if (columnDefinition?.raw_default) {
+      addExpressionDependencies(columnDefinition.raw_default, requires);
+    }
+    const columnConstraints = Array.isArray(columnDefinition?.constraints)
+      ? columnDefinition.constraints
+      : [];
+    for (const constraintItem of columnConstraints) {
+      const columnConstraint = asRecord(asRecord(constraintItem)?.Constraint);
+      if (columnConstraint?.raw_expr) {
+        addExpressionDependencies(columnConstraint.raw_expr, requires);
+      }
+    }
+
+    if (command?.subtype === "AT_ColumnDefault" && command.def) {
+      addExpressionDependencies(command.def, requires);
     }
 
     if (command?.subtype === "AT_ChangeOwner") {

--- a/packages/pg-topo/src/extract/extract-dependencies.ts
+++ b/packages/pg-topo/src/extract/extract-dependencies.ts
@@ -154,6 +154,25 @@ const extractCreateTableAsDependencies = (
   return { provides, requires };
 };
 
+const addConstraintExpressionDependencies = (
+  constraint: Record<string, unknown> | undefined,
+  requires: ObjectRef[],
+): void => {
+  if (!constraint) {
+    return;
+  }
+  for (const expressionNode of [
+    constraint.raw_expr,
+    constraint.cooked_expr,
+    constraint.exclusions,
+    constraint.where_clause,
+  ]) {
+    if (expressionNode) {
+      addExpressionDependencies(expressionNode, requires);
+    }
+  }
+};
+
 const extractAlterTableDependencies = (
   statementNode: Record<string, unknown>,
 ): ExtractDependenciesResult => {
@@ -189,9 +208,7 @@ const extractAlterTableDependencies = (
         provides.push(providedKey);
       }
     }
-    if (constraint?.raw_expr) {
-      addExpressionDependencies(constraint.raw_expr, requires);
-    }
+    addConstraintExpressionDependencies(constraint, requires);
 
     if (columnDefinition?.raw_default) {
       addExpressionDependencies(columnDefinition.raw_default, requires);
@@ -201,9 +218,7 @@ const extractAlterTableDependencies = (
       : [];
     for (const constraintItem of columnConstraints) {
       const columnConstraint = asRecord(asRecord(constraintItem)?.Constraint);
-      if (columnConstraint?.raw_expr) {
-        addExpressionDependencies(columnConstraint.raw_expr, requires);
-      }
+      addConstraintExpressionDependencies(columnConstraint, requires);
     }
 
     if (command?.subtype === "AT_ColumnDefault" && command.def) {

--- a/packages/pg-topo/test/alter-table-expression-dependencies.test.ts
+++ b/packages/pg-topo/test/alter-table-expression-dependencies.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { analyzeAndSort } from "../src/analyze-and-sort";
+import { validateAnalyzeResultWithPostgres } from "./support/postgres-validation";
+
+const seededRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+};
+
+const shuffleDeterministic = <T>(items: T[], seed: number): T[] => {
+  const random = seededRandom(seed);
+  const cloned = [...items];
+  for (let index = cloned.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(random() * (index + 1));
+    const current = cloned[index];
+    cloned[index] = cloned[randomIndex] as T;
+    cloned[randomIndex] = current as T;
+  }
+  return cloned;
+};
+
+const baseStatements = [
+  "create schema app;",
+  "create table app.items(id int primary key, name text, amount numeric);",
+];
+
+const assertAlterTableWaitsForExpressionFunction = async (
+  statements: string[],
+  seed: number,
+  alterSqlNeedle: string,
+): Promise<void> => {
+  const result = await analyzeAndSort(shuffleDeterministic(statements, seed));
+  const validation = await validateAnalyzeResultWithPostgres(result);
+  const executionErrors = validation.diagnostics.filter(
+    (diagnostic) => diagnostic.code === "RUNTIME_EXECUTION_ERROR",
+  );
+  const orderedSql = result.ordered.map((statement) =>
+    statement.sql.toLowerCase(),
+  );
+  const functionIndex = orderedSql.findIndex((sql) =>
+    sql.includes("create function app."),
+  );
+  const alterTableIndex = orderedSql.findIndex((sql) =>
+    sql.includes(alterSqlNeedle),
+  );
+
+  expect(executionErrors).toHaveLength(0);
+  expect(functionIndex).toBeGreaterThanOrEqual(0);
+  expect(alterTableIndex).toBeGreaterThanOrEqual(0);
+  expect(functionIndex).toBeLessThan(alterTableIndex);
+};
+
+describe("ALTER TABLE expression dependencies", () => {
+  test("ADD COLUMN DEFAULT waits for referenced function", async () => {
+    await assertAlterTableWaitsForExpressionFunction(
+      [
+        ...baseStatements,
+        "alter table app.items add column normalized text default app.normalize(name);",
+        "create function app.normalize(input text) returns text language sql immutable as $$ select lower(input) $$;",
+      ],
+      28101,
+      "add column normalized text default",
+    );
+  }, 120000);
+
+  test("ALTER COLUMN SET DEFAULT waits for referenced function", async () => {
+    await assertAlterTableWaitsForExpressionFunction(
+      [
+        ...baseStatements,
+        "alter table app.items add column normalized text;",
+        "alter table app.items alter column normalized set default app.normalize(name);",
+        "create function app.normalize(input text) returns text language sql immutable as $$ select lower(input) $$;",
+      ],
+      28102,
+      "alter column normalized set default",
+    );
+  }, 120000);
+
+  test("ADD CONSTRAINT CHECK waits for referenced function", async () => {
+    await assertAlterTableWaitsForExpressionFunction(
+      [
+        ...baseStatements,
+        "alter table app.items add constraint items_name_check check (app.is_valid_name(name));",
+        "create function app.is_valid_name(input text) returns boolean language sql immutable as $$ select input <> '' $$;",
+      ],
+      28103,
+      "add constraint items_name_check check",
+    );
+  }, 120000);
+
+  test("ADD GENERATED column waits for referenced function", async () => {
+    await assertAlterTableWaitsForExpressionFunction(
+      [
+        ...baseStatements,
+        "alter table app.items add column normalized text generated always as (app.normalize(name)) stored;",
+        "create function app.normalize(input text) returns text language sql immutable as $$ select lower(input) $$;",
+      ],
+      28104,
+      "generated always as",
+    );
+  }, 120000);
+
+  test("ALTER COLUMN TYPE USING waits for referenced function", async () => {
+    await assertAlterTableWaitsForExpressionFunction(
+      [
+        ...baseStatements,
+        "alter table app.items alter column amount type text using app.stringify(amount);",
+        "create function app.stringify(input numeric) returns text language sql immutable as $$ select input::text $$;",
+      ],
+      28105,
+      "alter column amount type text using",
+    );
+  }, 120000);
+});

--- a/packages/pg-topo/test/alter-table-expression-dependencies.test.ts
+++ b/packages/pg-topo/test/alter-table-expression-dependencies.test.ts
@@ -91,6 +91,32 @@ describe("ALTER TABLE expression dependencies", () => {
     );
   }, 120000);
 
+  test("ADD CONSTRAINT EXCLUDE expression waits for referenced function", async () => {
+    await assertAlterTableWaitsForExpressionFunction(
+      [
+        "create extension btree_gist;",
+        ...baseStatements,
+        "alter table app.items add constraint items_bucket_excl exclude using gist ((app.bucket(amount)) with =);",
+        "create function app.bucket(input numeric) returns numeric language sql immutable as $$ select floor(input) $$;",
+      ],
+      28106,
+      "add constraint items_bucket_excl exclude using gist",
+    );
+  }, 120000);
+
+  test("ADD CONSTRAINT EXCLUDE predicate waits for referenced function", async () => {
+    await assertAlterTableWaitsForExpressionFunction(
+      [
+        "create extension btree_gist;",
+        ...baseStatements,
+        "alter table app.items add constraint items_positive_excl exclude using gist (amount with =) where (app.is_positive(amount));",
+        "create function app.is_positive(input numeric) returns boolean language sql immutable as $$ select input > 0 $$;",
+      ],
+      28107,
+      "add constraint items_positive_excl exclude using gist",
+    );
+  }, 120000);
+
   test("ADD GENERATED column waits for referenced function", async () => {
     await assertAlterTableWaitsForExpressionFunction(
       [

--- a/packages/pg-topo/test/alter-table-expression-dependencies.test.ts
+++ b/packages/pg-topo/test/alter-table-expression-dependencies.test.ts
@@ -1,26 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { analyzeAndSort } from "../src/analyze-and-sort";
+import { objectRefKey } from "../src/model/object-ref";
 import { validateAnalyzeResultWithPostgres } from "./support/postgres-validation";
-
-const seededRandom = (seed: number): (() => number) => {
-  let state = seed >>> 0;
-  return () => {
-    state = (state * 1664525 + 1013904223) >>> 0;
-    return state / 4294967296;
-  };
-};
-
-const shuffleDeterministic = <T>(items: T[], seed: number): T[] => {
-  const random = seededRandom(seed);
-  const cloned = [...items];
-  for (let index = cloned.length - 1; index > 0; index -= 1) {
-    const randomIndex = Math.floor(random() * (index + 1));
-    const current = cloned[index];
-    cloned[index] = cloned[randomIndex] as T;
-    cloned[randomIndex] = current as T;
-  }
-  return cloned;
-};
+import { shuffleDeterministic } from "./support/shuffle";
 
 const baseStatements = [
   "create schema app;",
@@ -51,6 +33,22 @@ const assertAlterTableWaitsForExpressionFunction = async (
   expect(functionIndex).toBeGreaterThanOrEqual(0);
   expect(alterTableIndex).toBeGreaterThanOrEqual(0);
   expect(functionIndex).toBeLessThan(alterTableIndex);
+};
+
+const assertAlterTableRequires = async (
+  statements: string[],
+  alterSqlNeedle: string,
+  requiredObjectKeys: string[],
+): Promise<void> => {
+  const result = await analyzeAndSort(statements);
+  const alterStatement = result.ordered.find((statement) =>
+    statement.sql.toLowerCase().includes(alterSqlNeedle),
+  );
+
+  expect(alterStatement).toBeDefined();
+  expect(alterStatement?.requires.map(objectRefKey).sort()).toEqual(
+    expect.arrayContaining(requiredObjectKeys),
+  );
 };
 
 describe("ALTER TABLE expression dependencies", () => {
@@ -140,4 +138,30 @@ describe("ALTER TABLE expression dependencies", () => {
       "alter column amount type text using",
     );
   }, 120000);
+
+  test("ADD COLUMN records the referenced type dependency", async () => {
+    await assertAlterTableRequires(
+      [
+        "create schema app;",
+        "create table app.items(id int primary key);",
+        "alter table app.items add column payload app.payload;",
+        "create type app.payload as enum ('created', 'updated');",
+      ],
+      "add column payload app.payload",
+      ["type:app:payload:"],
+    );
+  });
+
+  test("ADD COLUMN records column-level foreign key dependencies", async () => {
+    await assertAlterTableRequires(
+      [
+        "create schema app;",
+        "create table app.items(id int primary key);",
+        "alter table app.items add column customer_id int references app.customers(id);",
+        "create table app.customers(id int primary key);",
+      ],
+      "add column customer_id int references app.customers",
+      ["table:app:customers:", "constraint:app:customers:(id)"],
+    );
+  });
 });

--- a/packages/pg-topo/test/diverse-schema-fixture.test.ts
+++ b/packages/pg-topo/test/diverse-schema-fixture.test.ts
@@ -11,7 +11,7 @@ import { analyzeAndSortFromRandomizedStatements } from "./support/randomized-run
 
 const fixtureRoot = path.resolve(import.meta.dir, "fixtures/diverse-schema");
 const baselineFingerprint =
-  "062a5cc44e1970ecf8feb43f9640ad127dfbb450aa699432502c915d4a4bb70e";
+  "c0f219f81402141b611af545acd68b18d5615c2e960874a1464814e3d8ff7e3f";
 
 let baselineResult: AnalyzeResult;
 let looseValidationDiagnosticsPromise: Promise<RuntimeDiagnostic[]> | null =

--- a/packages/pg-topo/test/function-body-dependency-chain.test.ts
+++ b/packages/pg-topo/test/function-body-dependency-chain.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { analyzeAndSort } from "../src/analyze-and-sort";
 import { validateAnalyzeResultWithPostgres } from "./support/postgres-validation";
+import { shuffleDeterministic } from "./support/shuffle";
 
 const complexFunctionChainStatements = [
   `
@@ -95,26 +96,6 @@ create table app.organizations (
 create schema app;
 `,
 ];
-
-const seededRandom = (seed: number): (() => number) => {
-  let state = seed >>> 0;
-  return () => {
-    state = (state * 1664525 + 1013904223) >>> 0;
-    return state / 4294967296;
-  };
-};
-
-const shuffleDeterministic = <T>(items: T[], seed: number): T[] => {
-  const random = seededRandom(seed);
-  const cloned = [...items];
-  for (let index = cloned.length - 1; index > 0; index -= 1) {
-    const randomIndex = Math.floor(random() * (index + 1));
-    const current = cloned[index];
-    cloned[index] = cloned[randomIndex] as T;
-    cloned[randomIndex] = current as T;
-  }
-  return cloned;
-};
 
 const defaultParamOverloadStatements = [
   "create schema auth;",

--- a/packages/pg-topo/test/support/fixture-regression.ts
+++ b/packages/pg-topo/test/support/fixture-regression.ts
@@ -2,26 +2,7 @@ import { expect } from "bun:test";
 import { analyzeAndSort } from "../../src/analyze-and-sort";
 import { validateAnalyzeResultWithPostgres } from "./postgres-validation";
 import { collectStatementsFromRoots } from "./randomized-input";
-
-const seededRandom = (seed: number): (() => number) => {
-  let state = seed >>> 0;
-  return () => {
-    state = (state * 1664525 + 1013904223) >>> 0;
-    return state / 4294967296;
-  };
-};
-
-const shuffleDeterministic = <T>(items: T[], seed: number): T[] => {
-  const random = seededRandom(seed);
-  const cloned = [...items];
-  for (let index = cloned.length - 1; index > 0; index -= 1) {
-    const randomIndex = Math.floor(random() * (index + 1));
-    const current = cloned[index];
-    cloned[index] = cloned[randomIndex] as T;
-    cloned[randomIndex] = current as T;
-  }
-  return cloned;
-};
+import { shuffleDeterministic } from "./shuffle";
 
 type RuntimeEnvelopeOptions = {
   fixtureRoot: string;

--- a/packages/pg-topo/test/support/randomized-runtime-analysis.ts
+++ b/packages/pg-topo/test/support/randomized-runtime-analysis.ts
@@ -1,26 +1,7 @@
 import { analyzeAndSort } from "../../src/analyze-and-sort";
 import type { AnalyzeResult } from "../../src/model/types";
 import { collectStatementsFromRoots } from "./randomized-input";
-
-const seededRandom = (seed: number): (() => number) => {
-  let state = seed >>> 0;
-  return () => {
-    state = (state * 1664525 + 1013904223) >>> 0;
-    return state / 4294967296;
-  };
-};
-
-const shuffleDeterministic = <T>(items: T[], seed: number): T[] => {
-  const random = seededRandom(seed);
-  const cloned = [...items];
-  for (let index = cloned.length - 1; index > 0; index -= 1) {
-    const randomIndex = Math.floor(random() * (index + 1));
-    const current = cloned[index];
-    cloned[index] = cloned[randomIndex] as T;
-    cloned[randomIndex] = current as T;
-  }
-  return cloned;
-};
+import { shuffleDeterministic } from "./shuffle";
 
 type RandomizedRuntimeAnalyzeOptions = {
   roots: string[];

--- a/packages/pg-topo/test/support/shuffle.ts
+++ b/packages/pg-topo/test/support/shuffle.ts
@@ -1,0 +1,19 @@
+const seededRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+};
+
+export const shuffleDeterministic = <T>(items: T[], seed: number): T[] => {
+  const random = seededRandom(seed);
+  const cloned = [...items];
+  for (let index = cloned.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(random() * (index + 1));
+    const current = cloned[index];
+    cloned[index] = cloned[randomIndex] as T;
+    cloned[randomIndex] = current as T;
+  }
+  return cloned;
+};


### PR DESCRIPTION
## Summary

Closes #281.

This fixes missing pg-topo dependencies for expression-bearing `ALTER TABLE` subcommands. The extractor now reuses the existing expression dependency traversal for:

- `ADD COLUMN ... DEFAULT app.fn(...)`
- `ADD CONSTRAINT ... CHECK (app.fn(...))`
- `ALTER COLUMN ... SET DEFAULT app.fn(...)`
- `ADD COLUMN ... GENERATED ALWAYS AS (app.fn(...)) STORED`
- `ALTER COLUMN ... TYPE ... USING app.fn(...)`

## RED evidence

Before the extractor change, the focused regression sorted `ALTER TABLE` before the referenced function for the cases above. The generated-column and `USING` variants also surfaced runtime execution errors against PostgreSQL.

## Validation

```bash
bun run --cwd packages/pg-topo scripts/run-tests.ts test/alter-table-expression-dependencies.test.ts
```

Result: `5 pass / 0 fail`.

```bash
bun run test:pg-topo
```

Result: `149 pass / 0 fail`.

```bash
bun run format-and-lint
bun run check-types
bun run knip
```

Result: passed. `knip` only reported existing configuration hints.
