### PR TITLE
fix(pg-topo): resolve COMMENT ON RULE dependencies

### DIFF
--- a/.changeset/rule-comment-dependency.md
+++ b/.changeset/rule-comment-dependency.md
@@ -2,4 +2,4 @@
 "@supabase/pg-topo": patch
 ---
 
-Resolve `COMMENT ON RULE` dependencies so comments are ordered after the rule they target. `objectKindFromObjType` now maps `OBJECT_RULE`, and rule comment refs use the same `relation.objectName` identity as triggers and policies.
+Resolve `COMMENT ON RULE` dependencies so comments are ordered after the rule they target. `objectKindFromObjType` now maps `OBJECT_RULE`, and rule comment refs use the same `relation.objectName` identity as triggers and policies. Plain views now also provide their implicit `_RETURN` rewrite rule, so `COMMENT ON RULE "_RETURN" ON <view>` resolves to the view instead of reporting an unresolved dependency.

--- a/.changeset/rule-comment-dependency.md
+++ b/.changeset/rule-comment-dependency.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-topo": patch
+---
+
+Resolve `COMMENT ON RULE` dependencies so comments are ordered after the rule they target. `objectKindFromObjType` now maps `OBJECT_RULE`, and rule comment refs use the same `relation.objectName` identity as triggers and policies.

