### PR TITLE
fix(pg-delta): break publication FK-chain drop cycles with partial publication membership

### DIFF
--- a/.changeset/loud-spies-search.md
+++ b/.changeset/loud-spies-search.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix unhandled `CycleError` when dropping a FK chain of tables alongside a referenced unique constraint while only some of the involved tables are publication members. The publication FK-chain cycle breaker required every dropped table in the cycle to be a member of the publication, but publications like `supabase_realtime` commonly contain only a subset of tables; the guard now only requires the publication edge that actually participates in the cycle.

--- a/packages/pg-delta/src/core/sort/cycle-breakers.test.ts
+++ b/packages/pg-delta/src/core/sort/cycle-breakers.test.ts
@@ -682,6 +682,132 @@ describe("tryBreakCycleByChangeInjection", () => {
     expect(broken).toContain(terminalDrop);
   });
 
+  test("publication FK-chain 4-cycle with partial publication membership: injects FK drops", () => {
+    // Sentry SUPABASE-API-7RS / CLI-1605. Same shape as the previous test,
+    // but the publication only contains the terminal constraint's table
+    // (trades) and the first dropped table (public_offering_events) — the
+    // intermediate FK-chain table (trade_status_events) was never a member
+    // of supabase_realtime. The breaker must not require every dropped
+    // table in the cycle to be a publication member; the pub edge only
+    // needs one of them.
+    //
+    // Schema:
+    //   trades.trade_id UNIQUE (trades_trade_id_key) — table survives
+    //   trade_status_events.trade_id REFERENCES trades(trade_id)
+    //   public_offering_events.source_event_id REFERENCES trade_status_events(id)
+    //   publication supabase_realtime: trades, public_offering_events only
+    const tableTrades = new Table({
+      ...baseTableProps,
+      name: "trades",
+      columns: [
+        { ...integerColumn("id", 1), not_null: true },
+        { ...integerColumn("trade_id", 2), not_null: true },
+      ],
+      constraints: [uniqueConstraint("trades_trade_id_key", "trade_id")],
+    });
+    const tableTradeStatusEvents = new Table({
+      ...baseTableProps,
+      name: "trade_status_events",
+      columns: [
+        { ...integerColumn("id", 1), not_null: true },
+        integerColumn("trade_id", 2),
+      ],
+      constraints: [
+        fkConstraint({
+          name: "trade_status_events_trade_id_fkey",
+          fkColumn: "trade_id",
+          targetSchema: "public",
+          targetTable: "trades",
+          targetColumn: "trade_id",
+        }),
+      ],
+    });
+    const tablePublicOfferingEvents = new Table({
+      ...baseTableProps,
+      name: "public_offering_events",
+      columns: [
+        { ...integerColumn("id", 1), not_null: true },
+        integerColumn("source_event_id", 2),
+      ],
+      constraints: [
+        fkConstraint({
+          name: "public_offering_events_source_event_id_fkey",
+          fkColumn: "source_event_id",
+          targetSchema: "public",
+          targetTable: "trade_status_events",
+        }),
+      ],
+    });
+    const publication = new Publication({
+      name: "supabase_realtime",
+      owner: "postgres",
+      comment: null,
+      all_tables: false,
+      publish_insert: true,
+      publish_update: true,
+      publish_delete: true,
+      publish_truncate: true,
+      publish_via_partition_root: false,
+      tables: [
+        {
+          schema: "public",
+          name: "public_offering_events",
+          columns: null,
+          row_filter: null,
+        },
+        { schema: "public", name: "trades", columns: null, row_filter: null },
+      ],
+      schemas: [],
+    });
+
+    const terminalDrop = new AlterTableDropConstraint({
+      table: tableTrades,
+      constraint: tableTrades.constraints[0],
+    });
+    const changes: Change[] = [
+      new AlterPublicationDropTables({
+        publication,
+        tables: publication.tables,
+      }),
+      new DropTable({ table: tablePublicOfferingEvents }),
+      new DropTable({ table: tableTradeStatusEvents }),
+      terminalDrop,
+    ];
+
+    const broken = tryBreakCycleByChangeInjection([0, 1, 2, 3], changes);
+    if (broken === null) throw new Error("expected breaker to fire");
+
+    const injectedDropNames = broken
+      .filter(
+        (change): change is AlterTableDropConstraint =>
+          change instanceof AlterTableDropConstraint && change !== terminalDrop,
+      )
+      .map((change) => change.constraint.name)
+      .sort();
+    expect(injectedDropNames).toEqual([
+      "public_offering_events_source_event_id_fkey",
+      "trade_status_events_trade_id_fkey",
+    ]);
+
+    for (const [tableId, constraintName] of [
+      [
+        tablePublicOfferingEvents.stableId,
+        "public_offering_events_source_event_id_fkey",
+      ],
+      [tableTradeStatusEvents.stableId, "trade_status_events_trade_id_fkey"],
+    ] as const) {
+      const rewrittenDrop = broken.find(
+        (change): change is DropTable =>
+          change instanceof DropTable && change.table.stableId === tableId,
+      );
+      if (!rewrittenDrop) throw new Error(`missing DropTable for ${tableId}`);
+      expect(
+        rewrittenDrop.externallyDroppedConstraints.has(constraintName),
+      ).toBe(true);
+    }
+    expect(broken).toContain(terminalDrop);
+  });
+
   test("returns null for a cycle with no recognised pattern (e.g. publication-only)", () => {
     // Cycle of `AlterPublicationSetOwner` changes — neither FK nor
     // publication-column shape. Breaker must bail so the formatted

--- a/packages/pg-delta/src/core/sort/cycle-breakers.ts
+++ b/packages/pg-delta/src/core/sort/cycle-breakers.ts
@@ -418,8 +418,18 @@ function tryBreakPublicationFkConstraintDropCycle(
     return null;
   }
 
-  for (const dropTable of dropTables) {
-    if (!publicationTableIds.has(dropTable.table.stableId)) return null;
+  // At least one dropped table must be a publication member — that's the
+  // publication → DropTable edge that pulls the publication change into the
+  // cycle (the back-edge is the terminal constraint's table, checked above).
+  // Don't require ALL of them: publications like supabase_realtime commonly
+  // contain only a subset of tables, so intermediate FK-chain tables may not
+  // be members (Sentry SUPABASE-API-7RS / CLI-1605).
+  if (
+    !dropTables.some((dropTable) =>
+      publicationTableIds.has(dropTable.table.stableId),
+    )
+  ) {
+    return null;
   }
 
   const cycleDropTableIds = new Set(

--- a/packages/pg-delta/tests/integration/dependencies-cycles.test.ts
+++ b/packages/pg-delta/tests/integration/dependencies-cycles.test.ts
@@ -591,6 +591,79 @@ for (const pgVersion of POSTGRES_VERSIONS) {
     );
 
     test(
+      "drop publication FK-chain tables with partial publication membership should not produce a cycle",
+      withDb(pgVersion, async (db) => {
+        /**
+         * Reproduction for production CycleError (Sentry SUPABASE-API-7RS,
+         * CLI-1605, alpha.24):
+         *
+         *   CycleError: dependency graph contains a cycle involving 4 changes:
+         *     1. AlterPublicationDropTables (supabase_realtime)
+         *     2. DropTable(public_offering_events)
+         *     3. DropTable(trade_status_events)
+         *     4. AlterTableDropConstraint(trades.trades_trade_id_key)
+         *
+         * Cycle path:
+         *   publication:supabase_realtime → table:public.public_offering_events
+         *   public_offering_events_source_event_id_fkey → column:public.trade_status_events.id
+         *   trade_status_events_trade_id_fkey → constraint:public.trades.trades_trade_id_key
+         *   constraint:public.trades.trades_trade_id_key → table:public.trades
+         *
+         * Same shape as the previous test, with one twist: the intermediate
+         * FK-chain table (trade_status_events) is NOT a member of the
+         * publication — supabase_realtime commonly contains only a subset
+         * of tables. The Branch C cycle breaker used to require every
+         * dropped table in the cycle to be a publication member and bailed,
+         * surfacing the raw CycleError to the user.
+         */
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+            CREATE TABLE public.trades (
+              id bigint PRIMARY KEY,
+              trade_id bigint NOT NULL,
+              CONSTRAINT trades_trade_id_key UNIQUE (trade_id)
+            );
+
+            CREATE TABLE public.trade_status_events (
+              id bigint PRIMARY KEY,
+              trade_id bigint NOT NULL,
+              CONSTRAINT trade_status_events_trade_id_fkey
+                FOREIGN KEY (trade_id)
+                REFERENCES public.trades(trade_id)
+            );
+
+            CREATE TABLE public.public_offering_events (
+              id bigint PRIMARY KEY,
+              source_event_id bigint NOT NULL,
+              CONSTRAINT public_offering_events_source_event_id_fkey
+                FOREIGN KEY (source_event_id)
+                REFERENCES public.trade_status_events(id)
+            );
+
+            -- trade_status_events is deliberately NOT in the publication.
+            CREATE PUBLICATION supabase_realtime
+              FOR TABLE public.trades, public.public_offering_events;
+          `,
+          testSql: `
+            ALTER PUBLICATION supabase_realtime
+              DROP TABLE public.public_offering_events, public.trades;
+
+            DROP TABLE public.public_offering_events;
+            DROP TABLE public.trade_status_events;
+
+            ALTER TABLE public.trades
+              DROP CONSTRAINT trades_trade_id_key;
+          `,
+          assertSqlStatements: (statements) => {
+            expect(statements).toMatchInlineSnapshot();
+          },
+        });
+      }),
+    );
+
+    test(
       "alter sequence data_type while owning column survives should not produce DropSequence cycle",
       withDb(pgVersion, async (db) => {
         /**

--- a/packages/pg-delta/tests/integration/dependencies-cycles.test.ts
+++ b/packages/pg-delta/tests/integration/dependencies-cycles.test.ts
@@ -657,7 +657,16 @@ for (const pgVersion of POSTGRES_VERSIONS) {
               DROP CONSTRAINT trades_trade_id_key;
           `,
           assertSqlStatements: (statements) => {
-            expect(statements).toMatchInlineSnapshot();
+            expect(statements).toMatchInlineSnapshot(`
+              [
+                "ALTER TABLE public.public_offering_events DROP CONSTRAINT public_offering_events_source_event_id_fkey",
+                "ALTER TABLE public.trade_status_events DROP CONSTRAINT trade_status_events_trade_id_fkey",
+                "DROP TABLE public.trade_status_events",
+                "ALTER TABLE public.trades DROP CONSTRAINT trades_trade_id_key",
+                "ALTER PUBLICATION supabase_realtime DROP TABLE public.public_offering_events, public.trades",
+                "DROP TABLE public.public_offering_events",
+              ]
+            `);
           },
         });
       }),


### PR DESCRIPTION
## Summary

Fixes an unhandled `CycleError` when dropping a foreign key chain of tables alongside a referenced unique constraint, where only some of the involved tables are members of a publication. The publication FK-chain cycle breaker was overly strict in requiring every dropped table in the cycle to be a publication member.

Refs: [CLI-1605](https://linear.app/supabase/issue/CLI-1605/pg-delta-cycleerror-on-publication-2-droptable-dropconstraint-4-cycle) · Sentry [SUPABASE-API-7RS](https://supabase.sentry.io/issues/7416308002/) (12× events on 6/11, user hard-blocked from diffing)

## Root cause

From the Sentry event's cycle edges: the explicit edge `constraint:public.trades.trades_trade_id_key → table:public.trades` landing on the `AlterPublicationDropTables` node proves `trades` is in the publication drop list, and the catalog edge proves `public_offering_events` is too. By elimination, the intermediate FK-chain table `trade_status_events` was **not** a `supabase_realtime` member — and Branch C (`tryBreakPublicationFkConstraintDropCycle`) required *every* dropped table in the cycle to be a publication member, so it bailed and the raw `CycleError` surfaced. (`fkReferencesConstraint` was not the problem: the single-column FK → unique-key match works fine.)

## Changes

- **cycle-breakers.ts**: Relaxed the publication membership guard in `tryBreakPublicationFkConstraintDropCycle()` to require only that at least one dropped table is a publication member (the edge that actually pulls the publication into the cycle), rather than all of them. The back-edge via the terminal constraint's table is still checked. Publications like `supabase_realtime` commonly contain only a subset of tables, so intermediate FK-chain tables may not be members.

- **cycle-breakers.test.ts**: Unit test covering the partial publication membership scenario, verifying the breaker injects FK drops for both publication and non-publication tables in the chain.

- **dependencies-cycles.test.ts**: Integration test reproducing the production schema (`trades` with unique `trade_id`, two event tables FK-chaining to it, partial `supabase_realtime` membership) with roundtrip fidelity validation and a snapshot of the generated statement order.

## RED → GREEN

Per repo TDD policy, the first commit contains only the failing regression tests:

- Unit: `error: expected breaker to fire`
- Integration: reproduced the production `CycleError` with byte-identical cycle edges to the Sentry event:

```text
CycleError: dependency graph contains a cycle involving 4 changes:
  1. [0] AlterPublicationDropTables
  2. [1] DropTable
  3. [2] DropTable
  4. [3] AlterTableDropConstraint
...
  [3] → [0] (source: explicit)
    Dependency: constraint:public.trades.trades_trade_id_key → table:public.trades
```

The second commit applies the fix (plus changeset); both tests pass, all 14 tests in the cycles integration file and all 1127 pg-delta unit tests are green, and `format-and-lint`, `check-types`, and `knip` are clean.

https://claude.ai/code/session_01Lh1FcyiZqWh97tFQZAH39r