--- a/packages/pg-topo/src/extract/extract-dependencies.ts
+++ b/packages/pg-topo/src/extract/extract-dependencies.ts
@@ -332,6 +332,18 @@ const extractViewDependencies = (
   const tableRef = relationFromRangeVarNode(viewRelation, "table");
   if (tableRef) {
     provides.push(createObjectRefFromAst(kind, tableRef.name, tableRef.schema));
+    // A plain view implicitly owns an "_RETURN" ON SELECT rewrite rule. Expose it
+    // so `COMMENT ON RULE "_RETURN" ON <view>` resolves to the view instead of
+    // reporting an unresolved dependency. Materialized views have no such rule.
+    if (kind === "view") {
+      provides.push(
+        createObjectRefFromAst(
+          "rule",
+          `${tableRef.name}._RETURN`,
+          tableRef.schema ?? DEFAULT_SCHEMA,
+        ),
+      );
+    }
     if (tableRef.schema) {
       requires.push(createObjectRefFromAst("schema", tableRef.schema));
     }

--- a/packages/pg-topo/src/extract/shared-refs.ts
+++ b/packages/pg-topo/src/extract/shared-refs.ts
@@ -61,6 +61,8 @@ export const objectKindFromObjType = (
       return "publication";
     case "OBJECT_ROLE":
       return "role";
+    case "OBJECT_RULE":
+      return "rule";
     case "OBJECT_SCHEMA":
       return "schema";
     case "OBJECT_SEQUENCE":
@@ -89,9 +91,13 @@ export const objectFromNameParts = (
     return null;
   }
 
-  // COMMENT ON TRIGGER/POLICY name parts are [schema?, relation, objectName]. Identity
-  // for trigger/policy is relation.objectName so dependency resolution matches CREATE.
-  if ((kind === "trigger" || kind === "policy") && parts.length >= 2) {
+  // COMMENT ON TRIGGER/POLICY/RULE name parts are [schema?, relation, objectName].
+  // Identity for these relation-scoped objects is relation.objectName so dependency
+  // resolution matches CREATE.
+  if (
+    (kind === "trigger" || kind === "policy" || kind === "rule") &&
+    parts.length >= 2
+  ) {
     const objectName = parts.at(-1);
     const relationName = parts.at(-2);
     if (!objectName || !relationName) {

--- a/packages/pg-topo/test/shared-refs.test.ts
+++ b/packages/pg-topo/test/shared-refs.test.ts
@@ -51,6 +51,7 @@ describe("objectKindFromObjType", () => {
     expect(objectKindFromObjType("OBJECT_TABLE")).toBe("table");
     expect(objectKindFromObjType("OBJECT_FUNCTION")).toBe("function");
     expect(objectKindFromObjType("OBJECT_VIEW")).toBe("view");
+    expect(objectKindFromObjType("OBJECT_RULE")).toBe("rule");
   });
 });
 
@@ -59,9 +60,10 @@ describe("objectFromNameParts", () => {
     expect(objectFromNameParts("table", [])).toBeNull();
   });
 
-  test("returns null for trigger/policy when objectName or relationName missing", () => {
+  test("returns null for trigger/policy/rule when objectName or relationName missing", () => {
     expect(objectFromNameParts("trigger", ["rel", ""])).toBeNull();
     expect(objectFromNameParts("policy", ["", "policy_name"])).toBeNull();
+    expect(objectFromNameParts("rule", ["rel", ""])).toBeNull();
   });
 
   test("returns ref for single-part schema-like kinds", () => {
@@ -104,6 +106,18 @@ describe("objectFromNameParts", () => {
       name: "users.users_select_policy",
     });
 
+    // COMMENT ON RULE name on relation → same shape
+    const ruleRef = objectFromNameParts(
+      "rule",
+      ["app", "users", "users_insert_guard"],
+      "public",
+    );
+    expect(ruleRef).toEqual({
+      kind: "rule",
+      schema: "app",
+      name: "users.users_insert_guard",
+    });
+
     // Two parts only (no schema) → schema from fallback
     const triggerNoSchema = objectFromNameParts(
       "trigger",
@@ -113,6 +127,17 @@ describe("objectFromNameParts", () => {
     expect(triggerNoSchema).toEqual({
       kind: "trigger",
       name: "my_table.my_trigger",
+      schema: "public",
+    });
+
+    const ruleNoSchema = objectFromNameParts(
+      "rule",
+      ["my_table", "my_rule"],
+      "public",
+    );
+    expect(ruleNoSchema).toEqual({
+      kind: "rule",
+      name: "my_table.my_rule",
       schema: "public",
     });
   });

--- a/packages/pg-topo/test/statement-coverage.test.ts
+++ b/packages/pg-topo/test/statement-coverage.test.ts
@@ -244,6 +244,75 @@ describe("statement coverage", () => {
     expect(validation.diagnostics).toHaveLength(0);
   }, 120000);
 
+  test("orders create rule without expressions after its relation", async () => {
+    const result = await analyzeAndSort([
+      "create rule users_delete_guard as on delete to app.users do instead nothing;",
+      "create table app.users(id int primary key);",
+      "create schema app;",
+    ]);
+    const unknownDiagnostics = result.diagnostics.filter(
+      (diagnostic) => diagnostic.code === "UNKNOWN_STATEMENT_CLASS",
+    );
+    const unresolvedDiagnostics = result.diagnostics.filter(
+      (diagnostic) => diagnostic.code === "UNRESOLVED_DEPENDENCY",
+    );
+    const orderedSql = result.ordered.map((statement) =>
+      statement.sql.toLowerCase(),
+    );
+    const tableIndex = orderedSql.findIndex((sql) =>
+      sql.includes("create table app.users"),
+    );
+    const ruleIndex = orderedSql.findIndex((sql) =>
+      sql.includes("create rule users_delete_guard"),
+    );
+    const validation = await validateAnalyzeResultWithPostgres(result);
+
+    expect(unknownDiagnostics).toHaveLength(0);
+    expect(unresolvedDiagnostics).toHaveLength(0);
+    expect(tableIndex).toBeGreaterThan(-1);
+    expect(ruleIndex).toBeGreaterThan(tableIndex);
+    expect(validation.diagnostics).toHaveLength(0);
+  }, 120000);
+
+  test("orders comment on rule after the rule it targets", async () => {
+    const result = await analyzeAndSort([
+      "comment on rule users_delete_guard on app.users is 'guard rule';",
+      "create rule users_delete_guard as on delete to app.users do instead nothing;",
+      "create table app.users(id int primary key);",
+      "create schema app;",
+    ]);
+    const unknownDiagnostics = result.diagnostics.filter(
+      (diagnostic) => diagnostic.code === "UNKNOWN_STATEMENT_CLASS",
+    );
+    const unresolvedDiagnostics = result.diagnostics.filter(
+      (diagnostic) => diagnostic.code === "UNRESOLVED_DEPENDENCY",
+    );
+    const orderedSql = result.ordered.map((statement) =>
+      statement.sql.toLowerCase(),
+    );
+    const ruleIndex = orderedSql.findIndex((sql) =>
+      sql.includes("create rule users_delete_guard"),
+    );
+    const commentIndex = orderedSql.findIndex((sql) =>
+      sql.includes("comment on rule users_delete_guard"),
+    );
+    const commentStatement = result.ordered.find((statement) =>
+      statement.sql.toLowerCase().includes("comment on rule"),
+    );
+    const validation = await validateAnalyzeResultWithPostgres(result);
+
+    expect(unknownDiagnostics).toHaveLength(0);
+    expect(unresolvedDiagnostics).toHaveLength(0);
+    expect(commentStatement?.requires).toContainEqual({
+      kind: "rule",
+      schema: "app",
+      name: "users.users_delete_guard",
+    });
+    expect(ruleIndex).toBeGreaterThan(-1);
+    expect(commentIndex).toBeGreaterThan(ruleIndex);
+    expect(validation.diagnostics).toHaveLength(0);
+  }, 120000);
+
   test("resolves correct overload when multiple overloads have defaults", async () => {
     const result = await analyzeAndSort([
       "create schema auth;",

--- a/packages/pg-topo/test/statement-coverage.test.ts
+++ b/packages/pg-topo/test/statement-coverage.test.ts
@@ -313,6 +313,44 @@ describe("statement coverage", () => {
     expect(validation.diagnostics).toHaveLength(0);
   }, 120000);
 
+  test("orders comment on a view's implicit _RETURN rule after the view", async () => {
+    const result = await analyzeAndSort([
+      "comment on rule \"_RETURN\" on app.v is 'implicit view rule';",
+      "create view app.v as select 1 as one;",
+      "create schema app;",
+    ]);
+    const unknownDiagnostics = result.diagnostics.filter(
+      (diagnostic) => diagnostic.code === "UNKNOWN_STATEMENT_CLASS",
+    );
+    const unresolvedDiagnostics = result.diagnostics.filter(
+      (diagnostic) => diagnostic.code === "UNRESOLVED_DEPENDENCY",
+    );
+    const orderedSql = result.ordered.map((statement) =>
+      statement.sql.toLowerCase(),
+    );
+    const viewIndex = orderedSql.findIndex((sql) =>
+      sql.includes("create view app.v"),
+    );
+    const commentIndex = orderedSql.findIndex((sql) =>
+      sql.includes('comment on rule "_return"'),
+    );
+    const viewStatement = result.ordered.find((statement) =>
+      statement.sql.toLowerCase().includes("create view app.v"),
+    );
+    const validation = await validateAnalyzeResultWithPostgres(result);
+
+    expect(unknownDiagnostics).toHaveLength(0);
+    expect(unresolvedDiagnostics).toHaveLength(0);
+    expect(viewStatement?.provides).toContainEqual({
+      kind: "rule",
+      schema: "app",
+      name: "v._RETURN",
+    });
+    expect(viewIndex).toBeGreaterThan(-1);
+    expect(commentIndex).toBeGreaterThan(viewIndex);
+    expect(validation.diagnostics).toHaveLength(0);
+  }, 120000);
+
   test("resolves correct overload when multiple overloads have defaults", async () => {
     const result = await analyzeAndSort([
       "create schema auth;",


### PR DESCRIPTION
## Summary

Follow-up to #290 (which added pg-topo `CREATE RULE` support). Addresses the `COMMENT ON RULE` linking gap raised in review of that PR.

After #290, rules became first-class providers (`rule:schema:relation.rulename`), but `COMMENT ON RULE r ON tbl` still extracted no dependency edge: `objectKindFromObjType` had no `OBJECT_RULE` case, and the `relation.objectName` identity special-case in `objectFromNameParts` covered only triggers/policies. A rule comment could therefore sort before the rule exists.

This PR:

- maps `OBJECT_RULE` → `rule` in `objectKindFromObjType`
- extends the `relation.objectName` identity special-case in `objectFromNameParts` to include `rule`, so `COMMENT ON RULE` resolves to the `CREATE RULE` provider

It also adds the `CREATE RULE`-without-expressions ordering test from #284's original test plan, which #290's implementation satisfied but never covered directly.

`COMMENT ON RULE name ON [schema.]relation` parses to `objtype: OBJECT_RULE` with `object.List.items = [schema?, relation, rulename]` — the same shape as triggers/policies — so the existing comment extractor needed only the kind mapping and identity fix.

## RED evidence

Before the fix:

```
objectFromNameParts > returns null for trigger/policy/rule when objectName or relationName missing
  expect(received).toBeNull()
  Received: { kind: "rule", name: "", schema: "rel" }

objectFromNameParts > trigger and policy use relation.objectName identity ...
  - "name": "users.users_insert_guard", "schema": "app"
  + "name": "users_insert_guard",       "schema": "users"

statement coverage > orders comment on rule after the rule it targets
  expect(commentStatement?.requires).toContainEqual({
    kind: "rule", schema: "app", name: "users.users_delete_guard" })
  Received: []
```

## Validation

```bash
bun run test            # 157 pass / 0 fail (pg-topo, runtime-validated against postgres:17-alpine)
bun run check-types     # passed
bun run format-and-lint:fix
bun run knip            # passed (only pre-existing config hints)
```

Refs #284.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Di293yQ2thRKhyohxpw1S4)_