### PR TITLE
docs: add north-star architecture for pg-delta and pg-topo

### DIFF
--- a/docs/stage-00-test-suite.md
+++ b/docs/stage-00-test-suite.md
@@ -27,9 +27,11 @@ subsequent stage lands against a pre-existing definition of done.
 1. **New package skeleton** — working directory `packages/pg-delta-next/`
    (the name is a placeholder; final naming is a stage-10 product decision).
    Contains only: the target public API as typed stubs that throw
-   `NotImplementedError` (`extractFactBase`, `diff`, `plan`, `provePlan`,
-   `apply`, `loadSqlFiles` — signatures from the architecture doc §3), the
-   corpus, and the test suite.
+   `NotImplementedError` (`extract`, `diff`, `plan`, `provePlan`, `apply`,
+   `loadSqlFiles` — names per the public API shape in §4.5, finalized in
+   stage 9), the corpus, and the test suite. Adopt a `debug`-namespace
+   logging convention (`DEBUG=<package>:*`) in the scaffold so every later
+   stage inherits it.
 2. **Corpus format.** One directory per scenario:
 
    ```text
@@ -66,7 +68,13 @@ subsequent stage lands against a pre-existing definition of done.
    stage flips it: maintain an explicit `EXPECTED_RED` list in one file so
    turning a scenario green is a deliberate one-line diff, and an
    accidentally-green test is a failure.
-5. **Differential baseline capture (green).** A script (not a test) that
+5. **The new package's CI lane.** Create the CI workflow this whole plan
+   runs on: a PG-version matrix (per the supported-versions policy in the
+   architecture doc §9) with lanes for fixture validity, baseline capture,
+   and the (red) engine suite. Later stages add lanes (extractor ring,
+   differential, soak) to this workflow — it must exist from stage 0 or no
+   gate is evaluable.
+6. **Differential baseline capture (green).** A script (not a test) that
    runs the *current* `@supabase/pg-delta` `createPlan` over every scenario
    and records: the statement list, apply success/failure, and the resulting
    schema (via `pg_dump --schema-only` for now — the new extractor doesn't
@@ -124,6 +132,7 @@ subsequent stage lands against a pre-existing definition of done.
 - Fixture validity green on PG 15, 17, 18.
 - Old-engine baselines captured for every scenario the old engine supports.
 - Engine suite red, with every red accounted for in `EXPECTED_RED`.
+- The CI workflow exists and runs all three lanes on the version matrix.
 - The corpus has scenarios covering: every cycle-breaker case
   (`cycle-breakers.ts` patterns), every post-diff-normalization case, the
   Supabase baseline flow, and at least one scenario per object kind.

--- a/docs/stage-00-test-suite.md
+++ b/docs/stage-00-test-suite.md
@@ -1,0 +1,135 @@
+# Stage 0: The Red Test Suite (corpus first)
+
+> Part of the [north-star architecture](./target-architecture.md) (§4.3, §9).
+> Read §10 (guardrails) before starting. Depends on: nothing — this is the
+> first thing built. Everything else depends on it.
+
+## Goal
+
+Stand up the **entire test architecture before any engine code exists**: the
+scenario corpus ported from the current integration suite, the proof-harness
+contract, and the differential baselines. Engine tests are red — by design —
+until stages 4–6 land. This inverts the usual order on purpose: the corpus
+is the distilled record of every field-discovered failure (the second most
+valuable asset after the extractor SQL), and writing it first means every
+subsequent stage lands against a pre-existing definition of done.
+
+**The red/green discipline that makes "all red" sound:**
+
+| Layer | State at end of stage 0 | What it proves |
+|---|---|---|
+| Fixture validity | **Green** | Every scenario's DDL applies cleanly on every supported PG version — the corpus itself is correct |
+| Old-engine baselines | **Green** | The current pg-delta produces a recorded plan/outcome per scenario — the differential oracle has data |
+| Engine tests (proof loop) | **Red on `NotImplementedError`** | Red for the *right reason* — the harness asserts the failure mode, so a fixture bug cannot masquerade as "engine missing" |
+
+## Deliverables
+
+1. **New package skeleton** — working directory `packages/pg-delta-next/`
+   (the name is a placeholder; final naming is a stage-10 product decision).
+   Contains only: the target public API as typed stubs that throw
+   `NotImplementedError` (`extractFactBase`, `diff`, `plan`, `provePlan`,
+   `apply`, `loadSqlFiles` — signatures from the architecture doc §3), the
+   corpus, and the test suite.
+2. **Corpus format.** One directory per scenario:
+
+   ```text
+   packages/pg-delta-next/corpus/<category>/<scenario-name>/
+   ├── a.sql            # DDL for the source state
+   ├── b.sql            # DDL for the desired state
+   ├── seed.sql         # optional: rows to seed for the data-preservation check
+   └── meta.ts          # name, description, tags, plan assertions
+   ```
+
+   `meta.ts` exports a typed object:
+
+   ```ts
+   export default defineScenario({
+     description: "publication drops column on surviving table",
+     tags: ["publication", "pg15", "pg17", "pg18"],     // pg tags drive the matrix
+     requires: [],                                       // e.g. ["logical-wal", "supabase-image", "isolated-cluster"]
+     expect: {                                           // semantic plan assertions — NEVER SQL bytes
+       dataLoss: "none",                                 // drives the seeded-rows proof
+       actions: [{ kind: "column", verb: "remove", via: "alter" }],  // optional, only where load-bearing
+       maxActions: 12,                                   // optional minimality budget
+     },
+   });
+   ```
+
+3. **Fixture-validity suite (green).** For every scenario × PG version:
+   apply `a.sql` to a fresh database, apply `b.sql` to another, fail on any
+   SQL error. Reuses the existing container infrastructure
+   (`packages/pg-delta/tests/container-manager.ts` — import it or copy it;
+   copying is fine, this package owns its destiny).
+4. **Engine suite (red).** For every scenario: the proof-loop test
+   (`plan → provePlan → assertions from meta.ts`) written against the stub
+   API. Each test asserts it fails with `NotImplementedError` *until* a
+   stage flips it: maintain an explicit `EXPECTED_RED` list in one file so
+   turning a scenario green is a deliberate one-line diff, and an
+   accidentally-green test is a failure.
+5. **Differential baseline capture (green).** A script (not a test) that
+   runs the *current* `@supabase/pg-delta` `createPlan` over every scenario
+   and records: the statement list, apply success/failure, and the resulting
+   schema (via `pg_dump --schema-only` for now — the new extractor doesn't
+   exist yet). Stored under `corpus-baselines/` (gitignored size permitting,
+   or regenerated in CI). Stage 3 upgrades this into the live differential
+   runner.
+
+## How to proceed
+
+1. Scaffold the package (tsconfig, bun test wiring, container manager).
+   Define the stub API and `NotImplementedError`.
+2. **Port the corpus.** Enumerate `packages/pg-delta/tests/integration/*.test.ts`
+   (63 files). For each test case, extract the `(main DDL, branch DDL)` pair
+   from the `withDb`/`withDbIsolated` callbacks and the
+   `roundtripFidelityTest` invocations into `a.sql`/`b.sql`. Keep a
+   `PORTING.md` checklist mapping every original test file → scenario
+   directories, so coverage is auditable (the stage gate counts this).
+3. While porting, translate — don't transcribe — the assertions:
+   - Inline SQL snapshots: identify what the snapshot was actually guarding
+     (an ALTER instead of drop+create? ordering? a specific clause?) and
+     express that as `expect.actions` / `expect.dataLoss` / `maxActions`.
+     Most snapshots guard nothing beyond convergence — omit `expect` then.
+   - Tests asserting planner internals: usually corpus-irrelevant; note
+     them in `PORTING.md` as "not ported — mechanism test".
+4. Tag scenarios honestly: `requires: ["supabase-image"]` for the Supabase
+   suite (they need the base-init baseline — port those last),
+   `["logical-wal"]` for subscription tests, `["isolated-cluster"]` for
+   role/shared-object scenarios, per-PG tags where behavior is
+   version-specific.
+5. Wire CI: fixture-validity + baseline capture run on the matrix; engine
+   suite runs but is satisfied by `EXPECTED_RED`.
+
+## What to look for (pitfalls)
+
+- **Scenarios that encode old-engine quirks.** Some tests assert behavior
+  the north star intentionally changes (e.g. exact emission shape, the
+  `invalidates` mechanics). Port the *scenario*, drop the *assertion*; the
+  proof loop is the new assertion.
+- **Setup that hides in test utils.** `withDbSupabaseIsolated` replays the
+  base-init fixture; scenarios extracted from those tests are incomplete
+  without the `supabase-image` requirement.
+- **Multi-step tests.** A few tests apply, mutate, re-plan. Those become
+  *two* scenarios (or a scenario chain — keep it simple: split them).
+- **Version-gated DDL.** PG18-only syntax in a scenario tagged for pg15
+  shows up immediately in fixture validity — that's the layer working.
+- **Don't fix old-engine bugs in the corpus.** If porting reveals a case
+  where the current engine seems wrong, port it as-is and add a
+  `suspectedOldEngineBug` note in `meta.ts`; the differential triage in
+  stage 5 adjudicates.
+
+## Gate (definition of done)
+
+- `PORTING.md` accounts for 100% of the existing integration test files
+  (ported / split / not-ported-with-reason).
+- Fixture validity green on PG 15, 17, 18.
+- Old-engine baselines captured for every scenario the old engine supports.
+- Engine suite red, with every red accounted for in `EXPECTED_RED`.
+- The corpus has scenarios covering: every cycle-breaker case
+  (`cycle-breakers.ts` patterns), every post-diff-normalization case, the
+  Supabase baseline flow, and at least one scenario per object kind.
+
+## Open decisions for this stage
+
+- Scenario directory taxonomy (`<category>/` grouping) — pick what reads
+  well after ~20 ports, then stick to it.
+- Whether baselines are committed or CI-regenerated (size-driven).

--- a/docs/stage-01-fact-core.md
+++ b/docs/stage-01-fact-core.md
@@ -58,6 +58,12 @@ stage to test exhaustively — exploit that.
 6. **Snapshot format v1.** A single JSON document: `{formatVersion: 1,
    pgVersion, capturedAt, facts: [...], edges: [...]}`. Round-trips
    losslessly: `deserialize(serialize(fb))` is hash-identical.
+7. **One shared diagnostic type** used by every later stage:
+   `{code, severity, subject?: StableId, message, context}`. Stage 2's
+   unresolved-reference diagnostics, stage 7's loader rejections, stage 8's
+   dangling-requirement error, and stage 6's apply reports all reuse this
+   shape — defining it here is what keeps error output renderable by one
+   CLI formatter instead of five ad-hoc shapes.
 
 ## How to proceed
 

--- a/docs/stage-01-fact-core.md
+++ b/docs/stage-01-fact-core.md
@@ -1,0 +1,108 @@
+# Stage 1: Identity Codec + Fact-Base Core
+
+> Part of the [north-star architecture](./target-architecture.md) (§3.1).
+> Depends on: stage 0 (the package exists). Pure library code — no database,
+> no Docker. Gate: property tests for codec round-trip, rollup algebra, hash
+> stability.
+
+## Goal
+
+The data layer everything else stands on: typed identity, facts, edges,
+hashing, Merkle rollups, and the snapshot format. Get this right and stages
+2–9 are consumers; get it wrong and every stage pays. It is also the easiest
+stage to test exhaustively — exploit that.
+
+## Deliverables
+
+1. **`StableId`** — discriminated union covering every fact kind. Enumerate
+   from the current system's `stableId.*` helpers
+   (`packages/pg-delta/src/core/objects/utils.ts`, ~25 helpers) as the
+   checklist of kinds: schema, table, view, materializedView, foreignTable,
+   sequence, index, trigger, rule, policy, procedure (signature-keyed),
+   aggregate, domain, collation, type (enum/composite/range), extension,
+   language, eventTrigger, publication, subscription, role, fdw, server,
+   userMapping — plus sub-entity kinds: column, constraint, default — plus
+   metadata kinds: comment, acl, securityLabel, membership, defaultPrivilege.
+2. **The codec** — `encodeId(id): string` / `parseId(s): StableId`:
+   - One escaping rule for all kinds (recommend: quote any part containing
+     `. : ( ) " ,` with `"`, double inner quotes — i.e. PostgreSQL's own
+     identifier-quoting convention, which contributors already know).
+   - A version tag in persisted form (`v1:` prefix or a snapshot-level
+     field — prefer snapshot-level: tag once, not per ID).
+   - **Do not copy the old format.** Today's strings have known quirks
+     (ad-hoc acl/defacl encodings, signature commas unescaped). Design
+     clean; nothing depends on the old format (architecture doc, decision
+     log f).
+3. **`Fact`, `DependencyEdge`, `FactBase`** as specified in §3.1. Facts are
+   immutable after construction. Edges: `{from: StableId, to: StableId,
+   kind: "depends" | "owns" | "memberOfExtension" | ...}` — enumerate edge
+   kinds from `depend.ts`'s deptype handling plus the synthesized
+   ACL/membership sources.
+4. **Canonical payload encoding + digest.**
+   - Canonical encoding: recursively sorted object keys; type-tagged
+     scalars (so `"1"` ≠ `1`); bigint-safe; arrays preserved as-is when
+     order is semantic, sorted when set-valued — the *payload author*
+     (stage 2) decides per attribute, the encoder just provides both.
+   - Digest: SHA-256 via `node:crypto` (works in Bun/Node/Deno without a
+     native dep; ≥128-bit per §3.1). Store full 32 bytes; compare as
+     strings. Revisit BLAKE3 only if profiling demands it.
+   - **Identity-free**: the encoder must never receive the fact's own name
+     or parent name. Enforce structurally — `payload` is a separate object
+     from `id`, and a lint-level test greps payload schemas for
+     name-shaped fields.
+5. **Rollup algebra.** `rollup(fact) = H(payloadHash ‖ sortedChildRollups ‖
+   sortedOutgoingEdgeHashes)` with sorting by canonical ID encoding.
+   Design now, even if computed lazily: the **structural rollup** variant
+   (same fold, IDs excluded) used by stage 9's rename matching — it shares
+   the tree walk, so the API should accept the variant as a parameter.
+6. **Snapshot format v1.** A single JSON document: `{formatVersion: 1,
+   pgVersion, capturedAt, facts: [...], edges: [...]}`. Round-trips
+   losslessly: `deserialize(serialize(fb))` is hash-identical.
+
+## How to proceed
+
+1. Types first, then codec with property tests, then hashing, then rollups,
+   then snapshot. Each layer's tests written before the layer (repo TDD
+   policy applies inside stages too).
+2. Property-test the codec hard: round-trip arbitrary identifiers including
+   `"`, `.`, `(`, unicode, empty-string schema (forbid it explicitly),
+   procedure args containing commas and quoted type names.
+3. Commit **golden hash fixtures**: a handful of hand-built fact bases with
+   their expected digests checked in. This pins the canonical encoding —
+   accidental drift (key-order change, scalar-tagging change) breaks the
+   golden test rather than silently invalidating every future snapshot.
+4. Rollup properties to assert: child-order independence; a payload change
+   propagates to every ancestor rollup and no sibling; an edge add/remove
+   changes exactly the owning fact's rollup chain; empty fact base has a
+   defined digest.
+
+## What to look for (pitfalls)
+
+- **Procedure identity.** Signature args must be *normalized type names*
+  (the old system resolves them at extraction); the codec just carries
+  strings — but define ordering and casing expectations here so stage 2 has
+  a contract.
+- **`acl` / `defaultPrivilege` identity** is composite (target + grantee
+  [+ grantor]); model them as structured fields, not packed strings.
+- **Hash truncation.** Don't truncate below 128 bits anywhere, including
+  "convenience" short forms in logs (log prefixes are fine, comparisons are
+  not).
+- **Determinism across runtimes.** JSON number formatting and string
+  ordering must be locale-independent — sort by code point, never
+  `localeCompare`.
+
+## Gate
+
+- Codec round-trip property suite green (including adversarial
+  identifiers).
+- Rollup algebra property suite green.
+- Golden hash fixtures committed and green.
+- Snapshot round-trip is hash-identical.
+- No payload schema contains identity fields (enforced by test).
+
+## Open decisions for this stage
+
+- Exact canonical-encoding details (scalar tagging syntax) — decide once,
+  pin with goldens.
+- Interned in-memory key representation (string vs number) — measure later;
+  start with strings, hide behind the FactBase API so it can change.

--- a/docs/stage-02-extractors.md
+++ b/docs/stage-02-extractors.md
@@ -79,6 +79,11 @@ import.
 
 ## What to look for (pitfalls)
 
+- **Connections are the caller's trust boundary.** The lead + N worker
+  connections all derive from the caller-supplied pool/URL — same
+  credentials, same SSL config; the library never stores or re-derives
+  credentials. Workers are read-only (`READ ONLY` transactions); enforce
+  that in the capture wrapper so an extractor bug cannot write.
 - **Shared objects.** Roles/memberships are cluster-level; the extractor
   must scope what it reports (roles referenced by the database's objects +
   all roles, as the old extractor does) and tag them so frontends can apply

--- a/docs/stage-02-extractors.md
+++ b/docs/stage-02-extractors.md
@@ -1,0 +1,119 @@
+# Stage 2: Extractor Port
+
+> Part of the [north-star architecture](./target-architecture.md) (§3.1–3.2).
+> Depends on: stage 1. Gate: extractor fixture ring per PG version; pg_dump
+> observer; content cross-check against old-engine catalogs.
+
+## Goal
+
+Port the most valuable asset in the old repository — the extractor SQL
+corpus — to produce the new fact base: structured identity parts, normalized
+payloads, dependency edges, all captured under one consistent snapshot.
+This stage is where the old system's accumulated `pg_catalog` knowledge
+(per-PG-version quirks, normalization doctrine) transfers; treat the old
+`*.model.ts` files as the reference implementation to mine, not code to
+import.
+
+## Deliverables
+
+1. **Snapshot-consistent capture.** Lead connection: `BEGIN ISOLATION LEVEL
+   REPEATABLE READ READ ONLY` + `pg_export_snapshot()`; N workers `SET
+   TRANSACTION SNAPSHOT` and run extractors in parallel. Fallback: if
+   snapshot export fails (transaction-mode poolers), degrade to serial
+   extraction on the single lead connection — still consistent, just not
+   parallel. Detect by attempting, not by guessing.
+2. **Per-kind extractors returning structured identity.** Queries return
+   identity *parts* as columns (`kind, schema, name, args, parent_*`) plus
+   the payload columns — never concatenated ID strings (guardrail 1). The
+   library-side codec builds IDs.
+3. **The fact decomposition.** This is the key design work of the stage —
+   what becomes its own fact. The mapping, mined from the old models:
+
+   | Old model nesting | New facts |
+   |---|---|
+   | `Table.columns[]` | `column` facts, parent = table |
+   | column `default` | `default` fact, parent = column (mirrors `pg_attrdef`, which has its own `pg_depend` rows) |
+   | `Table.constraints[]` | `constraint` facts, parent = table |
+   | `*.privileges[]` (aclexplode output) | `acl` facts, parent = target, identity includes grantee |
+   | `*.comment` | `comment` facts, parent = target |
+   | `*.security_labels[]` | `securityLabel` facts, parent = target, identity includes provider |
+   | role memberships | `membership` facts |
+   | extension ownership (currently an extraction-time *filter*) | `memberOfExtension` **edges** — extract everything, filter nothing (§3.9) |
+
+4. **Dependency edges.** Port `depend.ts`: the core `pg_depend` synthesis
+   query keeps its single-query shape but returns structured refs; the
+   independent ACL/membership/defacl sub-queries (lines ~43–500) become
+   separate parallel extractors. An unresolvable reference becomes a
+   **diagnostic**, not a silently-dropped `unknown:` row.
+5. **Equality-surface policy per kind.** Which attributes enter the hashed
+   payload is per-kind knowledge (§3.1). Port the old `stableSnapshot()`
+   overrides and `dataFields` exclusions; the known list to honor:
+   names-not-attnums everywhere (`tgattr`, `indkey`, `conkey`/`confkey`,
+   `prattrs`), canonical `pg_get_*def()` as the comparison form for
+   indexes/triggers/rules, **extension `version` excluded from equality**
+   (`extension.diff.ts:53-62` ignores it deliberately today).
+6. **The three verification rings** (these are the gate):
+   - *Fixture ring*: per PG version, a fixture database built from known
+     DDL, with tests asserting specific facts exist with specific payloads.
+     Start from the old extraction tests and catalog baselines.
+   - *pg_dump observer*: two databases the extractor calls hash-identical
+     must produce identical `pg_dump --schema-only` output (modulo a small
+     documented normalization of dump text).
+   - *Old-engine cross-check*: extract the same database with old and new;
+     a mapping table asserts every object the old catalog knows appears as
+     facts (this catches dropped coverage during the port).
+
+## How to proceed
+
+1. Order kinds by leverage: schema → role → extension (+ provenance edges)
+   → table/column/constraint/default → index → view/matview → procedure →
+   the rest. Tables first among the hard ones — they exercise the whole
+   decomposition.
+2. Per kind: write the fixture-ring test (red), port the SQL from
+   `packages/pg-delta/src/core/objects/<kind>/<kind>.model.ts` (keep the
+   per-PG-version variants — they encode real knowledge), define the
+   payload schema (zod is fine; it's a dev-time validator), wire the
+   equality-surface exclusions, green the ring.
+3. Then the depend port, then snapshot-consistency (capture wrapper), then
+   the pg_dump observer, then the old-engine cross-check.
+
+## What to look for (pitfalls)
+
+- **Shared objects.** Roles/memberships are cluster-level; the extractor
+  must scope what it reports (roles referenced by the database's objects +
+  all roles, as the old extractor does) and tag them so frontends can apply
+  the isolation rules (§3.2).
+- **Definition strings embed names.** `pg_get_indexdef()` output contains
+  the table name — that's payload, and it breaks rename hash-matching for
+  dependents (§4.1 accepts this; just don't *add* avoidable name embedding).
+- **The filter trap.** The old extractors pre-filter (`pg_catalog`,
+  `information_schema`, extension-owned objects). The new ones extract
+  everything visible and record provenance; *policy* filters (§3.9).
+  Exception: `pg_catalog`/`information_schema` system objects stay
+  excluded — they are not user state.
+- **Physical vs logical, again.** Any new payload field sourced from a
+  `*_oid` or attnum-bearing column needs name resolution at extraction.
+  This is the #1 historical bug class (see the old CLAUDE.md's attnum
+  doctrine); the fixture ring should include the canonical reproduction
+  (column dropped and re-added → identical logical state).
+- **Don't chase completeness silently.** If a catalog feature is
+  deliberately not modeled (storage params on some kind, etc.), record it
+  in a `COVERAGE.md` per kind — the pg_dump observer will surface gaps;
+  triage them into "model it" or "documented exclusion".
+
+## Gate
+
+- Fixture ring green on PG 15/17/18.
+- pg_dump observer green on the stage-0 corpus's fixture databases.
+- Old-engine cross-check: 100% of old-catalog objects accounted for
+  (mapped or documented exclusion).
+- Capture is snapshot-consistent (test: concurrent DDL during extraction
+  does not produce dangling edges).
+
+## Open decisions for this stage
+
+- Payload schema per kind (the structured replacement of each old model) —
+  decided kind-by-kind inside the stage, recorded in the payload schema
+  files themselves.
+- How much of `pg_dump` output normalization the observer needs (whitespace,
+  comment lines) — keep the normalizer tiny and documented.

--- a/docs/stage-03-proof-harness.md
+++ b/docs/stage-03-proof-harness.md
@@ -1,0 +1,107 @@
+# Stage 3: Proof Harness + Live Corpus
+
+> Part of the [north-star architecture](./target-architecture.md) (§3.7, §4.3).
+> Depends on: stages 0–2. Guardrail 5: this stage lands **before** stage 5
+> (planner) starts. Gate: the harness proves extract → materialize →
+> re-extract fidelity over the corpus.
+
+## Goal
+
+Turn the stage-0 test scaffold into the live oracle: `provePlan`, the
+data-preservation check, and the differential runner. After this stage, the
+project has its safety net — every later stage is judged by machinery built
+here, not by human review of SQL.
+
+## Deliverables
+
+1. **`provePlan(plan, sourceFactBase | sourcePool, desiredFactBase)`**:
+   materialize source → apply plan → extract → hash-compare against desired.
+   Returns a structured verdict (state diff if any, data-preservation
+   violations, observed rewrites).
+2. **Materialization, two forms** (§3.7):
+   - *Template clone* — `CREATE DATABASE … TEMPLATE` of a scratch source.
+     Works for everything CI does; requires the source to have no other
+     connections (the harness owns its containers, so it can guarantee
+     that).
+   - *Render-from-fact-base* — **deferred to stage 5/6**, because rendering
+     a fact base to DDL *is* the planner (`plan(∅ → fb)` applied to an
+     empty database). Stub it now with a clear error; wire it the moment
+     stage 5 can render creates. The stage-3 fidelity gate uses template
+     clones and snapshot round-trips only. Record this sequencing in the
+     code comment so nobody "fixes" the stub early.
+3. **Data-preservation check.** After materializing the source and before
+   applying the plan: run the scenario's `seed.sql` if present; otherwise
+   auto-seed — insert a small synthetic row into every insertable user
+   table (respecting NOT NULL/FK order by inserting in dependency order;
+   skip tables that can't be satisfied generically and record the skip).
+   After apply: every seeded row must survive (count + content sample) in
+   every table the plan did not declare data loss for. Violations fail the
+   proof with the offending table named.
+4. **Rewrite observation.** Record `pg_class.relfilenode` for user tables
+   before/after apply on the clone; a changed relfilenode under an action
+   that claimed no rewrite fails the proof (§3.7).
+5. **The differential runner.** Per scenario: old engine plans and applies
+   `A → B` on its own clone pair; new engine (once it exists) does the
+   same; both results extracted **with the new extractor** and
+   hash-compared. Until stage 5, the runner records old-engine results only
+   (upgrading the stage-0 pg_dump baselines to fact-base baselines).
+   Divergences land in a triage file with three buckets: `new-bug`,
+   `old-bug`, `accepted-difference` — every entry needs a one-line reason.
+6. **Generative scaffolding (minimal).** The harness API for
+   property-based runs: `roundtrip(generatorSeed)` — generate a schema,
+   prove `plan(∅ → S)` then `plan(S → S′)` for a mutated S′. Ship with a
+   trivial generator (a few kinds); growing the generator is continuous
+   background work from here on, not a one-time deliverable.
+
+## How to proceed
+
+1. Template-clone materialization + extract-fidelity first: for each
+   corpus scenario, build A, clone it, extract both, assert hash-identical.
+   This validates extractor determinism and the clone path with zero
+   planner involvement — and it's the stage gate.
+2. Snapshot fidelity: extract → serialize → deserialize → re-compare.
+3. Data-preservation mechanics against hand-built plans (literal SQL plans
+   written for the test — the harness shouldn't wait for the planner to
+   verify its own checks work). Include a deliberately destructive plan to
+   prove the check *fails* correctly.
+4. Rewrite observation, same approach: a hand-built `ALTER COLUMN TYPE`
+   plan must trip it; an `ADD COLUMN` must not.
+5. Differential runner recording old-engine fact-base baselines.
+6. Flip the stage-0 `EXPECTED_RED` entries for harness-infrastructure
+   tests; engine scenarios stay red.
+
+## What to look for (pitfalls)
+
+- **Harness bugs are invisible later.** A proof loop that vacuously passes
+  is worse than none. Every check needs its negative test (the
+  deliberately-broken plan that must fail) — treat the harness itself as
+  TDD subject.
+- **Auto-seed fragility.** Generic row synthesis hits exotic column types,
+  generated columns, and partitioned tables. Keep the skip-list explicit
+  and visible in proof output; a scenario where nothing could be seeded
+  proves nothing about data preservation and should say so.
+- **Clone cost.** Template clones are file copies — cheap, but per-scenario
+  × per-PG-version adds up. Reuse the stage-0 container pool; one container
+  per PG version, databases as the isolation unit (the old suite's model,
+  which is the right one).
+- **Old-engine quirks in the differential.** The old engine's plans
+  sometimes include session `SET` statements; normalize before applying,
+  don't diff statement lists — only resulting fact bases.
+
+## Gate
+
+- Extract → clone → re-extract hash-identical across the corpus, all PG
+  versions.
+- Snapshot round-trip fidelity across the corpus.
+- Data-preservation and rewrite checks each demonstrated with negative
+  tests.
+- Old-engine fact-base baselines recorded for the corpus.
+- Generative scaffold runs end-to-end with the trivial generator (proof of
+  plumbing, not coverage).
+
+## Open decisions for this stage
+
+- Auto-seed strategy details (how hard to try on FK graphs before
+  skipping).
+- Corpus-pruning policy stays open (architecture doc §11) — revisit once
+  generative coverage exists.

--- a/docs/stage-04-diff.md
+++ b/docs/stage-04-diff.md
@@ -1,0 +1,63 @@
+# Stage 4: Generic Diff
+
+> Part of the [north-star architecture](./target-architecture.md) (§3.3).
+> Depends on: stage 1 (rollups), stage 2 (real fact bases to test against).
+> Gate: fixture diffs; `diff(A, A) = ∅` generatively.
+
+## Goal
+
+The smallest stage, by design: rollup-guided descent over two fact bases,
+emitting fact-level deltas. There is **zero per-kind code here** — if a kind
+needs special handling during diff, that's a payload-definition problem
+(stage 2) or a rule problem (stage 5), never a diff problem. Guard that
+boundary jealously; it is the structural guarantee behind P2.
+
+## Deliverables
+
+1. **`diff(a: FactBase, b: FactBase): Delta[]`** implementing:
+   - Compare root rollups; equal → `[]`.
+   - Descend the parent tree: rollup-equal subtrees skipped wholesale;
+     differing facts compared by payload hash; differing payloads compared
+     attribute-by-attribute → `set` deltas; presence differences → `add` /
+     `remove` (with the whole subtree of a removed/added container emitted
+     as facts — the planner decides what's implicit).
+   - Edge set differences → `link` / `unlink` deltas.
+2. **Deterministic output order**: sorted by canonical ID encoding, then
+   verb. Determinism here is what makes plans reproducible artifacts.
+3. **Delta serialization** — deltas are the plan payload (§3.7); they
+   serialize/deserialize losslessly alongside the snapshot format.
+
+## How to proceed
+
+1. Unit tests on hand-built fact bases first (no database): every verb,
+   nesting, edge-only changes, the empty cases.
+2. Property tests: `diff(A, A) = ∅` over generated fact bases;
+   `diff(A, B)` and `diff(B, A)` are verb-mirrored; applying a delta list
+   to `A`'s fact set reproduces `B`'s fact set exactly (a pure-data "apply"
+   used only for testing the differ — do not confuse it with SQL apply).
+3. Then corpus-derived fixtures: extract real `(A, B)` pairs via the
+   stage-3 harness, snapshot them, and assert interesting deltas (these
+   become the fast Docker-free diff tests the architecture promised).
+
+## What to look for (pitfalls)
+
+- **The temptation to interpret.** "A removed table should suppress its
+  column removes" is planner knowledge (`implicitlyRemoves`), not diff
+  logic. The differ reports the full truth; the rule table decides
+  significance.
+- **Attribute-level `set` granularity** depends on payload schema shape:
+  an attribute that is itself a blob (a `pg_get_*def` string) diffs as one
+  `set` — that's correct and intended; don't decompose definition strings.
+- **Set-valued attributes** must have been sorted at extraction (stage 2's
+  contract). If a flapping diff shows up, fix the payload normalization,
+  not the differ.
+- **Performance is free here** — O(changed) falls out of rollups. Resist
+  adding caching or indexes until a profile demands it.
+
+## Gate
+
+- Unit + property suites green (no Docker).
+- Corpus-derived diff fixtures green.
+- `diff(A, A) = ∅` holds generatively over stage-3's generator output.
+- The differ contains no reference to any concrete fact kind (enforced by
+  a test that greps the module for kind names — crude, effective).

--- a/docs/stage-05-planner.md
+++ b/docs/stage-05-planner.md
@@ -44,6 +44,23 @@ where the two architectural inversions live — maximal decomposition
    serializers (`changes/*.ts` templates, `table.alter.ts`'s ~25 variants)
    for the SQL-shape knowledge — port the *strings*, not the class
    structure.
+6. **Loud failure on missing requirements.** The graph build fails with a
+   structured diagnostic (the stage-1 shared type) when an action's
+   `consumes`/edge target is absent from the fact set — this covers both
+   genuine missing dependencies and holes introduced by policy filtering
+   (stage 8 supplies the policy negative test; the *check* lives here).
+7. **The vetted lock-class table.** Net-new (the old engine has none):
+   populate per-DDL-form lock levels from PostgreSQL's documentation, with
+   a targeted unit assertion per form. This is the "vetted" tier of the
+   safety report (§3.7); stage 6 consumes it, stage 6 does not build it.
+8. **The benchmark fixture + timing harness.** A ≥10k-object schema fixture
+   and an extract/diff/plan wall-time harness, run in CI from this stage on
+   — stage 10's performance-parity bar reads these numbers; they must exist
+   long before cutover to catch regressions early.
+9. **Generator growth, per PR.** Each kind-batch PR extends the stage-3
+   generative engine to cover the kinds it lands. The stage-10 soak is only
+   meaningful if the generator emits every supported kind — coverage is
+   tracked as a simple kind-checklist in the generator module.
 
 ## Recommended PR sequence (each lands corpus-greens, flips `EXPECTED_RED` entries)
 
@@ -111,6 +128,19 @@ where the two architectural inversions live — maximal decomposition
   versions — `EXPECTED_RED` is empty for engine tests.
 - Differential vs old engine: zero untriaged divergences.
 - Generative soak: an agreed run-count (e.g. 10k generated roundtrips)
-  with zero proof failures and zero cycles.
+  with zero proof failures and zero cycles; the generator covers every
+  kind landed in this stage (checklist complete).
 - Zero cycle errors across corpus + soak (guardrail 4 holds with no
   exceptions needed).
+- Missing-requirement failure covered by a negative test; lock-class table
+  populated with per-form assertions; benchmark fixture + timing harness
+  running in CI.
+
+## Open decisions for this stage
+
+- Compaction's default aggressiveness (how much beyond
+  constraints-into-CREATE-TABLE the default merges) — listed as open in the
+  architecture doc §11; decide from corpus readability once the pass
+  exists.
+- The kind-weight table's exact ordering beyond the pg_dump-inspired seed —
+  tune for output readability, pinned by determinism tests.

--- a/docs/stage-05-planner.md
+++ b/docs/stage-05-planner.md
@@ -1,0 +1,116 @@
+# Stage 5: The Planner (rule table · actions · graph · compaction)
+
+> Part of the [north-star architecture](./target-architecture.md) (§3.4–3.6).
+> Depends on: stages 3–4 (the proof loop is the oracle — guardrail 5).
+> Gate: corpus green under proof; differential vs old engine; generative
+> soak; zero cycles. **The largest stage — plan for it to be many PRs.**
+
+## Goal
+
+Deltas in, ordered atomic actions out. This is where the old system's
+per-kind knowledge gets its second life as data: the rule table. It is also
+where the two architectural inversions live — maximal decomposition
+(cycles unconstructible) and the single mixed graph (no phases, no repair).
+
+## Deliverables
+
+1. **The rule table** (§3.4): per-kind `KindRules` — `createTemplate`,
+   `attributes` (alter / replace / conditional-replace per attribute),
+   `implicitlyRemoves`, `lockClass`, `rewriteRisk`, `dataLossClass`,
+   `identitySql`. Plus **global rules** (written once, first):
+   comment, acl, securityLabel, membership — they have no per-kind variants
+   by construction (§3.4).
+2. **Action emission**: deltas × rules → atomic actions, each carrying
+   `produces` / `consumes` / `destroys` fact IDs and the safety metadata.
+   Multi-delta atoms (delta-set rules) for the known cases: `ALTER COLUMN
+   TYPE` (column `set` + dependent invalidation), view replacement chains,
+   procedure signature changes (identity change = remove+add of a
+   signature-keyed fact, but rules may recognize same-name pairs).
+3. **The one graph + sort** (§3.6): edges from old-state deps (teardown:
+   destroyer-of-X after consumers-of-X), new-state deps (build:
+   producer-of-Y before consumers-of-Y), identity conflicts (remove `X`
+   before add `X`). Deterministic Kahn with a binary-heap ready queue;
+   tie-break: kind weight (mine pg_dump's section ordering and the old
+   `custom-constraints.ts` + pg-topo's `STATEMENT_CLASS_WEIGHT` for the
+   initial table) → canonical ID. **Cycle = throw with the full
+   edge-path diagnostic.** There is no breaker module to write (guardrail 4).
+4. **Compaction** (§3.6): merge adjacent actions into idiomatic compound
+   DDL only when no graph edge crosses the merge. Start with the two merges
+   that matter for readability: column definitions into `CREATE TABLE`, and
+   NOT NULL/defaults into column clauses. Everything else can stay
+   decomposed until someone complains — compaction can improve forever
+   without correctness risk.
+5. **Plan rendering**: every action renders one SQL statement. Mine the old
+   serializers (`changes/*.ts` templates, `table.alter.ts`'s ~25 variants)
+   for the SQL-shape knowledge — port the *strings*, not the class
+   structure.
+
+## Recommended PR sequence (each lands corpus-greens, flips `EXPECTED_RED` entries)
+
+1. **Skeleton + global metadata rules** — comment/acl/label/membership
+   over any kind whose create/drop exists; prove on trivial scenarios.
+2. **Bootstrap kinds**: schema, role, extension (+ provenance-aware
+   behavior), language. Simple creates/drops/alters; exercises the graph
+   end-to-end.
+3. **The relation core**: table, column, constraint, default, index,
+   sequence. This PR (or PR series) is the heart — decomposed emission
+   means `CREATE TABLE` bare + per-column/constraint actions, FK actions
+   always separate. The old cycle-breaker scenarios in the corpus
+   (dropped-table FK cycles, publication-column cycles) must sort
+   **cycle-free by construction** here; if one cycles, the emission isn't
+   decomposed enough — fix emission, never add repair.
+4. **Routine kinds**: procedure/function (signature identity), aggregate,
+   trigger, rule, policy. `check_function_bodies = off` as a plan session
+   setting (port from old `create.ts:350`).
+5. **View family**: view, materialized view — replacement chains via
+   delta-set rules; dependent rebuild ordering comes from edges, verify
+   against the corpus's policy/view recreation scenarios.
+6. **The long tail**: domain, collation, types (enum/composite/range),
+   publication, subscription, FDW family, event trigger.
+7. **Compaction pass** last — it's cosmetic; prove output stability
+   (compaction never changes proof results, asserted by running the corpus
+   both ways).
+
+## Mining map (old → new)
+
+| Old location | What to extract |
+|---|---|
+| `objects/*/changes/*.ts` | SQL templates per action |
+| `objects/*/*.diff.ts` | conditional knowledge: when ALTER vs replace (e.g. `table.diff.ts` constraint mutation logic) → `attributes` rules |
+| `expand-replace-dependencies.ts` | the replacement-closure semantics → delta-set rules + edges |
+| `post-diff-normalization.ts` | each pass encodes an implicit-cascade fact → `implicitlyRemoves` entries |
+| `sort/cycle-breakers.ts` | each breaker is a corpus scenario that must now be unconstructible — verification targets, not code to port |
+| `sort/custom-constraints.ts`, pg-topo `topo-sort.ts` weights | initial kind-weight table |
+| `plan/risk.ts` | data-loss classification seed |
+
+## What to look for (pitfalls)
+
+- **Rule-vocabulary creep toward code.** The moment a rule wants a 50-line
+  function, stop: either the payload is mis-shaped (stage 2 fix), the case
+  needs a named sub-rule form (extend the vocabulary, log the decision), or
+  it's two rules. Guardrail 3 is absolute.
+- **Differential triage discipline.** Old and new engines will diverge
+  constantly at first. Every divergence gets bucketed (`new-bug` /
+  `old-bug` / `accepted-difference`) with a reason — accepted-differences
+  become release-notes material for stage 10; old-bugs become new corpus
+  scenarios.
+- **Identity conflicts beyond names**: remove+add of the *same* ID is a
+  replace (order: remove first); remove+add where only the signature
+  differs (procedures) needs the delta-set rule, or you'll emit
+  collision-prone CREATE before DROP.
+- **Don't optimize the graph build.** O(deltas) construction over indexed
+  edges falls out naturally here — the old engine's O(catalog) scan was a
+  consequence of its shape, not something to "fix" again.
+- **Minimality assertions**: as kinds land, add `expect.actions` /
+  `maxActions` to the corpus scenarios where drop+create-instead-of-alter
+  would be silent (the proof can't see non-minimality — §3.7).
+
+## Gate
+
+- Corpus fully green under proof (state + data preservation) on all PG
+  versions — `EXPECTED_RED` is empty for engine tests.
+- Differential vs old engine: zero untriaged divergences.
+- Generative soak: an agreed run-count (e.g. 10k generated roundtrips)
+  with zero proof failures and zero cycles.
+- Zero cycle errors across corpus + soak (guardrail 4 holds with no
+  exceptions needed).

--- a/docs/stage-06-execution.md
+++ b/docs/stage-06-execution.md
@@ -1,0 +1,78 @@
+# Stage 6: Execution + Plan Artifact v1
+
+> Part of the [north-star architecture](./target-architecture.md) (§3.7–3.8).
+> Depends on: stage 5. Gate: end-to-end proof on the corpus including
+> segmented non-transactional actions.
+
+## Goal
+
+Plans become durable artifacts and applies become lock-aware, segmented,
+attributable executions. Also closes the stage-3 stub: render-from-fact-base
+materialization (`plan(∅ → fb)` applied to an empty scratch) now works,
+enabling proof against live sources.
+
+## Deliverables
+
+1. **Plan artifact v1** (version-tagged JSON):
+   `{formatVersion: 1, engineVersion, source: {fingerprint}, target:
+   {fingerprint}, deltas: [...], actions: [{sql, produces, consumes,
+   destroys, lockClass, rewriteRisk, dataLoss, transactional}],
+   safetyReport, policyId?}`. Fingerprints are fact-base rollup digests
+   (stage 1). Round-trips losslessly; `apply` accepts the artifact, never
+   a bare SQL list.
+2. **Segmented executor**: group maximal runs of `transactional: true`
+   actions into transactions; isolate non-transactional actions
+   (`CREATE INDEX CONCURRENTLY`, `ALTER SYSTEM`, certain
+   `ALTER TYPE … ADD VALUE` cases) between them with explicit failure
+   semantics: on mid-plan failure, report exactly which actions are
+   applied/unapplied/in-doubt. Per-statement error attribution (statement,
+   action, underlying PG error) — no joined-string megaqueries.
+3. **Fingerprint gate on apply**: source fingerprint must match the live
+   target's current fact-base digest (re-extract before apply);
+   `--force`-style override is a CLI concern, not a library default.
+   Post-apply verification is `provePlan`'s job and is **opt-in**.
+4. **Render-from-fact-base materialization** wired into the harness
+   (replaces the stage-3 stub); the §3.7 live-source proof path is now
+   real. Add corpus runs that prove via this path to catch render gaps.
+5. **Session preamble** as explicit plan metadata (e.g.
+   `check_function_bodies = off`), not loose SQL statements mixed into the
+   action list.
+
+## How to proceed
+
+1. Artifact schema + round-trip tests (pure).
+2. Executor against hand-built plans with deliberate mid-plan failures —
+   assert the applied/unapplied/in-doubt report before wiring real plans.
+3. Transactionality metadata: seed the static table from PostgreSQL docs
+   (which DDL cannot run in a transaction block); every entry needs a
+   corpus or unit scenario exercising it.
+4. Wire `apply` + fingerprint gate; flip the remaining harness paths to
+   consume artifacts.
+5. Render-from-fact-base: implement as `plan(emptyFactBase, fb)` through
+   the stage-5 planner; the fidelity gate is extract → render-materialize →
+   re-extract hash-identical across the corpus (this also doubles as a
+   brutal planner test — every extractable state must be constructible).
+
+## What to look for (pitfalls)
+
+- **The in-doubt window.** A failure between segments leaves a partially
+  applied plan; the report must distinguish it from a clean rollback.
+  Resumability (re-plan from current state) is the answer — document it;
+  don't build resume-from-statement bookkeeping.
+- **Render-materialization completeness** will lag (some states require
+  context the planner doesn't render yet — e.g. role passwords extract as
+  hashes). Maintain an explicit skip-list surfaced in proof output, same
+  policy as auto-seed skips.
+- **Lock-class honesty**: the executor doesn't *enforce* lock claims; it
+  reports them. Verification is stage-3's relfilenode check plus the vetted
+  static table (§3.7) — resist inventing runtime lock introspection here.
+
+## Gate
+
+- Corpus green end-to-end through artifacts (plan → serialize →
+  deserialize → apply → prove).
+- Segmentation demonstrated: corpus includes at least one
+  `CREATE INDEX CONCURRENTLY` scenario applying correctly.
+- Mid-plan failure reporting covered by negative tests.
+- Render-from-fact-base fidelity green across the corpus (modulo the
+  explicit skip-list).

--- a/docs/stage-06-execution.md
+++ b/docs/stage-06-execution.md
@@ -17,9 +17,12 @@ enabling proof against live sources.
    `{formatVersion: 1, engineVersion, source: {fingerprint}, target:
    {fingerprint}, deltas: [...], actions: [{sql, produces, consumes,
    destroys, lockClass, rewriteRisk, dataLoss, transactional}],
-   safetyReport, policyId?}`. Fingerprints are fact-base rollup digests
-   (stage 1). Round-trips losslessly; `apply` accepts the artifact, never
-   a bare SQL list.
+   safetyReport, policy?}` — `policy` carries the id *and* inline rules for
+   reproducibility (§3.9/stage 8). Fingerprints are fact-base rollup
+   digests (stage 1). Round-trips losslessly; `apply` accepts the artifact,
+   never a bare SQL list, and **rejects an artifact whose
+   `formatVersion`/`engineVersion` it does not understand** — the same
+   check stage 7 applies to snapshots.
 2. **Segmented executor.** Transactionality is three-valued, declared per
    action by the rule table:
    - `transactional` — the default; grouped into maximal transaction runs.
@@ -83,7 +86,8 @@ enabling proof against live sources.
   policy as auto-seed skips.
 - **Lock-class honesty**: the executor doesn't *enforce* lock claims; it
   reports them. Verification is stage-3's relfilenode check plus the vetted
-  static table (§3.7) — resist inventing runtime lock introspection here.
+  static table **built in stage 5** (§3.7) — this stage consumes that
+  table; resist inventing runtime lock introspection here.
 
 ## Gate
 

--- a/docs/stage-06-execution.md
+++ b/docs/stage-06-execution.md
@@ -20,13 +20,31 @@ enabling proof against live sources.
    safetyReport, policyId?}`. Fingerprints are fact-base rollup digests
    (stage 1). Round-trips losslessly; `apply` accepts the artifact, never
    a bare SQL list.
-2. **Segmented executor**: group maximal runs of `transactional: true`
-   actions into transactions; isolate non-transactional actions
-   (`CREATE INDEX CONCURRENTLY`, `ALTER SYSTEM`, certain
-   `ALTER TYPE … ADD VALUE` cases) between them with explicit failure
-   semantics: on mid-plan failure, report exactly which actions are
+2. **Segmented executor.** Transactionality is three-valued, declared per
+   action by the rule table:
+   - `transactional` — the default; grouped into maximal transaction runs.
+   - `nonTransactional` — cannot run inside a transaction block at all:
+     `CREATE INDEX CONCURRENTLY`, `REINDEX CONCURRENTLY`,
+     `ALTER TABLE … DETACH PARTITION CONCURRENTLY`, `ALTER SYSTEM`,
+     `CREATE`/`DROP DATABASE`/`TABLESPACE`, subscription operations that
+     create/drop replication slots. Executed alone, between transaction
+     segments.
+   - `commitBoundaryAfter` — *runs* in a transaction but its effect is not
+     usable until commit: the canonical case is `ALTER TYPE … ADD VALUE`,
+     whose new enum value cannot be referenced later in the same
+     transaction. The executor forces a segment boundary between the
+     action and any consumer of what it produced (the dependency edges
+     already say who consumes it).
+
+   Segmentation changes **transaction boundaries only, never order** — the
+   topological order is global across segments. Failure semantics are
+   explicit: on mid-plan failure, report exactly which actions are
    applied/unapplied/in-doubt. Per-statement error attribution (statement,
-   action, underlying PG error) — no joined-string megaqueries.
+   action, underlying PG error) — no joined-string megaqueries. Executor
+   *options* (operational policy, not safety metadata): per-segment
+   `lock_timeout` / `statement_timeout`, and optional
+   retry-on-lock-timeout for actions whose declared lock class is
+   contention-prone.
 3. **Fingerprint gate on apply**: source fingerprint must match the live
    target's current fact-base digest (re-extract before apply);
    `--force`-style override is a CLI concern, not a library default.

--- a/docs/stage-07-frontends.md
+++ b/docs/stage-07-frontends.md
@@ -47,6 +47,15 @@ pg-topo's production role are *replaced*, not ported.
 
 ## What to look for (pitfalls)
 
+- **Some inputs are unorderable in principle.** Two `CREATE TABLE`
+  statements with mutual *inline* FK clauses converge under no permutation
+  and no number of retry rounds — the user must split one FK into a
+  separate `ALTER TABLE … ADD CONSTRAINT`. The stuck-statement error for
+  this case should say exactly that (and the dev layer can suggest the
+  split). The ordering contract is **convergence or loud failure, never
+  silent wrongness** — reordering can never change what the SQL means,
+  because Postgres elaborates every statement. Add a corpus scenario for
+  the mutual-FK case asserting the diagnostic.
 - **Don't resurrect the retry engine as a production path.** The bounded
   rounds run against the throwaway shadow only. The plan that eventually
   touches a live target comes from the planner; the loader's job ends at a

--- a/docs/stage-07-frontends.md
+++ b/docs/stage-07-frontends.md
@@ -13,8 +13,9 @@ pg-topo's production role are *replaced*, not ported.
 
 ## Deliverables
 
-1. **`loadSqlFiles(roots, shadowTarget): FactBase`** with the four
-   obligations from §3.2, in execution order:
+1. **`loadSqlFiles(roots, shadowTarget): FactBase`** — six steps in
+   execution order (the four §3.2 shadow-loader obligations, bracketed by
+   discovery and extraction):
    1. *Discovery*: deterministic file enumeration (lexicographic, like
       migration tools — document the contract).
    2. *Loading with fail-safe ordering*: apply statements; on dependency
@@ -71,6 +72,11 @@ pg-topo's production role are *replaced*, not ported.
 - **Extensions in shadow**: files with `CREATE EXTENSION` need the
   extension available in the shadow image. Surface a clear error;
   the corpus's `requires` tags already model image needs.
+- **The shadow executes arbitrary user SQL.** Treat it as such: the shadow
+  must never share a cluster with anything valuable, its credentials must
+  not open anything beyond itself, and `isolatedCluster` mode is the only
+  safe home for files that touch shared objects. This is a trust boundary,
+  not just a hygiene rule.
 
 ## Gate
 

--- a/docs/stage-07-frontends.md
+++ b/docs/stage-07-frontends.md
@@ -1,0 +1,72 @@
+# Stage 7: Frontends (shadow-DB SQL loader · snapshots)
+
+> Part of the [north-star architecture](./target-architecture.md) (§3.2).
+> Depends on: stages 2, 6. Gate: declarative scenarios in the corpus;
+> loader rejection tests.
+
+## Goal
+
+The declarative workflow lands: SQL files become a fact base via a shadow
+database, then flow through the exact same diff/plan/proof path as
+everything else. This is the stage where the old round-apply engine and
+pg-topo's production role are *replaced*, not ported.
+
+## Deliverables
+
+1. **`loadSqlFiles(roots, shadowTarget): FactBase`** with the four
+   obligations from §3.2, in execution order:
+   1. *Discovery*: deterministic file enumeration (lexicographic, like
+      migration tools — document the contract).
+   2. *Loading with fail-safe ordering*: apply statements; on dependency
+      errors, defer and retry in bounded rounds **against the shadow**
+      (port the round mechanics from the old
+      `declarative-apply/round-apply.ts` — they are correct for this; what
+      was wrong was using them against live targets). Optionally pre-sort
+      via the dev layer when available. Exhausted rounds → structured error
+      listing stuck statements and their PG errors; nothing extracted.
+   3. *Shared-object isolation*: snapshot `pg_roles`/`pg_auth_members`
+      before loading; if loading changed them and the shadow is not an
+      isolated cluster, fail with the §3.2 explanation. Loader config
+      declares which mode it's in (`databaseScratch` vs `isolatedCluster`);
+      the corpus covers both.
+   4. *Body re-validation*: loading ran with `check_function_bodies = off`;
+      re-validate routine bodies with checks on (port the validation pass
+      semantics from `round-apply.ts:445-448`). Failures are loader errors,
+      not facts.
+   5. *DML rejection*: after loading, any user table containing rows →
+      structured error naming the tables. Parser-free by design.
+   6. *Extraction*: the stage-2 extractor against the shadow; returned fact
+      base is tagged with provenance (`source: sqlFiles`).
+2. **Snapshot frontend**: `loadSnapshot(path): FactBase` — deserialize +
+   format-version check + digest re-verification (a corrupted snapshot must
+   not silently plan).
+3. **Corpus additions**: declarative scenarios — out-of-order files,
+   a typo'd function body (must be rejected), a role-creating file in
+   database-scratch mode (must be rejected), an `INSERT`-bearing file (must
+   be rejected), and the happy path against a real schema.
+
+## What to look for (pitfalls)
+
+- **Don't resurrect the retry engine as a production path.** The bounded
+  rounds run against the throwaway shadow only. The plan that eventually
+  touches a live target comes from the planner; the loader's job ends at a
+  fact base.
+- **Shadow provisioning** belongs to the caller (CLI/harness): a template
+  database, a container, or a user-supplied scratch URL. The loader
+  *verifies* emptiness before loading (non-empty shadow → error) rather
+  than provisioning.
+- **Sequences and identity columns** hold non-initial values after DDL with
+  defaults — the DML check is "rows in tables", not "sequence state";
+  document that sequence `last_value` is not desired state (matches old
+  behavior).
+- **Extensions in shadow**: files with `CREATE EXTENSION` need the
+  extension available in the shadow image. Surface a clear error;
+  the corpus's `requires` tags already model image needs.
+
+## Gate
+
+- Declarative corpus scenarios green end-to-end (files → shadow → fact
+  base → plan → proof).
+- All four rejection behaviors covered by negative tests.
+- Out-of-order file scenario converges via bounded rounds.
+- Snapshot frontend round-trip + corruption test green.

--- a/docs/stage-08-policy.md
+++ b/docs/stage-08-policy.md
@@ -1,0 +1,74 @@
+# Stage 8: Policy Layer (DSL v2 + Supabase package)
+
+> Part of the [north-star architecture](./target-architecture.md) (§3.9).
+> Depends on: stages 4–6 (deltas and plans exist). Gate: policy scenarios;
+> baseline-subtraction proof against a real platform image.
+
+## Goal
+
+Vendor behavior as data: filtering (which deltas a user sees), serialization
+parameters (how actions render), and platform baselines (what "empty" means
+on a managed platform). Designed fresh for facts/deltas — the old DSL's
+pattern syntax is not carried (decision log f); its evaluation model
+(declarative rules, first-match-wins) is.
+
+## Deliverables
+
+1. **DSL v2.** Typed predicates over: fact kind, identity fields (schema,
+   name — with glob/regex matchers), delta verb, provenance (edge
+   predicates: `memberOfExtension`, ownership), and parent context.
+   Combinators: `all` / `any` / `not`. A policy =
+   `{filter?: Rule[], serialize?: Rule[], baseline?: SnapshotRef,
+   extends?: PolicyRef[]}` — rules first-match-wins, `extends` composition
+   with cycle detection (port the semantics, not the code, from the old
+   `integration-dsl.ts`).
+2. **Filter semantics**: filtering removes *deltas* before planning — the
+   engine extracted everything (stage 2's no-filter doctrine); policy
+   decides visibility. Filtered deltas are reported (counted, listable),
+   never silently absent — drift the user chose not to manage is still
+   drift they can ask about.
+3. **Serialize parameterization**: named parameters consumed by rule
+   templates (the `skipAuthorization` class of options). Parameters are
+   declared by the rule table (stage 5) so a policy referencing an unknown
+   parameter is a compile error, not a silent no-op.
+4. **Baseline subtraction**: `applyBaseline(fb, baselineSnapshot)` — facts
+   present-and-identical in the baseline are dropped from both sides before
+   diffing. The baseline is a stage-1 snapshot, version-tagged, regenerated
+   by script (port the *workflow* of the old `sync-base-images` script:
+   bare image vs fully-provisioned instance, extract, save).
+5. **The Supabase policy package** — the first consumer and the proof the
+   DSL suffices: port every rule from the old `supabase.ts` (schema/role
+   exclusion lists, skip-authorization rules, extension suppression) into
+   DSL v2, plus the platform baseline snapshot per supported PG version.
+   Maintain a mapping table old-rule → new-rule in the package so reviewers
+   can audit completeness.
+6. **Corpus additions**: policy scenarios — managed-schema changes
+   invisible under the Supabase policy but visible without it; provenance
+   filtering (extension-owned objects); baseline subtraction proven against
+   the real Supabase image (extract image, apply baseline, plan against a
+   user schema, prove).
+
+## What to look for (pitfalls)
+
+- **Predicate power creep.** If a Supabase rule can't be expressed, extend
+  the predicate vocabulary deliberately (and log it) — do not add a
+  function-valued escape hatch to the DSL; policies must stay serializable
+  data (they ship inside plan artifacts as `policyId` + inline policy for
+  reproducibility).
+- **Filtering vs correctness.** A filtered delta can be a dependency of an
+  unfiltered action (user table referencing a filtered-out role). The
+  planner must fail loudly on a dangling requirement introduced by policy —
+  a policy-induced hole is a user-facing error ("your filter excludes role
+  X required by table Y"), not a silent edge drop.
+- **Baseline drift.** Platform images change; a stale baseline shows up as
+  phantom deltas. The baseline snapshot embeds the image tag it came from;
+  the policy scenario in CI regenerates against the pinned tag so drift is
+  caught when the pin moves, not in production.
+
+## Gate
+
+- DSL v2 unit suite (predicates, composition, first-match-wins, extends
+  cycles).
+- Supabase policy package: mapping table complete; policy scenarios green,
+  including the real-image baseline-subtraction proof.
+- Dangling-requirement detection covered by a negative test.

--- a/docs/stage-08-policy.md
+++ b/docs/stage-08-policy.md
@@ -34,8 +34,11 @@ pattern syntax is not carried (decision log f); its evaluation model
 4. **Baseline subtraction**: `applyBaseline(fb, baselineSnapshot)` — facts
    present-and-identical in the baseline are dropped from both sides before
    diffing. The baseline is a stage-1 snapshot, version-tagged, regenerated
-   by script (port the *workflow* of the old `sync-base-images` script:
-   bare image vs fully-provisioned instance, extract, save).
+   by script — port the *workflow* of the old
+   `packages/pg-delta/scripts/sync-supabase-base-images.ts` (bare image vs
+   fully-provisioned instance, extract, save) and mine
+   `update-empty-catalog-baseline.ts` for the empty-catalog baseline this
+   mechanism replaces.
 5. **The Supabase policy package** — the first consumer and the proof the
    DSL suffices: port every rule from the old `supabase.ts` (schema/role
    exclusion lists, skip-authorization rules, extension suppression) into
@@ -57,9 +60,10 @@ pattern syntax is not carried (decision log f); its evaluation model
   reproducibility).
 - **Filtering vs correctness.** A filtered delta can be a dependency of an
   unfiltered action (user table referencing a filtered-out role). The
-  planner must fail loudly on a dangling requirement introduced by policy —
-  a policy-induced hole is a user-facing error ("your filter excludes role
-  X required by table Y"), not a silent edge drop.
+  *check* for this already exists — stage 5's graph build fails loudly on
+  any missing requirement (its deliverable 6); this stage's job is the
+  policy-shaped negative test and the user-facing message ("your filter
+  excludes role X required by table Y"), not a new mechanism.
 - **Baseline drift.** Platform images change; a stale baseline shows up as
   phantom deltas. The baseline snapshot embeds the image tag it came from;
   the policy scenario in CI regenerates against the pinned tag so drift is

--- a/docs/stage-09-renames-api.md
+++ b/docs/stage-09-renames-api.md
@@ -1,8 +1,10 @@
 # Stage 9: Renames + Public API & CLI
 
-> Part of the [north-star architecture](./target-architecture.md) (§4.1, §4.5).
-> Depends on: stages 5–6 (planner, artifacts); stage 1 designed the
-> structural rollup this stage uses. Gate: rename corpus; API review.
+> Part of the [north-star architecture](./target-architecture.md) (§4.1,
+> §4.2, §4.5). Depends on: stages 5–7 (planner, artifacts; stage 7's
+> `loadSqlFiles` is what the export round-trip gate runs through); stage 1
+> designed the structural rollup this stage uses. Gate: rename corpus;
+> export round-trip; API review.
 
 ## Goal
 
@@ -65,11 +67,20 @@ CLI — that consumers will actually touch.
    gains round-trip scenarios asserting exactly that, which closes the
    declarative loop: export → hand-edit → apply is the same proof-covered
    path in both directions.
-7. **CLI v2**, a thin consumer of the public API: `plan`, `apply`, `prove`,
-   `diff`, `schema export` (fact base → declarative files via renderer),
-   `schema apply` (files → shadow → plan → apply). Interactive rename
-   prompts; policy selection by name/path; plan artifacts as files. The
-   old CLI's command vocabulary is a reference, not a contract.
+7. **Drift detection, surfaced.** The §4.2 capability is a rollup-hash walk
+   the engine already does — this stage makes it a product feature:
+   `diff(extract(env), loadSnapshot(pinned))` exposed as a CLI verb
+   (`pgdelta drift <env> <snapshot>`) reporting changed/added/removed facts.
+   Without this deliverable the capability silently dies in the engine.
+8. **CLI v2**, a thin consumer of the public API: `plan`, `apply`, `prove`,
+   `diff`, `drift`, `schema export` (fact base → declarative files via
+   renderer), `schema apply` (files → shadow → plan → apply), `snapshot`
+   (fact base → file; replaces the old `catalog-export`). Interactive
+   rename prompts; policy selection by name/path; plan artifacts as files.
+   The old CLI's command vocabulary is a reference, not a contract — the
+   mapping table must cover all six old commands explicitly, including
+   `sync` (→ `plan` + `apply` in one invocation) and `catalog-export`
+   (→ `snapshot`).
 
 ## What to look for (pitfalls)
 
@@ -92,5 +103,7 @@ CLI — that consumers will actually touch.
   schemas (and the exported tree loads with zero deferred rounds — exports
   are emitted pre-ordered).
 - API review completed and recorded (a checklist in the PR, name by name).
-- CLI v2 covers the old CLI's workflows (mapping table old command → new),
-  demonstrated against the corpus's happy-path scenarios.
+- Drift verb demonstrated: a mutated environment vs a pinned snapshot
+  reports exactly the mutated facts.
+- CLI v2 covers the old CLI's workflows (mapping table covering all six
+  old commands), demonstrated against the corpus's happy-path scenarios.

--- a/docs/stage-09-renames-api.md
+++ b/docs/stage-09-renames-api.md
@@ -1,0 +1,84 @@
+# Stage 9: Renames + Public API & CLI
+
+> Part of the [north-star architecture](./target-architecture.md) (§4.1, §4.5).
+> Depends on: stages 5–6 (planner, artifacts); stage 1 designed the
+> structural rollup this stage uses. Gate: rename corpus; API review.
+
+## Goal
+
+The visible payoff stage: rename detection (the data-preserving feature no
+comparable tool ships) and the finalized public surface — library API and
+CLI — that consumers will actually touch.
+
+## Deliverables — renames
+
+1. **Candidate matching.** Over the diff's `remove`/`add` pairs:
+   - *Leaf renames*: same payload hash + same parent + same kind, different
+     name → candidate (`ALTER … RENAME`). Columns are the prize — they're
+     the case that destroys data in practice.
+   - *Container renames*: same **structural rollup** (the identity-free
+     fold from stage 1) + same kind → candidate; the rename rewrites the
+     whole subtree's IDs without emitting subtree actions.
+   - Ambiguity (n removed candidates × m added with equal hashes): never
+     guess — group them in the verdict for the policy to resolve.
+2. **Policy gate**: `renames: "auto" | "prompt" | "off"` on plan creation.
+   `auto` applies only unambiguous candidates; `prompt` surfaces candidates
+   in the plan artifact as questions (CLI renders them interactively;
+   library callers answer programmatically); `off` preserves drop+create.
+   Default: `prompt` in the CLI, `off` in the library (legibility for
+   programmatic consumers; revisit after field experience).
+3. **Proof integration**: a rename action must pass data preservation
+   trivially (the rows survive *because* it's a rename) — corpus scenarios
+   assert both the rename emission (`expect.actions`) and seeded-row
+   survival, plus the degradation case (hash-unequal "rename" stays
+   drop+create with `dataLoss` honestly reported).
+4. **Known limits, documented in output**: payloads referencing other
+   objects by name (FK constraints naming the renamed table) break
+   transitive hash equality (§4.1) — candidates degrade to drop+create,
+   never the reverse; the verdict says why when a near-miss occurred
+   (same structural rollup except name-bearing payloads).
+
+## Deliverables — API & CLI
+
+5. **Public API finalized** around the layers, each independently usable:
+
+   ```text
+   extract(pool | url, opts)          -> FactBase
+   loadSqlFiles(roots, shadow)        -> FactBase        (stage 7)
+   loadSnapshot(path)                 -> FactBase
+   diff(a, b)                         -> Delta[]
+   plan(a, b, {policy?, renames?})    -> Plan             (artifact, stage 6)
+   provePlan(plan, source, desired)   -> ProofVerdict
+   apply(plan, target, opts)          -> ApplyReport
+   ```
+
+   Subpath exports per layer; the root is a facade over the common path.
+   API review = a written pass over every exported name/type against the
+   architecture doc's vocabulary (facts, deltas, actions, proof — no legacy
+   terms like "catalog"/"changes" leaking through).
+6. **CLI v2**, a thin consumer of the public API: `plan`, `apply`, `prove`,
+   `diff`, `schema export` (fact base → declarative files via renderer),
+   `schema apply` (files → shadow → plan → apply). Interactive rename
+   prompts; policy selection by name/path; plan artifacts as files. The
+   old CLI's command vocabulary is a reference, not a contract.
+
+## What to look for (pitfalls)
+
+- **Rename vs replace identity collisions**: a rename candidate whose
+  target name also exists in the source is a swap/chain — out of scope for
+  `auto` (force prompt); cover with a corpus scenario so it can't sneak
+  into auto.
+- **Renames × policy filtering** (stage 8): a candidate where one side is
+  policy-filtered must not surface — match after filtering.
+- **API stability budget**: this is the last stage before cutover freezes
+  v1 of the surface; anything exported here is a multi-year commitment.
+  When in doubt, don't export.
+
+## Gate
+
+- Rename corpus green: leaf rename, container rename, ambiguous pair
+  (prompt), near-miss degradation, swap case, seeded-row survival on every
+  auto rename.
+- API review completed and recorded (a checklist in the PR, name by name).
+- CLI v2 covers the old CLI's workflows (mapping table old command → new),
+  demonstrated against the corpus's happy-path scenarios.

--- a/docs/stage-09-renames-api.md
+++ b/docs/stage-09-renames-api.md
@@ -56,7 +56,16 @@ CLI — that consumers will actually touch.
    API review = a written pass over every exported name/type against the
    architecture doc's vocabulary (facts, deltas, actions, proof — no legacy
    terms like "catalog"/"changes" leaking through).
-6. **CLI v2**, a thin consumer of the public API: `plan`, `apply`, `prove`,
+6. **Declarative export** — `exportSqlFiles(fb, mapping): FileTree`: render
+   the fact base via the stage-6 renderer and split the statements across
+   files by a mapping policy (kind/schema-driven paths — mine the old
+   `export/file-mapper.ts` for the layout users already know). Export
+   fidelity is provable, not aspirational:
+   `loadSqlFiles(exportSqlFiles(fb)) ≡ fb` hash-identically — the corpus
+   gains round-trip scenarios asserting exactly that, which closes the
+   declarative loop: export → hand-edit → apply is the same proof-covered
+   path in both directions.
+7. **CLI v2**, a thin consumer of the public API: `plan`, `apply`, `prove`,
    `diff`, `schema export` (fact base → declarative files via renderer),
    `schema apply` (files → shadow → plan → apply). Interactive rename
    prompts; policy selection by name/path; plan artifacts as files. The
@@ -79,6 +88,9 @@ CLI — that consumers will actually touch.
 - Rename corpus green: leaf rename, container rename, ambiguous pair
   (prompt), near-miss degradation, swap case, seeded-row survival on every
   auto rename.
+- Export round-trip green: `load(export(fb)) ≡ fb` over the corpus's
+  schemas (and the exported tree loads with zero deferred rounds — exports
+  are emitted pre-ordered).
 - API review completed and recorded (a checklist in the PR, name by name).
 - CLI v2 covers the old CLI's workflows (mapping table old command → new),
   demonstrated against the corpus's happy-path scenarios.

--- a/docs/stage-10-cutover.md
+++ b/docs/stage-10-cutover.md
@@ -19,11 +19,13 @@ gathering and a decision.
    corpus scenario.
 3. **Generative soak**: the agreed quota (set it now — e.g. a sustained
    CI-week of roundtrips at ≥10k schemas) with zero proof failures, zero
-   cycles, zero crashes.
+   cycles, zero crashes — **and the generator's kind-coverage checklist
+   complete** (stage 5 grew it per kind-batch PR); a soak from a
+   three-kind generator satisfies nothing.
 4. **Extractor ring**: green on all supported PG versions; `COVERAGE.md`
    per kind has no untriaged gaps; pg_dump observer green.
-5. **Performance**: the benchmark fixture (≥10k objects — build it during
-   stage 5 if it doesn't exist yet) shows the new engine ≥ old engine on
+5. **Performance**: the benchmark fixture and timing harness (built in
+   stage 5, running in CI since) show the new engine ≥ old engine on
    extract, diff, plan wall-time; publish the numbers.
 6. **Real-world shakedown**: the Supabase policy scenarios against current
    production image tags, plus at least one large real schema (anonymized

--- a/docs/stage-10-cutover.md
+++ b/docs/stage-10-cutover.md
@@ -1,0 +1,69 @@
+# Stage 10: Cutover at the Parity Bar
+
+> Part of the [north-star architecture](./target-architecture.md) (§9).
+> Depends on: everything. Gate: the parity bar itself.
+
+## Goal
+
+The switch: the new library becomes the product, the old one enters
+maintenance. This stage is mostly verification and product mechanics — if
+earlier gates held, there is no engineering cliff here, only evidence
+gathering and a decision.
+
+## The parity bar (all simultaneously true)
+
+1. **Corpus**: 100% green — proof (state + data preservation) across all
+   supported PG versions; `EXPECTED_RED` is empty and deleted.
+2. **Differential**: zero untriaged divergences; every `accepted-difference`
+   has a reason and appears in the migration guide; every `old-bug` has a
+   corpus scenario.
+3. **Generative soak**: the agreed quota (set it now — e.g. a sustained
+   CI-week of roundtrips at ≥10k schemas) with zero proof failures, zero
+   cycles, zero crashes.
+4. **Extractor ring**: green on all supported PG versions; `COVERAGE.md`
+   per kind has no untriaged gaps; pg_dump observer green.
+5. **Performance**: the benchmark fixture (≥10k objects — build it during
+   stage 5 if it doesn't exist yet) shows the new engine ≥ old engine on
+   extract, diff, plan wall-time; publish the numbers.
+6. **Real-world shakedown**: the Supabase policy scenarios against current
+   production image tags, plus at least one large real schema (anonymized
+   dump) through plan + prove.
+
+## Product mechanics
+
+- **Naming**: new major of `@supabase/pg-delta` vs a new package name —
+  product decision recorded in the architecture doc's decision log when
+  made. Either way: the old library's final minor gets a README banner and
+  a `@deprecated` pointer after cutover, not before.
+- **Maintenance policy for the old library**: security and
+  critical-correctness fixes only, for a stated window; no new object-kind
+  support after cutover (new PG versions are the new library's job).
+- **Migration guide** (write from the artifacts already accumulated):
+  API mapping (old call → new call), plan-artifact format differences,
+  output-shape changes (decomposed-by-default + compaction; the
+  accepted-differences list), policy DSL v1 → v2 cookbook (the stage-8
+  mapping table), snapshot regeneration instructions.
+- **Repo mechanics**: the new package leaves its `pg-delta-next`
+  placeholder name; CI matrices consolidate (the corpus suite replaces the
+  45-job matrix as the primary gate; the old suite keeps running only as
+  long as the old library is maintained); changesets configured for the
+  new package's release line.
+
+## What to look for (pitfalls)
+
+- **The bar is a conjunction.** Pressure will exist to cut over at "corpus
+  green, soak mostly done." The bar is cheap to state and expensive to
+  regret; hold it (guardrail 7).
+- **Consumer surprise area #1 is output shape.** The accepted-differences
+  list and the compaction defaults deserve more migration-guide space than
+  the API mapping — programmatic consumers adapt signatures quickly; humans
+  reviewing unfamiliar-looking SQL lose trust slowly.
+- **Don't delete the old engine at cutover.** It stays as the differential
+  oracle in CI until the maintenance window closes — divergences found by
+  *users* post-cutover still need it for adjudication.
+
+## Gate
+
+The parity bar, verified in a single CI run whose summary is attached to
+the cutover PR, plus the migration guide reviewed by someone who didn't
+build the engine.

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -777,8 +777,14 @@ cutover). There are no byte-compatibility gates anywhere — every stage
 ships behind proof-based gates only. Repository discipline (changesets,
 RED→GREEN regressions) applies as usual.
 
+Each stage has a detailed implementation document —
+[stage-00-test-suite.md](./stage-00-test-suite.md) through
+[stage-10-cutover.md](./stage-10-cutover.md) — covering deliverables,
+old-codebase mining maps, pitfalls, and the gate in checkable form.
+
 | # | Stage | Builds | Gate |
 |---|---|---|---|
+| 0 | **The red test suite, first**: scenario corpus ported from the existing integration tests; target API as typed stubs; fixture-validity layer green from day one; engine tests red on `NotImplementedError`, pinned by an explicit list; old-engine baselines captured | §4.3 | Fixture validity green on all PG versions; 100% of old integration files accounted for; every red explained |
 | 1 | Identity codec + fact-base core: typed IDs, identity-free payload hashing, Merkle rollups (facts + edges), snapshot format v1 (version-tagged) | §3.1 | Property tests: codec round-trip, rollup algebra, hash stability |
 | 2 | Extractor port: re-key the extractor SQL corpus to return structured identity parts and fact rows + edges; snapshot-consistent parallel capture | §3.1–3.2 | Extractor fixture ring per PG version; pg_dump observer; content cross-check against old-engine catalogs |
 | 3 | Proof harness + corpus: `provePlan` (state + data-preservation checks, both materialization forms); port the integration scenarios as the seed corpus; stand up the differential runner against the old engine | §3.7, §4.3 | Harness proves extract → materialize → re-extract fidelity over the corpus |
@@ -790,10 +796,14 @@ RED→GREEN regressions) applies as usual.
 | 9 | Renames (leaf + structural-rollup matching, policy-gated); public API and CLI finalized | §4.1, §4.5 | Rename corpus; API review |
 | 10 | **Cutover at the parity bar**: full corpus green; differential clean-or-explained; generative soak quota met; extractor ring green on all supported PG versions. Old library enters maintenance; consumer migration guide ships | — | The parity bar itself |
 
-Stages 1–4 are bottom-up construction with no user-visible surface; 5–6 are
-the engine; 7–9 are the product; 10 is the switch. The old engine is never
-modified beyond what the differential runner needs. Consumers migrate once,
-at cutover, to a new major — there is no in-place compatibility layer.
+Stage 0 builds the definition of done before any engine code exists — the
+corpus is the contract, and "all red" is sound because red is pinned to
+mean *engine missing*, never *fixture broken* (the fixture layer is green
+from day one). Stages 1–4 are bottom-up construction with no user-visible
+surface; 5–6 are the engine; 7–9 are the product; 10 is the switch. The old
+engine is never modified beyond what the differential runner needs.
+Consumers migrate once, at cutover, to a new major — there is no in-place
+compatibility layer.
 
 ## 10. Guardrails for implementers
 
@@ -908,6 +918,13 @@ code.
   replaced by proof/differential/fixture gates; consumers migrate once, at
   the cutover parity bar (§7). Entries (a)–(e) above predate this and any
   in-place-migration framing in them is superseded.
+- **2026-06-12 (g)** — Per-stage implementation documents authored
+  (`docs/stage-00-test-suite.md` … `docs/stage-10-cutover.md`), and the
+  path gained **stage 0** at the maintainer's suggestion: the test suite is
+  built first — corpus ported from the existing integration tests, target
+  API stubs, old-engine baselines — with one refinement: red must mean
+  *engine missing* (pinned `NotImplementedError` list), never *fixture
+  broken* (the fixture-validity layer is green from day one).
 - Open questions intentionally left to their stages: compaction's default
   aggressiveness (stage 5), rename-policy default (stage 9), how
   aggressively to prune the ported corpus once generative coverage matures

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -165,11 +165,21 @@ Five properties define it:
   column points at a fact that *exists*; nothing maps between coarse state
   and fine dependencies, because there is no coarse state.
 - **Content addressing with Merkle rollups.** Every fact hashes its
-  normalized payload; every parent's rollup hash folds its children's. Two
-  consequences: equality at any granularity is one comparison, and diffing
-  is **O(changed)** — subtrees whose rollups match are skipped wholesale.
-  Fingerprints, no-op detection, drift detection, and caching are the same
-  mechanism.
+  normalized payload; every parent's rollup hash folds its children's
+  hashes **and its outgoing edge set**, so edge-only changes (an object
+  gaining or losing extension ownership, a shifted dependency) are visible
+  to hash comparison, not just payload changes. Two consequences: equality
+  at any granularity is one comparison, and diffing is **O(changed)** —
+  subtrees whose rollups match are skipped wholesale. Fingerprints, no-op
+  detection, drift detection, and caching are the same mechanism. Because
+  hash equality is the **sole** equality gate (a deep-compare fallback on
+  matches would reinstate the full-compare cost on the unchanged majority),
+  the digest must be collision-resistant — ≥128 bits over the canonical
+  payload encoding (e.g. BLAKE3 or truncated SHA-256), computed once at
+  extraction where it amortizes into I/O wait. **Hashes are computed over
+  identity-free payloads**: a fact's own name and its parent's name live in
+  its `id`, never in the hashed payload — this is what makes rename
+  detection (§4.1) possible.
 - **Hierarchy is a view, not the storage.** Renderers and the compactor that
   need "a table with its columns and inlineable constraints" *join* facts
   along the parent relation at render time. The document shape exists where
@@ -187,7 +197,16 @@ The payload normalization doctrine carries over from today unchanged
 (logical names instead of physical attnums; canonical `pg_get_*def()` output
 as the comparison form where Postgres provides it): it answers *what we
 know* correctly. The fact model changes *how it is keyed* — which is where
-the current design pays (§8.7).
+the current design pays (§8.7). One sharpening: **which attributes
+participate in equality is itself per-kind knowledge** and lives in the
+payload definition, not in diff logic. Example: extension versions drift
+legitimately across environments, and today's diff deliberately ignores
+them
+([extension.diff.ts:53-62](../packages/pg-delta/src/core/objects/extension/extension.diff.ts))
+even though `version` sits in the equality fields — under the fact model
+that tolerance is declared once, by excluding `version` from the hashed
+payload (or marking its attribute rule a no-op), instead of being
+re-implemented inside an imperative diff.
 
 ### 3.2 Frontends: one elaborator, three doors
 
@@ -201,10 +220,39 @@ the current design pays (§8.7).
   so the catalog and its dependency rows can disagree under concurrent DDL —
   masked by the `unknown:` filter in
   [graph-builder.ts:26-33](../packages/pg-delta/src/core/sort/graph-builder.ts).
-- **SQL files**: applied in a single pass to an ephemeral shadow database
-  (template-cloned; `check_function_bodies = off`), then extracted. The
-  desired state is whatever Postgres actually builds — no fuzzy reference
-  matching, no retry heuristics. This *is* the declarative workflow.
+- **SQL files**: applied to an ephemeral shadow database, then extracted.
+  The desired state is whatever Postgres actually builds — no fuzzy
+  reference matching in the trusted path. This *is* the declarative
+  workflow. Four specifics the shadow loader owns:
+  - **Ordering is best-effort and fail-safe.** Files may not arrive
+    apply-ordered; the loader may pre-sort with the dev-layer static
+    analyzer and/or retry deferred statements in bounded rounds *against
+    the shadow*. This does not violate P1: ordering assistance can only
+    fail to build the shadow — a visible error before anything is
+    extracted — never corrupt the desired state, because Postgres remains
+    the elaborator. (The objection to round-retry was as a *production
+    apply engine* against live targets; on a throwaway shadow it is
+    harmless.)
+  - **Body validation is restored before extraction.** Loading runs with
+    `check_function_bodies = off`; accepting the catalog without
+    re-checking would admit a typo'd routine body into the desired state —
+    and the proof loop would vacuously agree, since it applies the same
+    invalid body. After loading, the loader re-validates routine bodies
+    with checks on — the same final pass the current declarative engine
+    performs
+    ([round-apply.ts:445-448](../packages/pg-delta/src/core/declarative-apply/round-apply.ts)).
+  - **Shared objects need cluster isolation.** Roles and memberships are
+    cluster-level: in a same-cluster scratch database, `CREATE ROLE` leaks
+    out of the shadow and can collide with existing roles. When declarative
+    files manage shared objects, the shadow must be an isolated ephemeral
+    cluster (throwaway instance/container); a same-cluster scratch database
+    is only safe for database-local schemas, and the loader enforces the
+    distinction.
+  - **Data statements are rejected, parser-free.** DML would succeed in the
+    shadow and then silently vanish from the schema-only plan. After
+    loading, the loader checks for observable data — any user table with
+    rows fails the run ("declarative files must not contain data
+    statements"). Detection by effect, not by parsing.
 - **Snapshots**: the serialized fact base round-trips losslessly and is the
   contract for offline diffing, fixtures, and caching. A flat fact relation
   serializes, filters, and streams trivially — properties a nested document
@@ -221,7 +269,9 @@ central data type:
 type Delta =
   | { verb: "add";    fact: Fact }
   | { verb: "remove"; fact: Fact }
-  | { verb: "set";    id: StableId; attr: string; from: unknown; to: unknown };
+  | { verb: "set";    id: StableId; attr: string; from: unknown; to: unknown }
+  | { verb: "link";   edge: DependencyEdge }    // edge-only changes are deltas too:
+  | { verb: "unlink"; edge: DependencyEdge };   // provenance/ownership shifts (§3.9)
 ```
 
 **Zero per-type diff code — structurally, not aspirationally.** The differ
@@ -354,9 +404,20 @@ machinery as equality — + the safety report aggregated from per-action
 metadata (locks, rewrites, data loss).
 
 **The proof loop is the architecture's keystone.** Because any state can be
-materialized (template-cloned scratch DB) and re-extracted, the planner can
-certify its own output. The proof has two checks, because schema convergence
-alone has a blind spot:
+materialized and re-extracted, the planner can certify its own output.
+Materialization has two forms: **template-cloning** (a cheap file copy —
+right for CI, scratch sources, and quiesced databases) and **re-creation
+from the extracted fact base** (render the fact base to DDL and apply it to
+an empty scratch). The second form exists because
+`CREATE DATABASE … TEMPLATE` requires the template database to have no
+other active connections — unavailable against a live production source.
+Proof against live targets therefore clones the *model* of the source, not
+its files; what that certifies is "the plan correctly transforms the state
+as extracted," which is the exact claim the proof makes anyway (extractor
+blind spots are a separate risk with a separate defense, §4.3).
+
+The proof has two checks, because schema convergence alone has a blind
+spot:
 
 1. **State proof.** Apply the plan to a clone of the source, extract,
    hash-compare against the desired fact base. Zero diff = the plan produces
@@ -365,8 +426,8 @@ alone has a blind spot:
    altering it converges to an *identical schema* — and destroys every row.
    State proof cannot see this. So the clone is seeded with rows before
    applying, and the proof asserts they survive wherever the plan claims
-   `dataLoss: none`. The safety report stops being a report and becomes a
-   **verified claim**.
+   `dataLoss: none`. The data-loss column of the safety report stops being
+   a report and becomes a **verified claim**.
 
 One failure class remains invisible to any state-based proof: the
 **convergent-but-non-minimal** plan (rebuilding an index unnecessarily loses
@@ -383,6 +444,14 @@ The proof loop inverts the correctness economy of the whole project:
 - **For the rule table**: rules that misdeclare cascades, alterability, or
   data-loss classes are caught as proof failures the day they are written,
   not as field bugs.
+
+Two safety fields need verification of their own, because state proof
+cannot see them: **rewrite risk** is checked observationally on the clone
+(a table whose `relfilenode` changed under an action that claimed no
+rewrite is a failed proof), and **lock classes** are not provable by
+outcome at all — they come from a vetted static table (PostgreSQL's
+documented lock levels per DDL form) with targeted assertions, and the plan
+presents them as *reported*, not certified.
 
 ### 3.8 Execution
 
@@ -443,6 +512,17 @@ same payload hash, same parent, different name. Governed by policy
 sufficient evidence of intent. Every tool in this class punts on renames;
 here they fall out of the state representation.
 
+The mechanics depend on two §3.1 properties. Payload hashes are
+identity-free (a fact's own name lives in its `id`, not in what is hashed),
+so renaming a leaf changes its ID but not its hash. For *container* renames
+— a renamed table changes every child's stable ID — matching uses the
+identity-free **structural rollup**: payload hashes folded over the subtree
+without any names, so the whole renamed subtree still matches. Honest
+limit: payloads that reference *other* objects by name (an FK constraint
+naming its referenced table) break hash-equality transitively, so detection
+is strongest at the leaf and degrades gracefully — an undetected rename
+falls back to today's drop+create behavior, never the reverse.
+
 ### 4.2 Proof-certified plans
 
 "This plan was applied to a clone, produced a hash-identical desired state,
@@ -486,6 +566,15 @@ The test architecture is P2 applied to testing itself: **one proof harness
   is itself an oracle: run both engines over the corpus and assert
   state-equivalent plans. Every divergence is a bug in one of them — and
   either finding is valuable.
+- **An independent extractor ring.** The proof loop reads both sides
+  through the same extractor, so an extractor blind spot (an unmodeled
+  reloption, a missed catalog field) passes proof **vacuously** — both
+  catalogs are equally blind. Two defenses: extraction fixture tests that
+  pin specific catalog facts per PG version (these survive from today),
+  and **pg_dump as an independent observer** — in CI proof runs, the
+  schema dumps of two states the proof calls equal must also be equal; a
+  divergence is an extractor gap found by a tool this project does not
+  maintain.
 
 What this replaces: the hand-written per-type matrix as the primary safety
 net (127 unit-test files / 18,505 LOC in `objects/` die with the structures
@@ -513,6 +602,15 @@ deps only) exposing the layers — fact base / diff / plan / proof / apply —
 as independently usable entry points; pg-topo as a dev tool; the CLI as a
 consumer of the public API. No further package engineering is required to
 get a WASM-free, embeddable core.
+
+Two clarifications so the dependency story is airtight: the `pgdelta`
+binary ships from the CLI package, **not** from the core library — making
+pg-topo optional can never strand a CLI user, because no install that
+provides the binary lacks its dependencies. And the north-star declarative
+path needs no pg-topo at all (the shadow frontend replaced the
+static-analysis engine, §3.2); only explicitly dev-facing commands (lint,
+file-ordering help) touch it, and those degrade with a clear install hint
+rather than failing obscurely.
 
 ---
 
@@ -585,6 +683,18 @@ over nearly verbatim:
   the compactor can improve forever without correctness risk.
 - **Proof costs an extra apply + extract.** Optional per environment; cheap
   with templates and hashes.
+- **`pg_depend` does not see routine bodies.** PL/pgSQL and string-literal
+  `LANGUAGE SQL` bodies are opaque to Postgres's dependency tracking (only
+  SQL-standard `BEGIN ATOMIC` bodies get edges), so the graph cannot order
+  a routine after a table its body references. The strategy is layered:
+  plans run with `check_function_bodies = off` (the diff path already
+  emits this —
+  [create.ts:350](../packages/pg-delta/src/core/plan/create.ts)); PL/pgSQL
+  is late-bound at runtime, so missing edges rarely matter for it;
+  SQL-language ordering gaps surface in the proof loop as a failed clone
+  apply — before production, not in it; and the dev layer (§4.4) can lint
+  bodies for ordering hints. What is explicitly not done: re-parsing
+  bodies in the trusted path to synthesize edges (P1).
 - **Output changes during migration.** Decomposition-by-default changes
   emitted SQL relative to today. The oracle therefore shifts: refactor
   phases keep byte-identical output; emission-changing phases are gated on
@@ -737,6 +847,24 @@ code.
   preparation for implementation planning being delegated phase by phase.
   The document is considered ready; further refinement happens through
   implementation contact and decision-log amendments.
+- **2026-06-12 (e)** — External review (PR #297, 13 findings — all
+  verified against the codebase and accepted, some with refined fixes):
+  collision-resistant identity-free hashing with edges folded into rollups
+  and `link`/`unlink` deltas (§3.1, §3.3); shadow-loader specifics —
+  fail-safe ordering, restored body validation, cluster isolation for
+  shared objects, parser-free DML rejection (§3.2); fact-base re-creation
+  as the proof materialization for live sources, since `TEMPLATE` cloning
+  requires a connection-free source (§3.7); narrowed safety-certification
+  claims — data loss proven, rewrite risk observed via `relfilenode`, lock
+  classes vetted-not-proven (§3.7); independent extractor ring with
+  pg_dump as outside observer against vacuous proof (§4.3); rename
+  mechanics via identity-free structural rollups with the
+  cross-reference caveat (§4.1); CLI packaging clarification (§4.5);
+  per-kind equality-surface policy with the extension-version example
+  (§3.1); `pg_depend` routine-body blind-spot strategy (§7). One reviewer
+  suggestion was rejected on technical grounds: a deep-compare fallback on
+  hash matches would reinstate the full-compare cost on the unchanged
+  majority — the accepted fix is a collision-resistant digest instead.
 - Open questions intentionally left to their phases: compaction's default
   aggressiveness (phase 5), rename-policy default (phase 10), how
   aggressively to prune the ported corpus once generative coverage matures

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -1,0 +1,683 @@
+# Target Architecture: pg-delta & pg-topo
+
+- **Status**: Proposal for team review
+- **Date**: 2026-06-12
+- **Baseline**: commit `115dde8` (`pg-delta@1.0.0-alpha.28`, `pg-topo@1.0.0-alpha.1`)
+- **Scope**: architecture roadmap only — no code changes ship with this document
+
+This document records the outcome of a full architecture review of the two core
+packages, the decisions taken, and a phased roadmap. Every code claim carries a
+`path:line` citation verified against the baseline commit. It is a decision
+record, not a menu: each topic ends in one recommendation; rejected
+alternatives get one line.
+
+---
+
+## 1. Executive summary
+
+pg-delta's pipeline is correct and well-layered. Extraction, diffing,
+dependency expansion, normalization, sorting, serialization, and apply are
+cleanly separated; dependency edges come from `pg_depend` (authoritative)
+rather than SQL re-parsing; the sort layer's cycle-handling doctrine
+(`packages/pg-delta/CLAUDE.md`) is hard-won and right. None of that changes.
+
+The review found four problems, in decreasing severity:
+
+1. **A latent correctness bug**: catalog extraction runs ~28 queries on
+   different pool connections with no shared snapshot, so the catalog and its
+   `pg_depend` edges can be mutually inconsistent under concurrent DDL
+   (§3.1).
+2. **Built for hundreds of objects, not 10k+**: object equality is a double
+   `JSON.stringify` per pair per diff (§3.2); the sort layer scans the entire
+   catalog's dependency rows regardless of diff size and rebuilds its graph
+   from scratch on every cycle-break round (§3.3); the topological queue is
+   O(V²) (§3.3).
+3. **~40% of the code is mechanical boilerplate**: `src/core/objects/` is 256
+   source files / 31,162 LOC (plus 127 test files / 18,505 LOC) across 21
+   object-type directories and 106 change classes, of which roughly 65% are
+   structurally identical (§4).
+4. **Library consumers pay for the CLI and a WASM parser**: `@supabase/pg-topo`
+   (→ libpg-query WASM), `@stricli/core`, and `chalk` are hard `dependencies`
+   of the library even for pure `createPlan` users
+   ([package.json:80-89](../packages/pg-delta/package.json)) (§5).
+
+The target architecture keeps the pipeline shape and every public contract
+that matters (stable-ID wire format, plan fingerprints, the
+`creates/drops/requires/invalidates` + `serialize()` change contract) and
+changes how the stages are implemented:
+
+| Track | Change | Headline outcome |
+|---|---|---|
+| Correctness & perf (§3) | Snapshot-consistent parallel extraction; content-hash equality; single-build sort with depend pre-filtering | Consistency bug fixed; diff 5–20× faster; tiny-diff-vs-huge-catalog goes from O(catalog) to ~O(changes) |
+| Simplicity (§4) | Typed stable IDs; one generic `Change` family; `ObjectTypeSpec` registry + one generic diff engine | −11–12K source LOC, ~150 fewer files; new object types become ~1 spec file |
+| API & packaging (§5) | Layered subpath exports; pg-topo becomes optional (dynamic import) | WASM-free core install; `diffCatalogs`/`sortChanges` independently usable |
+| Test & CI velocity (§6) | Template databases; catalog-fixture unit diffs replacing most Docker tests | 2–5× wall-clock; the 45-job integration matrix shrinks structurally |
+| Declarative (§7) | Converge on shadow-DB diff; round-based apply becomes the fallback | One trusted ordering engine (`pg_depend`); pg-topo narrows to dev-time ordering/validation |
+
+Decisions already taken (with maintainer sign-off): roadmap-first delivery;
+**moderate** packaging (no new packages — the five-package split and a shared
+`pg-graph` kernel were evaluated and rejected, §5.3); **shadow-DB
+convergence** for declarative apply (§7).
+
+---
+
+## 2. What stays (explicitly)
+
+A review that only lists changes invites accidental regressions of good
+decisions. The following are load-bearing and deliberately **unchanged**:
+
+- **The seven-stage pipeline shape**: extract → diff → expand-replace →
+  normalize → sort → serialize → apply, and the change contract — every
+  change exposes `creates` / `drops` / `requires` / `invalidates` (stable-ID
+  string arrays) plus `serialize(options?)`
+  ([base.change.ts](../packages/pg-delta/src/core/objects/base.change.ts)).
+  The sort/plan/apply layers already consume *only* this contract; that is
+  precisely what makes the simplicity track (§4) low-risk.
+- **The sort module's architecture.** Two-phase ordering (drops in reverse
+  topological order, then creates/alters forward), a generic graph builder,
+  weak-edge filtering, and cycle-breaking by change injection. The decision
+  tree for *where* cycle handling lives (object-local diff vs post-diff
+  normalization vs sort-phase injection vs `invalidates`) documented in
+  `packages/pg-delta/CLAUDE.md` stays canonical. §3.4 tunes data structures
+  inside this design; it does not redesign it.
+- **`pg_depend` at extract time as the only dependency source** for the core
+  diff path. No SQL parser ever enters the diffing path. This constraint has
+  repeatedly proven itself (expression-level dependencies that parsers miss,
+  Postgres-version drift) and is the foundation of §7's recommendation.
+- **Zod model schemas and per-type extractor SQL** in `<type>.model.ts`. They
+  encode real per-version `pg_catalog` knowledge. The registry (§4.3)
+  references extractors; it does not replace them.
+- **Bespoke diff/serialize for the genuinely complex types** — table
+  (3,528 LOC including a 975-line `table.alter.ts` with ~25 ALTER variants),
+  procedure (signature-keyed identity), view/materialized-view
+  (replace-vs-alter, dependency reconstruction). These are escape hatches in
+  the registry, never templated.
+- **Full in-memory catalog materialization.** At 10k objects the catalog is
+  tens of MB — trivial. Streaming/lazy diffing would forfeit cross-type
+  dependency resolution and fingerprinting for no measurable win below ~100k
+  objects. Explicitly rejected as premature.
+- **Sequential single-transaction apply**
+  ([apply.ts:125-131](../packages/pg-delta/src/core/plan/apply.ts)). Parallel
+  DDL apply is rejected: DDL takes `ACCESS EXCLUSIVE` locks, would deadlock on
+  shared catalogs, and would break the transaction as the atomicity boundary.
+  The topological order exists exactly so that serial execution is safe.
+- **The pg-delta / pg-topo identity duplication is deliberate.** pg-delta's
+  stable IDs (`table:public.users`) are a *catalog-exact wire format*,
+  persisted in plan fingerprints and matched against `pg_depend`-derived rows.
+  pg-topo's `ObjectRef` is a *lexical-approximate* identity recovered from
+  parsed SQL (quoted-identifier normalization, signature inference,
+  builtin-type filtering). The packages also differ in cycle policy: pg-delta
+  rewrites cycles (change injection); pg-topo reports them (diagnostics).
+  Unifying these would force the exact world to carry the approximate world's
+  fuzzy-matching semantics. Future contributors should not "DRY" them
+  together.
+
+---
+
+## 3. Correctness & performance track
+
+### 3.1 Snapshot-consistent parallel extraction
+
+**Problem.** `extractCatalog` fires ~28 extractors via `Promise.all` over a
+`pg.Pool`
+([catalog.model.ts:352-381](../packages/pg-delta/src/core/catalog.model.ts))
+whose default size is 5
+([postgres-config.ts:108](../packages/pg-delta/src/core/postgres-config.ts)).
+Each query lands on whatever connection frees up, at a different wall-clock
+time, with no shared transaction. Consequences:
+
+- **Correctness**: the object queries and the `pg_depend` query
+  ([depend.ts:511](../packages/pg-delta/src/core/depend.ts)) can observe
+  different database states under concurrent DDL. The result is a catalog
+  whose dependency rows reference objects the catalog doesn't contain (or
+  vice versa). The `unknown:` filter in
+  [graph-builder.ts:26-33](../packages/pg-delta/src/core/sort/graph-builder.ts)
+  silently drops such edges — masking the symptom, losing real ordering
+  information.
+- **Latency**: 28+ queries contending for 5 connections ≈ six serial waves,
+  and each of the heavy queries (`pg_get_*def`, `aclexplode`, lateral joins)
+  pays planning and queueing overhead. `applyPlan` runs **three full
+  extractions** per apply: source + target up front
+  ([apply.ts:83-86](../packages/pg-delta/src/core/plan/apply.ts)) and a
+  post-apply verification extract
+  ([apply.ts:138-152](../packages/pg-delta/src/core/plan/apply.ts)).
+
+**Target.** The pg_dump-parallel model — one exported snapshot, N workers:
+
+```ts
+// catalog.model.ts (sketch)
+const lead = await pool.connect();
+await lead.query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY");
+const { rows: [{ snap }] } = await lead.query("SELECT pg_export_snapshot() AS snap");
+
+const runExtractor = async <T>(extract: (c: ClientLike) => Promise<T>) => {
+  const worker = await pool.connect();
+  await worker.query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY");
+  await worker.query(`SET TRANSACTION SNAPSHOT '${snap}'`);
+  try { return await extract(worker); }
+  finally { await worker.query("COMMIT"); worker.release(); }
+};
+// run all extractors (objects + depends + version + user) with bounded
+// concurrency over the same snapshot, then COMMIT + release the lead.
+```
+
+Every extractor sees the exact same database state; parallelism is preserved
+(and improves, since the pool default rises to match the worker count). This
+is days of work and fixes the bug outright.
+
+**Second step, only if profiling justifies it**: collapse the per-type queries
+into ~6 "object family" queries returning `jsonb_agg` rows (relations,
+routines, types, security, replication, misc), cutting round-trips ~5×. A
+single mega-query is rejected — planner-hostile and unmaintainable.
+
+**Also**: make the post-apply verification extract **opt-in** instead of
+opt-out (today it runs unless `verifyPostApply: false`,
+[apply.ts:138](../packages/pg-delta/src/core/plan/apply.ts)). The plan's
+fingerprint contract already guards pre-apply state; the third extraction is a
+paranoia check that belongs in CI, not in every production apply. One-third
+fewer extractions per apply.
+
+### 3.2 Content-hash equality
+
+**Problem.** `BasePgModel.equals`
+([base.model.ts:70-75](../packages/pg-delta/src/core/objects/base.model.ts))
+delegates to `deepEqual`, which is
+`stringifyWithBigInt(a) === stringifyWithBigInt(b)`
+([objects/utils.ts:36-37](../packages/pg-delta/src/core/objects/utils.ts)) —
+a full recursive `JSON.stringify` of both sides, recomputed for every shared
+object on every diff. For a table model (columns, constraints, privileges,
+security labels) that is a deep tree. At 10k shared objects, this dominates
+diff CPU. `table.diff.ts` already works around it locally with
+cheap-scalar-first comparisons — evidence the cost is real.
+
+**Target.** A memoized content hash on the base model:
+
+```ts
+// base.model.ts (sketch)
+abstract class BasePgModel {
+  #contentHash?: string;
+  get contentHash(): string {
+    return (this.#contentHash ??= hashCanonical(this.stableSnapshot().data));
+  }
+  equals(other: BasePgModel): boolean {
+    return this.stableId === other.stableId
+        && this.contentHash === other.contentHash;
+  }
+}
+```
+
+`hashCanonical` = canonical serialization (sorted keys, bigint-safe — the
+existing `stringifyWithBigInt` semantics) fed to a fast non-cryptographic hash
+(xxhash64 or FNV-1a). The hash is computed once per object, lazily, and
+overlaps with extraction I/O wait. `stableSnapshot()` is already the correct
+equality surface — subclasses override it to drop unstable fields (the
+"physical attnums vs logical names" rule), so the hash inherits every
+normalization for free.
+
+Two integration points:
+
+- `fingerprint.ts` already canonically stringifies models for plan
+  fingerprints; feed it the same canonical string so the work is shared (keep
+  SHA-256 there — fingerprints cross machine boundaries).
+- Keep `table.diff.ts`'s scalar fast paths: they classify *what kind* of
+  ALTER to emit for objects already known to differ. The hash replaces only
+  the *are-they-equal* gate.
+
+Diff becomes O(n) 8-byte compares. Expected 5–20× on the diff stage at scale.
+
+### 3.3 Sort: build once, scan only what changed
+
+**Problems** (all in `src/core/sort/`):
+
+1. `convertCatalogDependenciesToConstraints` iterates **every** `pg_depend`
+   row in the catalog on every sort
+   ([graph-builder.ts:26](../packages/pg-delta/src/core/sort/graph-builder.ts)),
+   regardless of how many changes are being sorted. A one-change diff against
+   a 10k-object catalog (≈100k+ depend rows) pays the full scan — twice, once
+   per phase.
+2. `sortPhaseChanges` re-invokes `attemptSortRound` from scratch after every
+   cycle-breaking change injection
+   ([sort-changes.ts:259-289](../packages/pg-delta/src/core/sort/sort-changes.ts)),
+   and `attemptSortRound` rebuilds all graph data each call
+   ([sort-changes.ts:161-167](../packages/pg-delta/src/core/sort/sort-changes.ts)).
+3. `performStableTopologicalSort` keeps its ready-queue sorted with linear
+   scan + `splice`, and pops with `shift`
+   ([topological-sort.ts:33-52](../packages/pg-delta/src/core/sort/topological-sort.ts))
+   — O(V²) exactly in the large-schema case where thousands of independent
+   nodes are ready simultaneously.
+4. `logicalSort`'s comparator re-runs regexes per comparison
+   ([logical-sort.ts:71-73](../packages/pg-delta/src/core/sort/logical-sort.ts)).
+
+**Target**, in order of impact:
+
+1. **Pre-filter depend rows to the change set.** Index the phase's
+   created/required stable IDs first, then visit only depend rows whose
+   endpoints appear in that index. Sorting cost becomes O(changes ·
+   avg-fanout) instead of O(catalog). This is the single biggest sort win and
+   makes the common dev-loop case (tiny diff, huge database) effectively
+   O(changes).
+2. **Build the graph once per phase; patch on injection.** Cycle injection
+   adds a handful of changes — extend the adjacency/index structures
+   incrementally instead of rebuilding. Re-running `findCycle` after each
+   repair is fine (cycles are rare); rebuilding everything is not.
+3. **Binary min-heap ready-queue** keyed by original index → O(E log V),
+   identical output order (the tie-break rule is unchanged).
+4. **Parse stable IDs once** into structs before `logicalSort`'s comparator
+   runs (this falls out of typed stable IDs, §4.1).
+
+The phase structure, edge semantics, weak-edge filters, and cycle-breaker
+logic are untouched; the existing sort test suite is the oracle.
+
+**Expected multipliers** (estimates, to be validated with a benchmark fixture
+at ~10k objects): extraction 2–4×, diff 5–20×, sort 3–10× — compounding,
+since they are different pipeline stages.
+
+---
+
+## 4. Simplicity track
+
+### 4.0 Where the volume is
+
+`src/core/objects/` = **256 source files / 31,162 LOC** + **127 test files /
+18,505 LOC**, across 21 object-type directories (some hold multiple kinds:
+`type/` → enum/composite/range; `foreign-data-wrapper/` → FDW, server,
+foreign table, user mapping). Each type follows the same template —
+`<type>.model.ts`, `<type>.diff.ts`, and a `changes/` directory with
+create/alter/drop/comment/privilege/security-label classes — for **106
+concrete change classes** total.
+
+The decisive finding: **everything downstream of diffing is already
+generic.** The sort, plan, and apply layers consume only
+`creates/drops/requires/invalidates` + `serialize()`. The 106 classes exist
+to produce four string arrays and one SQL string each. Per-type *information*
+varies; per-type *structure* almost never does. Roughly 65% of the volume is
+structural duplication, concentrated in the ~15 cookie-cutter types
+(collation 676 LOC, extension 646, language 758, schema 792 … up to
+publication 1,116), while table (3,528), procedure (1,608), role (1,815), and
+the view family carry genuinely irreducible logic.
+
+The duplication also leaks outward as five hand-maintained per-`objectType`
+dispatch sites that must be edited for every new type:
+
+- `getPrivilegeTargetStableId`
+  ([catalog.diff.ts:47](../packages/pg-delta/src/core/catalog.diff.ts))
+- `getSchema`
+  ([change-utils.ts:10](../packages/pg-delta/src/core/change-utils.ts))
+- `getPrimaryStableId`
+  ([fingerprint.ts:88](../packages/pg-delta/src/core/fingerprint.ts))
+- `OBJECT_TYPE_TO_PROPERTY_KEY`
+  ([change.types.ts:65](../packages/pg-delta/src/core/change.types.ts), used
+  by `integrations/filter/flatten.ts`)
+- `getFilePath`
+  ([export/file-mapper.ts:59](../packages/pg-delta/src/core/export/file-mapper.ts))
+
+### 4.1 Typed stable IDs (first — it unblocks everything)
+
+Stable IDs are strings built by `stableId.*` helpers but **re-parsed** with
+regex/string slicing where structure is needed — e.g.
+`stableId.slice("procedure:".length, paren)` and `normalizeDependentId` in
+[expand-replace-dependencies.ts:419-425](../packages/pg-delta/src/core/expand-replace-dependencies.ts).
+That is fragile (quoting, signature commas) and scatters the format.
+
+**Target**: one parsed value type with a frozen canonical string form.
+
+```ts
+// src/core/stable-id.ts (sketch)
+export type StableId =
+  | { kind: "schema"; schema: string }
+  | { kind: "table" | "view" | "materializedView" | "sequence" | "domain"
+        | "collation" | "type" | "foreignTable"; schema: string; name: string }
+  | { kind: "procedure"; schema: string; name: string; args: string[] }
+  | { kind: "column" | "constraint" | "index"; schema: string; table: string; name: string }
+  | { kind: "role"; role: string }
+  | { kind: "comment" | "acl" | "securityLabel"; target: StableId; /* … */ }
+  | { kind: "membership"; role: string; member: string }
+  // … defacl, server, userMapping, foreignDataWrapper, …
+
+export function formatStableId(id: StableId): string; // byte-identical to today's strings
+export function parseStableId(s: string): StableId;
+```
+
+**The wire format is frozen.** Stable-ID strings are persisted in plan
+fingerprints and matched against SQL-side string synthesis in `depend.ts`;
+`formatStableId` must reproduce today's output byte-for-byte, verified by a
+parse/format round-trip test over every existing helper. Graph keys and the
+change contract keep using strings; structure is recovered with
+`parseStableId` instead of regex.
+
+### 4.2 One generic `Change` family with a typed `ref`
+
+Today every change class carries its model under a per-type property
+(`.table`, `.collation`, …), which is what forces the five dispatch switches
+and the 21-member union in
+[change.types.ts](../packages/pg-delta/src/core/change.types.ts).
+
+**Target**: the base change exposes one uniform reference —
+
+```ts
+interface ObjectRef {
+  objectType: ObjectType;
+  stableId: StableId;
+  model: BasePgModel;
+}
+
+abstract class Change {
+  abstract operation: "create" | "alter" | "drop";
+  abstract scope: "object" | "comment" | "privilege" | "security_label" | "membership" | "default_privilege";
+  abstract ref: ObjectRef;
+  abstract creates: string[];   abstract drops: string[];
+  abstract requires: string[];  get invalidates(): string[] { return []; }
+  abstract serialize(options?: SerializeOptions): string;
+}
+```
+
+— plus a small set of generic concrete shapes (`GenericCreate`,
+`GenericDrop`, `GenericAlter` with a discriminated `action` payload,
+`SetComment`, `GrantPrivilege` / `RevokePrivilege` / `RevokeGrantOption`,
+`SetSecurityLabel`) whose behavior is driven by the registry (§4.3). Complex
+types keep their bespoke classes (`AlterTableAlterColumnType` et al.) but
+extend the same base and expose the same `ref`.
+
+With `ref` in place, all five switches collapse to one-liners
+(`change.ref.stableId`, `change.ref.model.schemaName`, a registry lookup for
+file paths) and `OBJECT_TYPE_TO_PROPERTY_KEY` is deleted. The filter DSL's
+public `<objectType>/<field>` paths are preserved by flattening `ref.model`
+under the same keys — guarded by a key-set equality test (§9).
+
+### 4.3 `ObjectTypeSpec` registry + one generic diff engine
+
+```ts
+// src/core/registry/spec.ts (sketch)
+interface ObjectTypeSpec<M extends BasePgModel> {
+  objectType: ObjectType;
+  sqlKeyword: string;                  // "COLLATION", "TABLE", …
+  hasComment: boolean;
+  hasPrivileges: boolean;              // + columnLevelPrivileges for relations
+  hasSecurityLabel: boolean;
+  extract(pool: Pool): Promise<M[]>;   // existing extractor, referenced not rewritten
+  requires(model: M): StableId[];      // schema, owner, types, collations, …
+  identitySql(model: M): string;       // "schema.name" / "schema.name(args)"
+  serializeCreate(model: M, opts?: SerializeOptions): string;
+  alterableFields?: Record<string, (m: M, opts?: SerializeOptions) => string>;
+  customDiff?(ctx: DiffContext, main: Record<string, M>, branch: Record<string, M>): Change[];
+}
+```
+
+One generic engine consumes the spec: set-algebra created/dropped/altered
+(via §3.2 hashes), then emits `GenericCreate` (+ owner alter, comments,
+grants, security labels), `GenericDrop`, and per-field `GenericAlter` —
+falling back to drop+create for non-alterable fields. It reuses the existing
+shared helpers (`emitObjectPrivilegeChanges` — already used by 16 of 21
+types — and `diffSecurityLabels` — 18 of 21); the registry deletes the
+per-type *class wrappers* around them, not the logic. `diffCatalogs`'s 21
+hand-sequenced imports become a loop over the registry.
+
+**Scope boundary**: the ~15 cookie-cutter types go fully generic. Table,
+procedure, view, materialized-view, role, and subscription keep their
+diff/serialize behind `customDiff` and only adopt the generic
+comment/privilege/security-label shapes. Quirky-but-simple cases (collation's
+`REFRESH VERSION`) are an `alterableFields` entry, not a reason to fork.
+
+**Quantified estimate**: −11–12K source LOC and ~150 fewer files (≈35–40% of
+`objects/`), with a comparable test-LOC reduction after per-class test files
+collapse into per-spec tests. Adding a future object type drops from ~13
+files to ~2 (model + spec).
+
+### 4.4 `depend.ts` decomposition
+
+[depend.ts](../packages/pg-delta/src/core/depend.ts) is 1,895 lines but only
+two functions: `extractPrivilegeAndMembershipDepends` (line 43 — a series of
+independent `aclexplode`/membership/defacl sub-queries) and `extractDepends`
+(line 511 — the core `pg_depend` synthesis query with 30+ CTEs).
+
+**Target**: split the ACL/membership part into ~5 named functions
+(`relationAclDepends`, `schemaAclDepends`, `membershipDepends`,
+`defaclDepends`, `fdwAclDepends`) run via `Promise.all` — they are already
+independent queries. **Keep the core `pg_depend` query whole**: it is one
+recursive join over `pg_depend`; splitting it would multiply round-trips and
+re-implement the OID→stable-ID mapping N times. Centralize the SQL-side
+stable-ID `format(...)` literals into one CTE that mirrors `formatStableId`,
+so the wire format lives in exactly two audited places (TS + SQL).
+
+Moving per-type dependency extraction next to each type's extractor was
+evaluated and rejected: dependency synthesis is inherently cross-type.
+
+### 4.5 Explicit plan pipeline
+
+`diffCatalogs` currently interleaves raw diffing with an inline
+dropped-target ACL filter, then callers wire `expandReplaceDependencies` and
+`normalizePostDiffChanges` around it. **Target**: a named stage list with one
+contract —
+
+```ts
+const STAGES: Array<(changes: Change[], ctx: PlanContext) => Change[]> = [
+  rawDiff, filterDroppedObjectAcls, expandReplaceDependencies, normalizePostDiffChanges,
+];
+```
+
+This is a wiring change only. The CLAUDE.md doctrine that these stages are
+distinct *by the information they need* is preserved — the goal is to make
+the chokepoints legible and independently testable, not to merge them.
+
+### 4.6 Migration order (each step independently shippable)
+
+Old and new coexist throughout because everything downstream speaks the same
+change contract; the registry dispatches per-type to either the spec engine
+or the legacy diff function during transition.
+
+1. Typed stable IDs (`stable-id.ts`), helpers reimplemented on top; replace
+   the parsers in `expand-replace-dependencies.ts`. Zero wire-format drift,
+   proven by round-trip tests.
+2. Add `ref` to the base change (temporary adapter derives it from existing
+   per-type properties); collapse the five switches; delete
+   `OBJECT_TYPE_TO_PROPERTY_KEY`.
+3. Registry + generic engine; migrate **collation**, then **extension** as
+   proofs. Each migration deletes a `changes/` directory and a `*.diff.ts`.
+4. Batch-migrate the remaining cookie-cutter types, one PR per batch.
+5. Complex types last: route through the registry via `customDiff`; swap
+   their comment/privilege/seclabel wrappers for the generic shapes; bespoke
+   alter classes stay.
+6. Delete the legacy union and dead base plumbing.
+
+**Hard rule per PR: zero serialized-SQL drift.** The existing per-type diff
+tests and the integration roundtrip suite are the oracle; a migration PR that
+changes any emitted SQL byte is wrong by definition.
+
+---
+
+## 5. API & packaging track (moderate)
+
+### 5.1 Layered subpath exports
+
+The current root export is a flat bag mixing catalog, plan, execution, and
+integration concerns, while the two most reusable functions —
+`diffCatalogs` and `sortChanges` — are internal. Embedders (e.g. the
+Supabase CLI) that already hold two catalogs must go through the monolithic
+`createPlan`.
+
+**Target** `@supabase/pg-delta` exports:
+
+```text
+.              createPlan / applyPlan / extractCatalog (facade — unchanged)
+./catalog      extractCatalog, serializeCatalog, deserializeCatalog, snapshots
+./diff         diffCatalogs(main, branch) -> Change[]
+./sort         sortChanges(ctx, changes) -> Change[]
+./plan         createPlan, applyPlan, Plan, fingerprints, sql-format
+./integrations filter + serialize DSL (vendor-neutral) — supabase stays at
+               ./integrations/supabase
+./catalog-export  (existing, unchanged)
+```
+
+Each layer is independently usable; the facade stays the documented happy
+path. The `Plan` + fingerprint contract is good and keeps its shape.
+
+### 5.2 WASM-free core install
+
+`@supabase/pg-topo` is imported in `src/core/` **only** by
+`declarative-apply/` and one dev-time test helper — the code boundary is
+clean; the manifest is not
+([package.json:80-89](../packages/pg-delta/package.json) makes it a hard
+dependency, dragging libpg-query WASM into every install).
+
+**Target**: move `@supabase/pg-topo` to an **optional peer dependency**,
+loaded via dynamic `import()` inside `declarative-apply` with a clear error
+("declarative apply requires @supabase/pg-topo — install it alongside
+@supabase/pg-delta") when absent.
+
+`@stricli/core` and `chalk` were evaluated under the same lens and **kept**
+as regular dependencies for now: they are a few kB of pure JS — the cost of
+splitting a CLI package today outweighs the win. Revisit if/when an embedder
+objects or §7 changes the CLI's shape.
+
+### 5.3 Rejected restructurings (recorded so they are not re-litigated)
+
+- **Five-package split** (`pg-delta` / `pg-delta-cli` / `pg-delta-declarative`
+  / `pg-delta-supabase` / `pg-graph`): cleanest boundaries, but five
+  changeset-coupled packages for one tool is real release overhead, and the
+  two concrete pains it solves (WASM weight, layered API) are solved by §5.1
+  + §5.2 without it. Deferred until a second embedder demands it.
+- **Shared `pg-graph` kernel** for the Kahn/Tarjan code used by both
+  packages: the genuinely identical code is ~80 lines; everything around it
+  (tie-break semantics, cycle policy) is intentionally different (§2). Not
+  worth a package.
+
+### 5.4 Monorepo hygiene
+
+- Move `packages/bun-istanbul-coverage` → `tools/` — it is private test
+  infrastructure, not a product, and currently gets swept by every
+  `--filter '*'` script.
+- Document why the root `.stubs/cpu-features` override exists (testcontainers
+  → ssh2 transitive native dep) so it survives cleanup passes.
+- Defer any `tests.yml` split until §6 reshapes the test pyramid.
+
+---
+
+## 6. Test & CI velocity track
+
+The integration matrix is 45 jobs (3 PG versions × 15 shards, ~10–14 min
+each). Profiling the harness shows the time goes to per-test lifecycle, not
+to assertions:
+
+- Every `withDb` test creates **two databases** and two fresh pools
+  ([container-manager.ts:148-170](../packages/pg-delta/tests/container-manager.ts)),
+  and cleanup opens a **third pool per database** just to probe for
+  subscriptions
+  ([container-manager.ts:176-199](../packages/pg-delta/tests/container-manager.ts)).
+- Supabase-flavored tests replay the multi-MB base-init SQL blob into **both**
+  databases per test
+  ([tests/utils.ts:76-95](../packages/pg-delta/tests/utils.ts)).
+- Every roundtrip test pays 2–3 full catalog extractions (§3.1 makes these
+  cheaper, but fewer is better than faster).
+
+**Target**, in order of leverage:
+
+1. **Template databases.** Build the Supabase baseline once per container
+   into `supabase_base`, then per-test isolation becomes
+   `CREATE DATABASE … TEMPLATE supabase_base` — a file-level copy — instead
+   of replaying the SQL blob twice per test.
+2. **Fixture-first test pyramid.** `serializeCatalog`/`deserializeCatalog`
+   already exist. Capture `(catalogA, catalogB)` JSON fixtures once (from a
+   container run, regenerated by script like the existing Supabase baselines),
+   and turn the bulk of "this DDL change produces these statements"
+   assertions into **Docker-free unit tests** of
+   `diffCatalogs` + `sortChanges` + serialization. Keep a deliberately thin
+   ring of true roundtrip-fidelity integration tests (extract → diff → apply
+   → re-extract → assert convergence) as the safety net. This is the change
+   that structurally shrinks the 45-job matrix rather than just speeding it
+   up.
+3. **Skip the subscription probe** unless the test declared it creates
+   subscriptions; reuse the admin pool for cleanup.
+
+Expected: 2–5× integration wall-clock from (1) + (3), and a materially
+smaller matrix from (2). The shard count and PG-version list then get
+revisited from data, not guessed.
+
+---
+
+## 7. Declarative apply: converge on shadow-DB diff
+
+Today there are two ordering engines: the diff path (catalog-exact,
+`pg_depend`-driven) and declarative apply (pg-topo static sort + round-based
+retry, `maxRounds = 100` —
+[round-apply.ts:252-281](../packages/pg-delta/src/core/declarative-apply/round-apply.ts)).
+Round-retry is simple and battle-tested, but worst-case O(n²) statement
+executions against the live database, and it is only as good as static
+parsing — every defer is a wasted network round-trip caused by an edge the
+parser could not see.
+
+**Decision: converge on shadow-DB diff as the canonical declarative path.**
+
+```text
+.sql files ──single pass──▶ scratch/shadow DB ──extractCatalog──▶ desired Catalog
+                                                       │
+live target ──extractCatalog──▶ current Catalog ──diffCatalogs/createPlan──▶ plan
+```
+
+- Postgres itself resolves the desired state (no fuzzy `ObjectRef` matching,
+  no retry heuristics); the trusted `pg_depend` engine produces the plan; the
+  output is byte-identical in style to the diff path. `createPlan` already
+  accepts a resolved `Catalog` input, so the plumbing exists.
+- **pg-topo narrows to its honest strengths**: dev-time ordering of `.sql`
+  files for humans, syntax validation, dependency diagnostics, cycle
+  reporting. It stops being a production apply engine.
+- **Round-based apply remains as the fallback** for environments that cannot
+  reach a scratch database, and is not retired until the shadow-DB path is
+  green across the full integration matrix. Near-term improvement to the
+  fallback: single-pass execution with a bounded deferred queue instead of
+  full-round restarts.
+
+Honest trade-offs, stated once: the shadow path requires a reachable Postgres
+(scratch database, throwaway container, or template-created sibling DB); it
+adds one extraction + diff of latency; round-apply needs nothing but the
+target and has accumulated real-world mileage. That is why this is a
+convergence with a fallback, not a replacement.
+
+---
+
+## 8. Phased roadmap
+
+| Phase | Content | Effort | Risk | Depends on |
+|---|---|---|---|---|
+| 1 | Snapshot-consistent extraction (§3.1); content-hash equality (§3.2); opt-in post-apply verify; heap topo queue | days | low | — |
+| 2 | Typed `StableId` + `ref` on `Change` + dispatch-switch removal (§4.1–4.2) | ~1 wk | low | — |
+| 3 | `ObjectTypeSpec` registry + cookie-cutter type migration, batched PRs (§4.3) | weeks, incremental | medium (SQL-drift gate) | 2 |
+| 4 | Sort single-build + depend pre-filter (§3.3); `depend.ts` split (§4.4); explicit pipeline (§4.5) | ~1 wk | low–medium | — |
+| 5 | Subpath API (§5.1); optional pg-topo (§5.2); `tools/` move (§5.4) | days | medium (publish config) | — |
+| 6 | Template DBs + fixture-based unit diffs + matrix shrink (§6) | ~1–2 wk | low | — |
+| 7 | Shadow-DB declarative path, feature-flagged, parity-gated (§7) | longer | medium | 5 |
+
+Phases 1, 2, 5, and 6 are mutually independent and can start immediately;
+phase 3 builds on 2; phase 4 can land any time; phase 7 follows 5 (it wants
+the `./diff` + `./catalog` layers). Every phase ships behind the standing
+rules: changeset per behavior change, RED→GREEN regression tests, zero
+serialized-SQL drift for refactor phases.
+
+---
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Serialized-SQL byte drift** during the registry migration silently changes real migrations | One type per PR; existing per-type diff tests + integration roundtrip suite as the oracle; a PR that changes any emitted byte fails by definition |
+| **Stable-ID wire-format drift** breaks persisted plan fingerprints and the SQL-side synthesis in `depend.ts` | Format frozen; `formatStableId` round-trip tests over every helper; the SQL-side format lives in one CTE mirrored against the TS helper |
+| **Filter DSL path breakage** — users' filters address `<objectType>/<field>` paths produced by `flatten.ts` | Key-set equality test asserting identical flattened paths before/after for every type |
+| **Registry type erosion** (heterogeneous spec list tempts `any`) | `ObjectTypeSpec<BasePgModel>` at the engine boundary; full model typing stays inside each spec module |
+| **Optional-dependency UX** (declarative apply with pg-topo absent) | Dynamic import with an explicit actionable error; documented in README + CLI help |
+| **Snapshot extraction vs poolers** (`pg_export_snapshot` requires session-level transactions; transaction-mode poolers break it) | Detect and fall back to single-connection serial extraction within one transaction (still consistent, just not parallel) |
+| **Shadow-DB parity is real work** — round-apply handles parser-blind cases today | Flag-gated rollout; round-apply retired only after the full integration matrix is green on the shadow path |
+| **Estimate risk** on the perf multipliers | Add a benchmark fixture (~10k objects) in phase 1 so every later phase measures rather than asserts |
+
+---
+
+## Appendix: baseline metrics
+
+| Metric | Value (commit `115dde8`) |
+|---|---|
+| pg-delta source (src/) | ~88K LOC, ~511 files |
+| `src/core/objects/` | 256 source files / 31,162 LOC; 127 test files / 18,505 LOC |
+| Object-type directories / concrete change classes | 21 / 106 |
+| `depend.ts` | 1,895 LOC, 2 functions, 30+ CTEs |
+| `sort/` | ~4.6K LOC across 15 files |
+| Integration tests | 63 files × 3 PG versions, 15 CI shards (45 jobs) |
+| pg-topo source | ~4.4K LOC, 18 modules; 38 statement classes, 28 object kinds, 6 phases |
+| Library hard deps | `pg`, `zod`, `@ts-safeql/sql-tag`, `picomatch`, `debug`, `@stricli/core`, `chalk`, `@supabase/pg-topo` (→ libpg-query WASM) |

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -355,19 +355,34 @@ metadata (locks, rewrites, data loss).
 
 **The proof loop is the architecture's keystone.** Because any state can be
 materialized (template-cloned scratch DB) and re-extracted, the planner can
-certify its own output: apply the plan to a clone of the source, extract,
-hash-compare against the desired fact base. Zero diff = proven plan. This
-inverts the correctness economy of the whole project:
+certify its own output. The proof has two checks, because schema convergence
+alone has a blind spot:
 
-- **In CI**: property-based testing becomes the primary coverage engine —
-  generate schemas, generate mutations, roundtrip, assert fixpoint. The
-  hand-written per-type test matrix (127 test files / 18,505 LOC in
-  `objects/`, 63 integration files × 3 PG versions × 15 shards = 45 jobs)
-  shrinks to a thin integration ring around a generative core.
+1. **State proof.** Apply the plan to a clone of the source, extract,
+   hash-compare against the desired fact base. Zero diff = the plan produces
+   the right schema.
+2. **Data-preservation proof.** A plan that drop+creates a table instead of
+   altering it converges to an *identical schema* — and destroys every row.
+   State proof cannot see this. So the clone is seeded with rows before
+   applying, and the proof asserts they survive wherever the plan claims
+   `dataLoss: none`. The safety report stops being a report and becomes a
+   **verified claim**.
+
+One failure class remains invisible to any state-based proof: the
+**convergent-but-non-minimal** plan (rebuilding an index unnecessarily loses
+nothing and converges fine — it is merely catastrophic on a 2 TB table).
+Minimality is asserted at the plan level — semantic assertions on action
+kinds and budgets, never on SQL bytes — in the test architecture (§4.3).
+
+The proof loop inverts the correctness economy of the whole project:
+
+- **In CI**: it is the universal oracle behind both the scenario corpus and
+  the generative engine (§4.3).
 - **In production**: proof-on-shadow is an optional pre-apply step for
   high-stakes targets.
-- **For the rule table**: rules that misdeclare cascades or alterability are
-  caught as state mismatches the day they are written, not as field bugs.
+- **For the rule table**: rules that misdeclare cascades, alterability, or
+  data-loss classes are caught as proof failures the day they are written,
+  not as field bugs.
 
 ### 3.8 Execution
 
@@ -403,16 +418,55 @@ here they fall out of the state representation.
 
 ### 4.2 Proof-certified plans
 
-"This plan was applied to a clone and produced a hash-identical desired
-state" is a product claim no comparable tool makes. It also gives drift
+"This plan was applied to a clone, produced a hash-identical desired state,
+and preserved seeded data everywhere it claimed to" is a product claim no
+comparable tool makes. It also gives drift
 detection for free: comparing any environment against any snapshot is a
 rollup-hash walk.
 
-### 4.3 Generative testing as the safety net
+### 4.3 Tests as data: one harness, a seed corpus, a generative engine
 
-The oracle stops being "did a human anticipate this case in a test file" and
-becomes "does apply(plan(A→B), A) equal B" over generated A and B. Coverage
-grows with compute, not with test-authoring effort.
+The test architecture is P2 applied to testing itself: **one proof harness
+(machinery) + scenarios (data)**.
+
+- **The seed corpus.** Every scenario is a named
+  `(DDL_A, DDL_B[, seed rows][, plan assertions])` fixture run through the
+  proof harness. The existing integration suite ports into this corpus
+  nearly mechanically — its dominant pattern (set up two databases, plan,
+  apply, assert convergence) already *is* the proof loop, hand-rolled per
+  test. What the corpus preserves is not the old assertions but the
+  **problem corpus**: every field-discovered edge case and PostgreSQL
+  semantic the project has been burned by — publication/FK-cycle drops,
+  policy recreation chains, attnum drift, partition juggling. After the
+  extractor SQL, it is the second most valuable asset in the repository,
+  and it is exactly what a greenfield engine would otherwise silently
+  regress on. The RED→GREEN discipline carries over: every new field bug
+  becomes a corpus entry that fails before the fix and is pinned forever
+  after.
+- **The generative engine.** Property-based testing explores beyond the
+  corpus: generate schemas, generate mutations, roundtrip through the proof
+  loop — including the data-preservation check (§3.7) — and assert
+  fixpoint. Coverage grows with compute, not with test-authoring effort;
+  the corpus pins old ground so generation never re-loses it (the fuzzing
+  model: seed corpus + exploration).
+- **Semantic plan assertions.** Where a scenario's point is *how* the goal
+  is reached — minimality, in-place alteration, risk class — the fixture
+  asserts action kinds and budgets ("this delta yields an `alter`-class
+  action, not a replace"; "≤ N actions"), never SQL bytes. Byte snapshots
+  die with the old engine: they assert emission shape, which decomposition
+  (§3.5) intentionally changes and the compactor may change again.
+- **Differential testing during migration.** Until retired, the old engine
+  is itself an oracle: run both engines over the corpus and assert
+  state-equivalent plans. Every divergence is a bug in one of them — and
+  either finding is valuable.
+
+What this replaces: the hand-written per-type matrix as the primary safety
+net (127 unit-test files / 18,505 LOC in `objects/` die with the structures
+they assert; 63 integration files × 3 PG versions × 15 CI shards = 45 jobs
+collapse into corpus entries behind one harness). What survives unchanged:
+extraction tests and catalog baselines (the extractor corpus survives, so
+its tests do), and the Supabase integration tests (they assert filtering
+policy, not engine behavior).
 
 ### 4.4 An honest role for static analysis
 
@@ -445,6 +499,11 @@ over nearly verbatim:
   valuable asset in the repository. It becomes the fact producer; what
   changes is the keying of its output (fact rows instead of nested
   documents), not its content.
+- **The integration scenario corpus** — the distilled record of every
+  field-discovered failure, and the second most valuable asset after the
+  extractor SQL. The scenarios survive as seed-corpus fixtures for the
+  proof harness (§4.3); only their implementation-coupled assertions and
+  byte-level SQL snapshots are retired.
 - **The `pg_depend` doctrine** — deepened from "the diff path's source of
   truth" to "the only semantic engine, period" (P1).
 - **The normalization knowledge** in `stableSnapshot()` overrides (physical
@@ -473,7 +532,7 @@ over nearly verbatim:
 | pg-topo in the apply path | pg-topo as dev-experience layer (§4.4) |
 | String stable-ID re-parsing ([expand-replace-dependencies.ts:419-425](../packages/pg-delta/src/core/expand-replace-dependencies.ts)) | typed `StableId` (§3.1) |
 | `JSON.stringify` equality + triple extraction per apply | content hashes + single-snapshot extraction + proof-as-opt-in (§3.1, §3.2, §3.7) |
-| Hand-written per-type test matrix as primary safety net | generative roundtrip proof + thin integration ring (§4.3) |
+| Hand-written per-type test matrix as primary safety net; byte-level SQL snapshots | one proof harness over the seed scenario corpus + generative exploration + semantic plan assertions (§4.3) |
 
 ## 7. Honest costs
 
@@ -559,7 +618,7 @@ RED→GREEN regression test per repository policy.
 |---|---|---|---|
 | 1 | Single-snapshot parallel extraction; memoized content hashes on models; hash-based `equals`; post-apply verify becomes explicit proof opt-in | Fact base capture & hashing §3.1–3.2 | Fixes the consistency bug on day one; hashes later power fingerprints, renames, proof |
 | 2 | Typed `StableId` (frozen canonical string form, parse/format round-trip tested); kill regex re-parsing | Fact identity §3.1 | Wire format byte-frozen — persisted in plan fingerprints |
-| 3 | `provePlan(plan, source)` as a first-class API: template-cloned scratch, apply, extract, hash-compare. Adopt as CI oracle; begin generative roundtrip tests; shrink the hand-written integration matrix as proof coverage grows | Proof loop §3.7, §4.3 | **Do this before touching emission** — it is the safety net for phases 5–8 |
+| 3 | `provePlan(plan, source)` as a first-class API: template-cloned scratch, apply, extract, hash-compare — plus the data-preservation check (seeded rows). Port the integration scenarios into the seed corpus behind one harness; replace load-bearing SQL snapshots with semantic plan assertions; stand up old-vs-new differential runs; begin generative roundtrip tests | Proof loop §3.7, test architecture §4.3 | **Do this before touching emission** — it is the safety net for phases 5–8 |
 | 4 | Sort hygiene while the old sort still exists: depend-row pre-filtering to the change set, single graph build per phase, heap queue | Interim perf | Pure wins now; code is absorbed by phase 6 |
 | 5 | Decomposition-by-default emission + the compaction pass; delete cycle breakers by attrition as their cycle classes become unconstructible | §3.5–3.6 | First emission-changing phase; gated on state-proof + review |
 | 6 | One mixed graph (old-state edges + new-state edges + identity conflicts) replaces two-phase + `invalidates` + repair loop | §3.6 | A surviving cycle after 5+6 is a rule/emission bug — fix the rule, never add a breaker |
@@ -593,9 +652,19 @@ product payoff. Phases 1, 2, 4 can start immediately and in parallel.
   doctrine) is affirmed as correct; the reshaping concerns its keying, plus
   provenance (extension membership) captured as edge facts instead of
   extraction-time filtering.
+- **2026-06-12 (c)** — Following maintainer review ("should we keep the
+  current tests in some form?"), the test architecture is specified (§4.3):
+  the integration suite's *scenarios* are kept as the seed corpus of the
+  proof harness; their implementation-coupled assertions and byte-level SQL
+  snapshots are not ported. The proof loop gains a **data-preservation
+  check** (§3.7), closing the convergent-but-destructive blind spot of
+  schema-state proof; convergent-but-non-minimal plans are covered by
+  semantic plan assertions. The old engine serves as a differential oracle
+  until retired.
 - Open questions intentionally left to their phases: compaction's default
-  aggressiveness (phase 5), rename-policy default (phase 10), the minimum
-  integration-test ring kept alongside generative proof (phase 3).
+  aggressiveness (phase 5), rename-policy default (phase 10), how
+  aggressively to prune the ported corpus once generative coverage matures
+  (phase 3).
 
 ---
 

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -1,683 +1,501 @@
-# Target Architecture: pg-delta & pg-topo
+# North Star Architecture: pg-delta & pg-topo
 
-- **Status**: Proposal for team review
+- **Status**: North star — the project's target design, judged on technical
+  merit alone, deliberately ignoring migration cost and past choices
 - **Date**: 2026-06-12
-- **Baseline**: commit `115dde8` (`pg-delta@1.0.0-alpha.28`, `pg-topo@1.0.0-alpha.1`)
-- **Scope**: architecture roadmap only — no code changes ship with this document
+- **Baseline for all code citations**: commit `115dde8`
+  (`pg-delta@1.0.0-alpha.28`, `pg-topo@1.0.0-alpha.1`)
 
-This document records the outcome of a full architecture review of the two core
-packages, the decisions taken, and a phased roadmap. Every code claim carries a
-`path:line` citation verified against the baseline commit. It is a decision
-record, not a menu: each topic ends in one recommendation; rejected
-alternatives get one line.
-
----
-
-## 1. Executive summary
-
-pg-delta's pipeline is correct and well-layered. Extraction, diffing,
-dependency expansion, normalization, sorting, serialization, and apply are
-cleanly separated; dependency edges come from `pg_depend` (authoritative)
-rather than SQL re-parsing; the sort layer's cycle-handling doctrine
-(`packages/pg-delta/CLAUDE.md`) is hard-won and right. None of that changes.
-
-The review found four problems, in decreasing severity:
-
-1. **A latent correctness bug**: catalog extraction runs ~28 queries on
-   different pool connections with no shared snapshot, so the catalog and its
-   `pg_depend` edges can be mutually inconsistent under concurrent DDL
-   (§3.1).
-2. **Built for hundreds of objects, not 10k+**: object equality is a double
-   `JSON.stringify` per pair per diff (§3.2); the sort layer scans the entire
-   catalog's dependency rows regardless of diff size and rebuilds its graph
-   from scratch on every cycle-break round (§3.3); the topological queue is
-   O(V²) (§3.3).
-3. **~40% of the code is mechanical boilerplate**: `src/core/objects/` is 256
-   source files / 31,162 LOC (plus 127 test files / 18,505 LOC) across 21
-   object-type directories and 106 change classes, of which roughly 65% are
-   structurally identical (§4).
-4. **Library consumers pay for the CLI and a WASM parser**: `@supabase/pg-topo`
-   (→ libpg-query WASM), `@stricli/core`, and `chalk` are hard `dependencies`
-   of the library even for pure `createPlan` users
-   ([package.json:80-89](../packages/pg-delta/package.json)) (§5).
-
-The target architecture keeps the pipeline shape and every public contract
-that matters (stable-ID wire format, plan fingerprints, the
-`creates/drops/requires/invalidates` + `serialize()` change contract) and
-changes how the stages are implemented:
-
-| Track | Change | Headline outcome |
-|---|---|---|
-| Correctness & perf (§3) | Snapshot-consistent parallel extraction; content-hash equality; single-build sort with depend pre-filtering | Consistency bug fixed; diff 5–20× faster; tiny-diff-vs-huge-catalog goes from O(catalog) to ~O(changes) |
-| Simplicity (§4) | Typed stable IDs; one generic `Change` family; `ObjectTypeSpec` registry + one generic diff engine | −11–12K source LOC, ~150 fewer files; new object types become ~1 spec file |
-| API & packaging (§5) | Layered subpath exports; pg-topo becomes optional (dynamic import) | WASM-free core install; `diffCatalogs`/`sortChanges` independently usable |
-| Test & CI velocity (§6) | Template databases; catalog-fixture unit diffs replacing most Docker tests | 2–5× wall-clock; the 45-job integration matrix shrinks structurally |
-| Declarative (§7) | Converge on shadow-DB diff; round-based apply becomes the fallback | One trusted ordering engine (`pg_depend`); pg-topo narrows to dev-time ordering/validation |
-
-Decisions already taken (with maintainer sign-off): roadmap-first delivery;
-**moderate** packaging (no new packages — the five-package split and a shared
-`pg-graph` kernel were evaluated and rejected, §5.3); **shadow-DB
-convergence** for declarative apply (§7).
+This document defines where the project is going. It is not a critique of how
+it got here: the current design is the strongest in its class (it is the only
+tool in the migra/pg-schema-diff family that treats `pg_depend` as the source
+of ordering truth), and its accumulated PostgreSQL knowledge is the asset the
+north star is built from. But the north star is derived from the problem, not
+from the codebase — §9 then re-derives an incremental path from today's code
+toward it. When a local decision conflicts with this document, this document
+wins or this document gets amended.
 
 ---
 
-## 2. What stays (explicitly)
+## 1. The problem, stated purely
 
-A review that only lists changes invites accidental regressions of good
-decisions. The following are load-bearing and deliberately **unchanged**:
+Given two PostgreSQL schema states — each obtainable from a live database,
+from SQL files, or from a serialized snapshot — produce a **minimal,
+correctly ordered, reviewable, safety-classified** DDL script that transforms
+one state into the other, **deterministically**, and be able to **prove** it
+did.
 
-- **The seven-stage pipeline shape**: extract → diff → expand-replace →
-  normalize → sort → serialize → apply, and the change contract — every
-  change exposes `creates` / `drops` / `requires` / `invalidates` (stable-ID
-  string arrays) plus `serialize(options?)`
-  ([base.change.ts](../packages/pg-delta/src/core/objects/base.change.ts)).
-  The sort/plan/apply layers already consume *only* this contract; that is
-  precisely what makes the simplicity track (§4) low-risk.
-- **The sort module's architecture.** Two-phase ordering (drops in reverse
-  topological order, then creates/alters forward), a generic graph builder,
-  weak-edge filtering, and cycle-breaking by change injection. The decision
-  tree for *where* cycle handling lives (object-local diff vs post-diff
-  normalization vs sort-phase injection vs `invalidates`) documented in
-  `packages/pg-delta/CLAUDE.md` stays canonical. §3.4 tunes data structures
-  inside this design; it does not redesign it.
-- **`pg_depend` at extract time as the only dependency source** for the core
-  diff path. No SQL parser ever enters the diffing path. This constraint has
-  repeatedly proven itself (expression-level dependencies that parsers miss,
-  Postgres-version drift) and is the foundation of §7's recommendation.
-- **Zod model schemas and per-type extractor SQL** in `<type>.model.ts`. They
-  encode real per-version `pg_catalog` knowledge. The registry (§4.3)
-  references extractors; it does not replace them.
-- **Bespoke diff/serialize for the genuinely complex types** — table
-  (3,528 LOC including a 975-line `table.alter.ts` with ~25 ALTER variants),
-  procedure (signature-keyed identity), view/materialized-view
-  (replace-vs-alter, dependency reconstruction). These are escape hatches in
-  the registry, never templated.
-- **Full in-memory catalog materialization.** At 10k objects the catalog is
-  tens of MB — trivial. Streaming/lazy diffing would forfeit cross-type
-  dependency resolution and fingerprinting for no measurable win below ~100k
-  objects. Explicitly rejected as premature.
-- **Sequential single-transaction apply**
-  ([apply.ts:125-131](../packages/pg-delta/src/core/plan/apply.ts)). Parallel
-  DDL apply is rejected: DDL takes `ACCESS EXCLUSIVE` locks, would deadlock on
-  shared catalogs, and would break the transaction as the atomicity boundary.
-  The topological order exists exactly so that serial execution is safe.
-- **The pg-delta / pg-topo identity duplication is deliberate.** pg-delta's
-  stable IDs (`table:public.users`) are a *catalog-exact wire format*,
-  persisted in plan fingerprints and matched against `pg_depend`-derived rows.
-  pg-topo's `ObjectRef` is a *lexical-approximate* identity recovered from
-  parsed SQL (quoted-identifier normalization, signature inference,
-  builtin-type filtering). The packages also differ in cycle policy: pg-delta
-  rewrites cycles (change injection); pg-topo reports them (diagnostics).
-  Unifying these would force the exact world to carry the approximate world's
-  fuzzy-matching semantics. Future contributors should not "DRY" them
-  together.
+Five sub-problems follow from this statement, and any architecture in this
+space must answer all five: state capture, comparison, action synthesis,
+ordering, execution. Every serious tool (pg_dump/pg_restore itself, migra,
+pg-schema-diff, atlas, skeema) converges on this staged shape; the
+architectural freedom — and where this design differs from the current
+codebase — is *within* the stages: where semantic knowledge lives, who is
+trusted to elaborate PostgreSQL semantics, how cycles are handled, and how
+correctness is established.
+
+Out of scope, permanently: data migrations (DML). The tool's contract is
+schema state, not data movement.
 
 ---
 
-## 3. Correctness & performance track
+## 2. The two principles
 
-### 3.1 Snapshot-consistent parallel extraction
+Everything in this design follows from two principles.
 
-**Problem.** `extractCatalog` fires ~28 extractors via `Promise.all` over a
-`pg.Pool`
-([catalog.model.ts:352-381](../packages/pg-delta/src/core/catalog.model.ts))
-whose default size is 5
-([postgres-config.ts:108](../packages/pg-delta/src/core/postgres-config.ts)).
-Each query lands on whatever connection frees up, at a different wall-clock
-time, with no shared transaction. Consequences:
+### P1 — Postgres is the only elaborator
 
-- **Correctness**: the object queries and the `pg_depend` query
-  ([depend.ts:511](../packages/pg-delta/src/core/depend.ts)) can observe
-  different database states under concurrent DDL. The result is a catalog
-  whose dependency rows reference objects the catalog doesn't contain (or
-  vice versa). The `unknown:` filter in
-  [graph-builder.ts:26-33](../packages/pg-delta/src/core/sort/graph-builder.ts)
-  silently drops such edges — masking the symptom, losing real ordering
-  information.
-- **Latency**: 28+ queries contending for 5 connections ≈ six serial waves,
-  and each of the heavy queries (`pg_get_*def`, `aclexplode`, lateral joins)
-  pays planning and queueing overhead. `applyPlan` runs **three full
-  extractions** per apply: source + target up front
-  ([apply.ts:83-86](../packages/pg-delta/src/core/plan/apply.ts)) and a
-  post-apply verification extract
-  ([apply.ts:138-152](../packages/pg-delta/src/core/plan/apply.ts)).
+The single deepest source of bugs in this tool class is reimplementing
+PostgreSQL semantics: name resolution, type elaboration, dependency
+inference, default normalization. The current codebase half-commits to this
+principle (dependency edges come from `pg_depend`, never from parsing — the
+right call) but still runs **three** semantic engines:
 
-**Target.** The pg_dump-parallel model — one exported snapshot, N workers:
+1. catalog extraction (exact),
+2. pg-topo's libpg-query static analysis (approximate — quoted-identifier
+   normalization, signature inference, builtin-type filtering are all
+   heuristic recoveries of what Postgres already knows),
+3. declarative apply's round-based retry, which is "ask Postgres for
+   forgiveness, one error message at a time"
+   ([round-apply.ts:252-281](../packages/pg-delta/src/core/declarative-apply/round-apply.ts),
+   worst-case O(n²) statement executions).
 
-```ts
-// catalog.model.ts (sketch)
-const lead = await pool.connect();
-await lead.query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY");
-const { rows: [{ snap }] } = await lead.query("SELECT pg_export_snapshot() AS snap");
+The north star has **one**: every input state is resolved by an actual
+Postgres instance. Live databases trivially; SQL files by applying them to an
+ephemeral shadow database and extracting the result; the system's own output
+by applying it to a scratch clone and re-extracting (§3.7). No static SQL
+parser exists anywhere in the trusted path. Static analysis survives only as
+a developer-experience layer (§4.4).
 
-const runExtractor = async <T>(extract: (c: ClientLike) => Promise<T>) => {
-  const worker = await pool.connect();
-  await worker.query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY");
-  await worker.query(`SET TRANSACTION SNAPSHOT '${snap}'`);
-  try { return await extract(worker); }
-  finally { await worker.query("COMMIT"); worker.release(); }
-};
-// run all extractors (objects + depends + version + user) with bounded
-// concurrency over the same snapshot, then COMMIT + release the lead.
-```
+### P2 — PostgreSQL knowledge exists in exactly two forms
 
-Every extractor sees the exact same database state; parallelism is preserved
-(and improves, since the pool default rises to match the worker count). This
-is days of work and fixes the bug outright.
+The per-type knowledge — what is alterable, what forces replacement, what
+cascades implicitly, what locks, what rewrites — is the irreducible core of
+the problem. Today it is smeared across **eight forms**: extractor SQL, Zod
+models, per-type diff functions, 106 change classes, serializers, custom
+sort constraints, cycle breakers, and post-diff normalization passes. Every
+new PostgreSQL version or object type touches most of them.
 
-**Second step, only if profiling justifies it**: collapse the per-type queries
-into ~6 "object family" queries returning `jsonb_agg` rows (relations,
-routines, types, security, replication, misc), cutting round-trips ~5×. A
-single mega-query is rejected — planner-hostile and unmaintainable.
+The north star has **two**:
 
-**Also**: make the post-apply verification extract **opt-in** instead of
-opt-out (today it runs unless `verifyPostApply: false`,
-[apply.ts:138](../packages/pg-delta/src/core/plan/apply.ts)). The plan's
-fingerprint contract already guards pre-apply state; the third extraction is a
-paranoia check that belongs in CI, not in every production apply. One-third
-fewer extractions per apply.
+1. **Extraction queries** — catalog → facts (the existing extractor SQL
+   corpus, the most valuable code in the repository, survives nearly
+   verbatim).
+2. **The rule table** — fact-deltas → actions (§3.3).
 
-### 3.2 Content-hash equality
-
-**Problem.** `BasePgModel.equals`
-([base.model.ts:70-75](../packages/pg-delta/src/core/objects/base.model.ts))
-delegates to `deepEqual`, which is
-`stringifyWithBigInt(a) === stringifyWithBigInt(b)`
-([objects/utils.ts:36-37](../packages/pg-delta/src/core/objects/utils.ts)) —
-a full recursive `JSON.stringify` of both sides, recomputed for every shared
-object on every diff. For a table model (columns, constraints, privileges,
-security labels) that is a deep tree. At 10k shared objects, this dominates
-diff CPU. `table.diff.ts` already works around it locally with
-cheap-scalar-first comparisons — evidence the cost is real.
-
-**Target.** A memoized content hash on the base model:
-
-```ts
-// base.model.ts (sketch)
-abstract class BasePgModel {
-  #contentHash?: string;
-  get contentHash(): string {
-    return (this.#contentHash ??= hashCanonical(this.stableSnapshot().data));
-  }
-  equals(other: BasePgModel): boolean {
-    return this.stableId === other.stableId
-        && this.contentHash === other.contentHash;
-  }
-}
-```
-
-`hashCanonical` = canonical serialization (sorted keys, bigint-safe — the
-existing `stringifyWithBigInt` semantics) fed to a fast non-cryptographic hash
-(xxhash64 or FNV-1a). The hash is computed once per object, lazily, and
-overlaps with extraction I/O wait. `stableSnapshot()` is already the correct
-equality surface — subclasses override it to drop unstable fields (the
-"physical attnums vs logical names" rule), so the hash inherits every
-normalization for free.
-
-Two integration points:
-
-- `fingerprint.ts` already canonically stringifies models for plan
-  fingerprints; feed it the same canonical string so the work is shared (keep
-  SHA-256 there — fingerprints cross machine boundaries).
-- Keep `table.diff.ts`'s scalar fast paths: they classify *what kind* of
-  ALTER to emit for objects already known to differ. The hash replaces only
-  the *are-they-equal* gate.
-
-Diff becomes O(n) 8-byte compares. Expected 5–20× on the diff stage at scale.
-
-### 3.3 Sort: build once, scan only what changed
-
-**Problems** (all in `src/core/sort/`):
-
-1. `convertCatalogDependenciesToConstraints` iterates **every** `pg_depend`
-   row in the catalog on every sort
-   ([graph-builder.ts:26](../packages/pg-delta/src/core/sort/graph-builder.ts)),
-   regardless of how many changes are being sorted. A one-change diff against
-   a 10k-object catalog (≈100k+ depend rows) pays the full scan — twice, once
-   per phase.
-2. `sortPhaseChanges` re-invokes `attemptSortRound` from scratch after every
-   cycle-breaking change injection
-   ([sort-changes.ts:259-289](../packages/pg-delta/src/core/sort/sort-changes.ts)),
-   and `attemptSortRound` rebuilds all graph data each call
-   ([sort-changes.ts:161-167](../packages/pg-delta/src/core/sort/sort-changes.ts)).
-3. `performStableTopologicalSort` keeps its ready-queue sorted with linear
-   scan + `splice`, and pops with `shift`
-   ([topological-sort.ts:33-52](../packages/pg-delta/src/core/sort/topological-sort.ts))
-   — O(V²) exactly in the large-schema case where thousands of independent
-   nodes are ready simultaneously.
-4. `logicalSort`'s comparator re-runs regexes per comparison
-   ([logical-sort.ts:71-73](../packages/pg-delta/src/core/sort/logical-sort.ts)).
-
-**Target**, in order of impact:
-
-1. **Pre-filter depend rows to the change set.** Index the phase's
-   created/required stable IDs first, then visit only depend rows whose
-   endpoints appear in that index. Sorting cost becomes O(changes ·
-   avg-fanout) instead of O(catalog). This is the single biggest sort win and
-   makes the common dev-loop case (tiny diff, huge database) effectively
-   O(changes).
-2. **Build the graph once per phase; patch on injection.** Cycle injection
-   adds a handful of changes — extend the adjacency/index structures
-   incrementally instead of rebuilding. Re-running `findCycle` after each
-   repair is fine (cycles are rare); rebuilding everything is not.
-3. **Binary min-heap ready-queue** keyed by original index → O(E log V),
-   identical output order (the tie-break rule is unchanged).
-4. **Parse stable IDs once** into structs before `logicalSort`'s comparator
-   runs (this falls out of typed stable IDs, §4.1).
-
-The phase structure, edge semantics, weak-edge filters, and cycle-breaker
-logic are untouched; the existing sort test suite is the oracle.
-
-**Expected multipliers** (estimates, to be validated with a benchmark fixture
-at ~10k objects): extraction 2–4×, diff 5–20×, sort 3–10× — compounding,
-since they are different pipeline stages.
+Everything between — diffing, ordering, planning, verification — is generic
+machinery that never changes when Postgres evolves. Supporting PostgreSQL 19
+means updating extraction queries and adding rules. **That is the
+scalability that matters most over a decade: scaling with PostgreSQL's
+evolution, not only with schema size.**
 
 ---
 
-## 4. Simplicity track
-
-### 4.0 Where the volume is
-
-`src/core/objects/` = **256 source files / 31,162 LOC** + **127 test files /
-18,505 LOC**, across 21 object-type directories (some hold multiple kinds:
-`type/` → enum/composite/range; `foreign-data-wrapper/` → FDW, server,
-foreign table, user mapping). Each type follows the same template —
-`<type>.model.ts`, `<type>.diff.ts`, and a `changes/` directory with
-create/alter/drop/comment/privilege/security-label classes — for **106
-concrete change classes** total.
-
-The decisive finding: **everything downstream of diffing is already
-generic.** The sort, plan, and apply layers consume only
-`creates/drops/requires/invalidates` + `serialize()`. The 106 classes exist
-to produce four string arrays and one SQL string each. Per-type *information*
-varies; per-type *structure* almost never does. Roughly 65% of the volume is
-structural duplication, concentrated in the ~15 cookie-cutter types
-(collation 676 LOC, extension 646, language 758, schema 792 … up to
-publication 1,116), while table (3,528), procedure (1,608), role (1,815), and
-the view family carry genuinely irreducible logic.
-
-The duplication also leaks outward as five hand-maintained per-`objectType`
-dispatch sites that must be edited for every new type:
-
-- `getPrivilegeTargetStableId`
-  ([catalog.diff.ts:47](../packages/pg-delta/src/core/catalog.diff.ts))
-- `getSchema`
-  ([change-utils.ts:10](../packages/pg-delta/src/core/change-utils.ts))
-- `getPrimaryStableId`
-  ([fingerprint.ts:88](../packages/pg-delta/src/core/fingerprint.ts))
-- `OBJECT_TYPE_TO_PROPERTY_KEY`
-  ([change.types.ts:65](../packages/pg-delta/src/core/change.types.ts), used
-  by `integrations/filter/flatten.ts`)
-- `getFilePath`
-  ([export/file-mapper.ts:59](../packages/pg-delta/src/core/export/file-mapper.ts))
-
-### 4.1 Typed stable IDs (first — it unblocks everything)
-
-Stable IDs are strings built by `stableId.*` helpers but **re-parsed** with
-regex/string slicing where structure is needed — e.g.
-`stableId.slice("procedure:".length, paren)` and `normalizeDependentId` in
-[expand-replace-dependencies.ts:419-425](../packages/pg-delta/src/core/expand-replace-dependencies.ts).
-That is fragile (quoting, signature commas) and scatters the format.
-
-**Target**: one parsed value type with a frozen canonical string form.
-
-```ts
-// src/core/stable-id.ts (sketch)
-export type StableId =
-  | { kind: "schema"; schema: string }
-  | { kind: "table" | "view" | "materializedView" | "sequence" | "domain"
-        | "collation" | "type" | "foreignTable"; schema: string; name: string }
-  | { kind: "procedure"; schema: string; name: string; args: string[] }
-  | { kind: "column" | "constraint" | "index"; schema: string; table: string; name: string }
-  | { kind: "role"; role: string }
-  | { kind: "comment" | "acl" | "securityLabel"; target: StableId; /* … */ }
-  | { kind: "membership"; role: string; member: string }
-  // … defacl, server, userMapping, foreignDataWrapper, …
-
-export function formatStableId(id: StableId): string; // byte-identical to today's strings
-export function parseStableId(s: string): StableId;
-```
-
-**The wire format is frozen.** Stable-ID strings are persisted in plan
-fingerprints and matched against SQL-side string synthesis in `depend.ts`;
-`formatStableId` must reproduce today's output byte-for-byte, verified by a
-parse/format round-trip test over every existing helper. Graph keys and the
-change contract keep using strings; structure is recovered with
-`parseStableId` instead of regex.
-
-### 4.2 One generic `Change` family with a typed `ref`
-
-Today every change class carries its model under a per-type property
-(`.table`, `.collation`, …), which is what forces the five dispatch switches
-and the 21-member union in
-[change.types.ts](../packages/pg-delta/src/core/change.types.ts).
-
-**Target**: the base change exposes one uniform reference —
-
-```ts
-interface ObjectRef {
-  objectType: ObjectType;
-  stableId: StableId;
-  model: BasePgModel;
-}
-
-abstract class Change {
-  abstract operation: "create" | "alter" | "drop";
-  abstract scope: "object" | "comment" | "privilege" | "security_label" | "membership" | "default_privilege";
-  abstract ref: ObjectRef;
-  abstract creates: string[];   abstract drops: string[];
-  abstract requires: string[];  get invalidates(): string[] { return []; }
-  abstract serialize(options?: SerializeOptions): string;
-}
-```
-
-— plus a small set of generic concrete shapes (`GenericCreate`,
-`GenericDrop`, `GenericAlter` with a discriminated `action` payload,
-`SetComment`, `GrantPrivilege` / `RevokePrivilege` / `RevokeGrantOption`,
-`SetSecurityLabel`) whose behavior is driven by the registry (§4.3). Complex
-types keep their bespoke classes (`AlterTableAlterColumnType` et al.) but
-extend the same base and expose the same `ref`.
-
-With `ref` in place, all five switches collapse to one-liners
-(`change.ref.stableId`, `change.ref.model.schemaName`, a registry lookup for
-file paths) and `OBJECT_TYPE_TO_PROPERTY_KEY` is deleted. The filter DSL's
-public `<objectType>/<field>` paths are preserved by flattening `ref.model`
-under the same keys — guarded by a key-set equality test (§9).
-
-### 4.3 `ObjectTypeSpec` registry + one generic diff engine
-
-```ts
-// src/core/registry/spec.ts (sketch)
-interface ObjectTypeSpec<M extends BasePgModel> {
-  objectType: ObjectType;
-  sqlKeyword: string;                  // "COLLATION", "TABLE", …
-  hasComment: boolean;
-  hasPrivileges: boolean;              // + columnLevelPrivileges for relations
-  hasSecurityLabel: boolean;
-  extract(pool: Pool): Promise<M[]>;   // existing extractor, referenced not rewritten
-  requires(model: M): StableId[];      // schema, owner, types, collations, …
-  identitySql(model: M): string;       // "schema.name" / "schema.name(args)"
-  serializeCreate(model: M, opts?: SerializeOptions): string;
-  alterableFields?: Record<string, (m: M, opts?: SerializeOptions) => string>;
-  customDiff?(ctx: DiffContext, main: Record<string, M>, branch: Record<string, M>): Change[];
-}
-```
-
-One generic engine consumes the spec: set-algebra created/dropped/altered
-(via §3.2 hashes), then emits `GenericCreate` (+ owner alter, comments,
-grants, security labels), `GenericDrop`, and per-field `GenericAlter` —
-falling back to drop+create for non-alterable fields. It reuses the existing
-shared helpers (`emitObjectPrivilegeChanges` — already used by 16 of 21
-types — and `diffSecurityLabels` — 18 of 21); the registry deletes the
-per-type *class wrappers* around them, not the logic. `diffCatalogs`'s 21
-hand-sequenced imports become a loop over the registry.
-
-**Scope boundary**: the ~15 cookie-cutter types go fully generic. Table,
-procedure, view, materialized-view, role, and subscription keep their
-diff/serialize behind `customDiff` and only adopt the generic
-comment/privilege/security-label shapes. Quirky-but-simple cases (collation's
-`REFRESH VERSION`) are an `alterableFields` entry, not a reason to fork.
-
-**Quantified estimate**: −11–12K source LOC and ~150 fewer files (≈35–40% of
-`objects/`), with a comparable test-LOC reduction after per-class test files
-collapse into per-spec tests. Adding a future object type drops from ~13
-files to ~2 (model + spec).
-
-### 4.4 `depend.ts` decomposition
-
-[depend.ts](../packages/pg-delta/src/core/depend.ts) is 1,895 lines but only
-two functions: `extractPrivilegeAndMembershipDepends` (line 43 — a series of
-independent `aclexplode`/membership/defacl sub-queries) and `extractDepends`
-(line 511 — the core `pg_depend` synthesis query with 30+ CTEs).
-
-**Target**: split the ACL/membership part into ~5 named functions
-(`relationAclDepends`, `schemaAclDepends`, `membershipDepends`,
-`defaclDepends`, `fdwAclDepends`) run via `Promise.all` — they are already
-independent queries. **Keep the core `pg_depend` query whole**: it is one
-recursive join over `pg_depend`; splitting it would multiply round-trips and
-re-implement the OID→stable-ID mapping N times. Centralize the SQL-side
-stable-ID `format(...)` literals into one CTE that mirrors `formatStableId`,
-so the wire format lives in exactly two audited places (TS + SQL).
-
-Moving per-type dependency extraction next to each type's extractor was
-evaluated and rejected: dependency synthesis is inherently cross-type.
-
-### 4.5 Explicit plan pipeline
-
-`diffCatalogs` currently interleaves raw diffing with an inline
-dropped-target ACL filter, then callers wire `expandReplaceDependencies` and
-`normalizePostDiffChanges` around it. **Target**: a named stage list with one
-contract —
-
-```ts
-const STAGES: Array<(changes: Change[], ctx: PlanContext) => Change[]> = [
-  rawDiff, filterDroppedObjectAcls, expandReplaceDependencies, normalizePostDiffChanges,
-];
-```
-
-This is a wiring change only. The CLAUDE.md doctrine that these stages are
-distinct *by the information they need* is preserved — the goal is to make
-the chokepoints legible and independently testable, not to merge them.
-
-### 4.6 Migration order (each step independently shippable)
-
-Old and new coexist throughout because everything downstream speaks the same
-change contract; the registry dispatches per-type to either the spec engine
-or the legacy diff function during transition.
-
-1. Typed stable IDs (`stable-id.ts`), helpers reimplemented on top; replace
-   the parsers in `expand-replace-dependencies.ts`. Zero wire-format drift,
-   proven by round-trip tests.
-2. Add `ref` to the base change (temporary adapter derives it from existing
-   per-type properties); collapse the five switches; delete
-   `OBJECT_TYPE_TO_PROPERTY_KEY`.
-3. Registry + generic engine; migrate **collation**, then **extension** as
-   proofs. Each migration deletes a `changes/` directory and a `*.diff.ts`.
-4. Batch-migrate the remaining cookie-cutter types, one PR per batch.
-5. Complex types last: route through the registry via `customDiff`; swap
-   their comment/privilege/seclabel wrappers for the generic shapes; bespoke
-   alter classes stay.
-6. Delete the legacy union and dead base plumbing.
-
-**Hard rule per PR: zero serialized-SQL drift.** The existing per-type diff
-tests and the integration roundtrip suite are the oracle; a migration PR that
-changes any emitted SQL byte is wrong by definition.
-
----
-
-## 5. API & packaging track (moderate)
-
-### 5.1 Layered subpath exports
-
-The current root export is a flat bag mixing catalog, plan, execution, and
-integration concerns, while the two most reusable functions —
-`diffCatalogs` and `sortChanges` — are internal. Embedders (e.g. the
-Supabase CLI) that already hold two catalogs must go through the monolithic
-`createPlan`.
-
-**Target** `@supabase/pg-delta` exports:
+## 3. The architecture
 
 ```text
-.              createPlan / applyPlan / extractCatalog (facade — unchanged)
-./catalog      extractCatalog, serializeCatalog, deserializeCatalog, snapshots
-./diff         diffCatalogs(main, branch) -> Change[]
-./sort         sortChanges(ctx, changes) -> Change[]
-./plan         createPlan, applyPlan, Plan, fingerprints, sql-format
-./integrations filter + serialize DSL (vendor-neutral) — supabase stays at
-               ./integrations/supabase
-./catalog-export  (existing, unchanged)
+frontends:   live DB ──(single-snapshot extract)──┐
+             SQL files ──(shadow-DB elaboration)──┼──▶  FACT BASE
+             snapshot JSON ───────────────────────┘     typed facts + dependency edges,
+                                                        content-addressed (hash per object)
+                                  │
+                     generic set-diff (hash compare — zero per-type code)
+                                  │
+                              DELTA SET
+                                  │
+                     RULE TABLE  ◀── the only per-type logic in the system
+                                  │
+                          ATOMIC ACTIONS
+              maximally decomposed; each declares produces / consumes /
+              destroys, lock class, rewrite risk, data-loss class,
+              transactionality
+                                  │
+              ONE dependency graph → one deterministic topological sort
+              (a cycle is a rule bug caught by CI, not a runtime repair job)
+                                  │
+              optional COMPACTION: merge adjacent actions into idiomatic DDL
+              only where no edge crosses the merge (cosmetics; off for machines)
+                                  │
+                   PLAN = actions + fingerprints + safety report
+                                  │
+            ┌── PROOF: apply to scratch clone, re-extract, hash-compare ──┐
+            └──────────── apply (lock-aware segmented txns) ──────────────┘
 ```
 
-Each layer is independently usable; the facade stays the documented happy
-path. The `Plan` + fingerprint contract is good and keeps its shape.
+### 3.1 The fact base
 
-### 5.2 WASM-free core install
+One normalized, immutable representation of "a schema state," identical
+regardless of origin. Three properties define it:
 
-`@supabase/pg-topo` is imported in `src/core/` **only** by
-`declarative-apply/` and one dev-time test helper — the code boundary is
-clean; the manifest is not
-([package.json:80-89](../packages/pg-delta/package.json) makes it a hard
-dependency, dragging libpg-query WASM into every install).
+- **Typed identity.** Stable IDs are a parsed discriminated union
+  (`{kind: "procedure", schema, name, args}` …) with a frozen canonical
+  string form for persistence and graph keys. Structure is accessed by
+  field, never recovered by regex (today:
+  [expand-replace-dependencies.ts:419-425](../packages/pg-delta/src/core/expand-replace-dependencies.ts)
+  slices `"procedure:"` strings apart).
+- **Content addressing.** Every object carries a content hash computed once
+  at construction from its normalized equality surface (the existing
+  `stableSnapshot()` normalizations — the "physical attnums vs logical
+  names" doctrine — carry over intact). A catalog is effectively a Merkle
+  set: equality checks, fingerprints, no-op detection, and caching are all
+  O(1) per object. (Today equality is a double `JSON.stringify` per shared
+  object per diff —
+  [base.model.ts:70-75](../packages/pg-delta/src/core/objects/base.model.ts),
+  [objects/utils.ts:36-37](../packages/pg-delta/src/core/objects/utils.ts).)
+- **Dependencies as facts.** `pg_depend`-derived edges (plus the synthesized
+  ACL/membership/ownership edges) are part of the state, extracted under the
+  same snapshot as everything else.
 
-**Target**: move `@supabase/pg-topo` to an **optional peer dependency**,
-loaded via dynamic `import()` inside `declarative-apply` with a clear error
-("declarative apply requires @supabase/pg-topo — install it alongside
-@supabase/pg-delta") when absent.
+### 3.2 Frontends: one elaborator, three doors
 
-`@stricli/core` and `chalk` were evaluated under the same lens and **kept**
-as regular dependencies for now: they are a few kB of pure JS — the cost of
-splitting a CLI package today outweighs the win. Revisit if/when an embedder
-objects or §7 changes the CLI's shape.
+- **Live database**: all extraction queries run against one exported
+  snapshot (`pg_export_snapshot()` + `SET TRANSACTION SNAPSHOT` on N worker
+  connections — the pg_dump-parallel model). Parallel *and* consistent.
+  Today's extraction has neither property: ~28 queries race over a 5-connection
+  pool with no shared transaction
+  ([catalog.model.ts:352-381](../packages/pg-delta/src/core/catalog.model.ts),
+  [postgres-config.ts:108](../packages/pg-delta/src/core/postgres-config.ts)),
+  so the catalog and its dependency rows can disagree under concurrent DDL —
+  masked by the `unknown:` filter in
+  [graph-builder.ts:26-33](../packages/pg-delta/src/core/sort/graph-builder.ts).
+- **SQL files**: applied in a single pass to an ephemeral shadow database
+  (template-cloned; `check_function_bodies = off`), then extracted. The
+  desired state is whatever Postgres actually builds — no fuzzy reference
+  matching, no retry heuristics. This *is* the declarative workflow.
+- **Snapshots**: the serialized fact base round-trips losslessly (exists
+  today as `serializeCatalog`/`deserializeCatalog`; becomes the contract for
+  offline diffing, fixtures, and caching).
 
-### 5.3 Rejected restructurings (recorded so they are not re-litigated)
+### 3.3 Generic diff
 
-- **Five-package split** (`pg-delta` / `pg-delta-cli` / `pg-delta-declarative`
-  / `pg-delta-supabase` / `pg-graph`): cleanest boundaries, but five
-  changeset-coupled packages for one tool is real release overhead, and the
-  two concrete pains it solves (WASM weight, layered API) are solved by §5.1
-  + §5.2 without it. Deferred until a second embedder demands it.
-- **Shared `pg-graph` kernel** for the Kahn/Tarjan code used by both
-  packages: the genuinely identical code is ~80 lines; everything around it
-  (tie-break semantics, cycle policy) is intentionally different (§2). Not
-  worth a package.
+With content addressing, comparison is set algebra on `(stableId → hash)`:
+added, removed, changed. **Zero per-type diff code** — no `table.diff.ts`
+(1,034 lines today), no per-type diff functions at all. Per-type knowledge is
+not needed to detect *that* something changed; it is needed only to decide
+*what to do about it* — which is the rule table's job.
 
-### 5.4 Monorepo hygiene
+### 3.4 The rule table
 
-- Move `packages/bun-istanbul-coverage` → `tools/` — it is private test
-  infrastructure, not a product, and currently gets swept by every
-  `--filter '*'` script.
-- Document why the root `.stubs/cpu-features` override exists (testcontainers
-  → ssh2 transitive native dep) so it survives cleanup passes.
-- Defer any `tests.yml` split until §6 reshapes the test pyramid.
+The only per-type logic in the system. For each object kind, structured data
+declares:
 
----
-
-## 6. Test & CI velocity track
-
-The integration matrix is 45 jobs (3 PG versions × 15 shards, ~10–14 min
-each). Profiling the harness shows the time goes to per-test lifecycle, not
-to assertions:
-
-- Every `withDb` test creates **two databases** and two fresh pools
-  ([container-manager.ts:148-170](../packages/pg-delta/tests/container-manager.ts)),
-  and cleanup opens a **third pool per database** just to probe for
-  subscriptions
-  ([container-manager.ts:176-199](../packages/pg-delta/tests/container-manager.ts)).
-- Supabase-flavored tests replay the multi-MB base-init SQL blob into **both**
-  databases per test
-  ([tests/utils.ts:76-95](../packages/pg-delta/tests/utils.ts)).
-- Every roundtrip test pays 2–3 full catalog extractions (§3.1 makes these
-  cheaper, but fewer is better than faster).
-
-**Target**, in order of leverage:
-
-1. **Template databases.** Build the Supabase baseline once per container
-   into `supabase_base`, then per-test isolation becomes
-   `CREATE DATABASE … TEMPLATE supabase_base` — a file-level copy — instead
-   of replaying the SQL blob twice per test.
-2. **Fixture-first test pyramid.** `serializeCatalog`/`deserializeCatalog`
-   already exist. Capture `(catalogA, catalogB)` JSON fixtures once (from a
-   container run, regenerated by script like the existing Supabase baselines),
-   and turn the bulk of "this DDL change produces these statements"
-   assertions into **Docker-free unit tests** of
-   `diffCatalogs` + `sortChanges` + serialization. Keep a deliberately thin
-   ring of true roundtrip-fidelity integration tests (extract → diff → apply
-   → re-extract → assert convergence) as the safety net. This is the change
-   that structurally shrinks the 45-job matrix rather than just speeding it
-   up.
-3. **Skip the subscription probe** unless the test declared it creates
-   subscriptions; reuse the admin pool for cleanup.
-
-Expected: 2–5× integration wall-clock from (1) + (3), and a materially
-smaller matrix from (2). The shard count and PG-version list then get
-revisited from data, not guessed.
-
----
-
-## 7. Declarative apply: converge on shadow-DB diff
-
-Today there are two ordering engines: the diff path (catalog-exact,
-`pg_depend`-driven) and declarative apply (pg-topo static sort + round-based
-retry, `maxRounds = 100` —
-[round-apply.ts:252-281](../packages/pg-delta/src/core/declarative-apply/round-apply.ts)).
-Round-retry is simple and battle-tested, but worst-case O(n²) statement
-executions against the live database, and it is only as good as static
-parsing — every defer is a wasted network round-trip caused by an edge the
-parser could not see.
-
-**Decision: converge on shadow-DB diff as the canonical declarative path.**
-
-```text
-.sql files ──single pass──▶ scratch/shadow DB ──extractCatalog──▶ desired Catalog
-                                                       │
-live target ──extractCatalog──▶ current Catalog ──diffCatalogs/createPlan──▶ plan
+```ts
+// sketch — rules are data with functions in narrow slots only
+interface KindRules<M> {
+  kind: ObjectKind;
+  identitySql(m: M): string;
+  createTemplate(m: M): string;                    // bare object only (§3.5)
+  attributes: Record<string, AttributeRule<M>>;    // per changed attribute:
+  //   { alter: (old, new) => string }             //   in-place ALTER
+  //   | { replace: true }                         //   forces drop+create
+  //   | { replace: (old, new) => boolean }        //   conditional (e.g. column type)
+  implicitlyDrops(m: M): StableId[];               // cascade knowledge (DROP TABLE → its
+                                                   // constraints, columns, owned sequences)
+  lockClass(action: Action): LockClass;
+  rewriteRisk(action: Action): boolean;
+  dataLossClass(action: Action): DataLoss;
+}
 ```
 
-- Postgres itself resolves the desired state (no fuzzy `ObjectRef` matching,
-  no retry heuristics); the trusted `pg_depend` engine produces the plan; the
-  output is byte-identical in style to the diff path. `createPlan` already
-  accepts a resolved `Catalog` input, so the plumbing exists.
-- **pg-topo narrows to its honest strengths**: dev-time ordering of `.sql`
-  files for humans, syntax validation, dependency diagnostics, cycle
-  reporting. It stops being a production apply engine.
-- **Round-based apply remains as the fallback** for environments that cannot
-  reach a scratch database, and is not retired until the shadow-DB path is
-  green across the full integration matrix. Near-term improvement to the
-  fallback: single-pass execution with a bounded deferred queue instead of
-  full-round restarts.
+Hard cases — column type changes, view replacement chains, procedure
+signature identity — are *conditional rules with more structure*, not
+imperative escape hatches. The discipline that keeps rules from degenerating
+into code-in-disguise: functions appear only in predicate and template
+slots, and every rule's claims are checked by the proof loop (§3.7) — a rule
+that lies about cascades or alterability produces a state mismatch in CI,
+not a latent bug.
 
-Honest trade-offs, stated once: the shadow path requires a reachable Postgres
-(scratch database, throwaway container, or template-created sibling DB); it
-adds one extraction + diff of latency; round-apply needs nothing but the
-target and has accumulated real-world mileage. That is why this is a
-convergence with a fallback, not a replacement.
+This replaces, outright: 21 per-type diff functions, 106 change classes, the
+five per-`objectType` dispatch switches
+([catalog.diff.ts:47](../packages/pg-delta/src/core/catalog.diff.ts),
+[change-utils.ts:10](../packages/pg-delta/src/core/change-utils.ts),
+[fingerprint.ts:88](../packages/pg-delta/src/core/fingerprint.ts),
+[change.types.ts:65](../packages/pg-delta/src/core/change.types.ts),
+[file-mapper.ts:59](../packages/pg-delta/src/core/export/file-mapper.ts)),
+and the shared privilege/comment/security-label wrapper classes. Today that
+surface is 256 files / 31,162 LOC of source in `objects/` alone; the rule
+table plus models is estimated at a third of it.
+
+### 3.5 Atomic actions: maximal decomposition
+
+Every action is the smallest valid DDL unit: bare `CREATE TABLE`; every
+constraint, default, FK, index, grant, comment, ownership change as its own
+action. Each action declares `produces` / `consumes` / `destroys` (stable
+IDs), plus the safety metadata from its rule.
+
+This is pg_dump's deep trick, adopted wholesale: **pg_dump has no
+cycle-breaker module because at this granularity, cycles structurally cannot
+form** for entire categories of dependencies (mutual FKs, FK-vs-drop
+interleavings). The current codebase already half-believes this — the create
+phase emits constraints as separate `AlterTableAddConstraint` changes
+([table.diff.ts:84](../packages/pg-delta/src/core/objects/table/table.diff.ts)),
+which is exactly why all three cycle breakers
+([cycle-breakers.ts](../packages/pg-delta/src/core/sort/cycle-breakers.ts):
+`tryBreakFkCycle`, `tryBreakPublicationColumnCycle`,
+`tryBreakPublicationFkConstraintDropCycle`) live in the **drop phase**, where
+compound `DROP TABLE` semantics create implicit edges. Worse, the system
+currently fights itself: post-diff normalization *prunes* constraint drops
+for compactness, then the cycle breaker *re-injects* them when compactness
+creates a cycle. The north star resolves the tension in one direction:
+decomposed by construction, compacted only where provably safe (§3.6 output
+stage).
+
+Failure-mode analysis is the argument: with repair, a new cycle class means
+a wrong/unsortable plan in production and a new hand-written breaker (the
+git history is a string of exactly these fixes). With avoidance, the
+worst case is a more verbose script. Verbosity is recoverable; wrongness is
+not.
+
+### 3.6 One graph, one sort, then cosmetic compaction
+
+A single dependency graph over all atomic actions — drops, creates, alters
+together. Edges come from three sources: the old state's dependency facts
+(teardown ordering: an action destroying X follows everything that consumes
+X), the new state's dependency facts (build ordering: an action producing Y
+precedes everything consuming Y), and identity conflicts (drop of `X` before
+create of new `X`). One deterministic Kahn pass (heap-based ready queue,
+tie-break by phase weight → kind weight → name) replaces today's two-phase
+sort + `invalidates` side channel + repair loop: an in-place mutation is
+simply an action that destroys the old fact and produces the new one, and
+the mixed graph orders its dependents' teardown and rebuild around it
+naturally.
+
+**A cycle is a rule bug.** Cycle detection remains as an assertion with a
+high-quality diagnostic, and as a property-test target — never as a runtime
+repair subsystem. (Today: graph rebuilt from scratch on every repair round,
+[sort-changes.ts:161-289](../packages/pg-delta/src/core/sort/sort-changes.ts);
+full catalog depend-row scan regardless of diff size,
+[graph-builder.ts:26](../packages/pg-delta/src/core/sort/graph-builder.ts);
+O(V²) ready queue,
+[topological-sort.ts:33-52](../packages/pg-delta/src/core/sort/topological-sort.ts).
+All of it dissolves rather than getting optimized.)
+
+**Compaction** is the final, optional stage: merge adjacent actions into
+idiomatic compound DDL (constraints inlined into `CREATE TABLE`, column
+clauses folded) only when no graph edge crosses the merge boundary. It is a
+peephole optimization on an already-correct sorted script — it can produce
+ugliness, never wrongness. On by default for humans, off for machines.
+
+### 3.7 Plan and proof
+
+A plan is: ordered actions + source/target fingerprints (which are now just
+fact-base hashes — same machinery as equality) + the safety report
+aggregated from per-action metadata (locks, rewrites, data loss).
+
+**The proof loop is the architecture's keystone.** Because any state can be
+materialized (template-cloned scratch DB) and re-extracted, the planner can
+certify its own output: apply the plan to a clone of the source, extract,
+hash-compare against the desired fact base. Zero diff = proven plan. This
+inverts the correctness economy of the whole project:
+
+- **In CI**: property-based testing becomes the primary coverage engine —
+  generate schemas, generate mutations, roundtrip, assert fixpoint. The
+  hand-written per-type test matrix (127 test files / 18,505 LOC in
+  `objects/`, 63 integration files × 3 PG versions × 15 shards = 45 jobs)
+  shrinks to a thin integration ring around a generative core.
+- **In production**: proof-on-shadow is an optional pre-apply step for
+  high-stakes targets.
+- **For the rule table**: rules that misdeclare cascades or alterability are
+  caught as state mismatches the day they are written, not as field bugs.
+
+### 3.8 Execution
+
+Sequential, lock-aware, segmented: actions self-declare transactionality, so
+the executor groups maximal transactional runs and isolates the exceptions
+(`CREATE INDEX CONCURRENTLY`, …) instead of today's all-or-nothing single
+concatenated script
+([apply.ts:125-131](../packages/pg-delta/src/core/plan/apply.ts), with its
+own `TODO` admitting the gap at
+[apply.ts:122](../packages/pg-delta/src/core/plan/apply.ts)). Parallel DDL
+execution stays rejected — `ACCESS EXCLUSIVE` locks make it a deadlock
+machine, and the transaction is the atomicity contract. Per-statement error
+attribution replaces the joined-string megaquery.
 
 ---
 
-## 8. Phased roadmap
+## 4. Capabilities the design unlocks
 
-| Phase | Content | Effort | Risk | Depends on |
-|---|---|---|---|---|
-| 1 | Snapshot-consistent extraction (§3.1); content-hash equality (§3.2); opt-in post-apply verify; heap topo queue | days | low | — |
-| 2 | Typed `StableId` + `ref` on `Change` + dispatch-switch removal (§4.1–4.2) | ~1 wk | low | — |
-| 3 | `ObjectTypeSpec` registry + cookie-cutter type migration, batched PRs (§4.3) | weeks, incremental | medium (SQL-drift gate) | 2 |
-| 4 | Sort single-build + depend pre-filter (§3.3); `depend.ts` split (§4.4); explicit pipeline (§4.5) | ~1 wk | low–medium | — |
-| 5 | Subpath API (§5.1); optional pg-topo (§5.2); `tools/` move (§5.4) | days | medium (publish config) | — |
-| 6 | Template DBs + fixture-based unit diffs + matrix shrink (§6) | ~1–2 wk | low | — |
-| 7 | Shadow-DB declarative path, feature-flagged, parity-gated (§7) | longer | medium | 5 |
+These are not cleanups — they are features the current architecture cannot
+express:
 
-Phases 1, 2, 5, and 6 are mutually independent and can start immediately;
-phase 3 builds on 2; phase 4 can land any time; phase 7 follows 5 (it wants
-the `./diff` + `./catalog` layers). Every phase ships behind the standing
-rules: changeset per behavior change, RED→GREEN regression tests, zero
-serialized-SQL drift for refactor phases.
+### 4.1 Rename detection
+
+Content addressing makes renames visible: an object removed on one side and
+added on the other **with the same content hash** is a rename candidate →
+emit `ALTER … RENAME` (data-preserving) instead of drop+create
+(data-destroying), governed by policy (`auto` / `prompt` / `off`) since
+hash-equality is necessary but not sufficient evidence of intent. Every tool
+in this class punts on renames; here it falls out of the state
+representation.
+
+### 4.2 Proof-certified plans
+
+"This plan was applied to a clone and produced a byte-identical desired
+state" is a product claim no comparable tool makes. It also gives drift
+detection for free: fingerprint comparison between any environment and any
+snapshot is two hash sets.
+
+### 4.3 Generative testing as the safety net
+
+The oracle stops being "did a human anticipate this case in a test file" and
+becomes "does apply(plan(A→B), A) equal B" over generated A and B. Coverage
+grows with compute, not with test-authoring effort.
+
+### 4.4 An honest role for static analysis
+
+pg-topo exits the trusted path and becomes the developer-experience layer it
+is genuinely good at: instant editor feedback, file ordering for humans
+authoring declarative schemas, lint, cycle diagnostics. Its approximate
+`ObjectRef` identity stops needing to agree with the exact engine, because
+nothing downstream depends on it. (Consequence: the libpg-query WASM
+dependency leaves the core install —
+[package.json:80-89](../packages/pg-delta/package.json) currently forces it
+on every consumer.)
+
+### 4.5 Packaging that falls out instead of being debated
+
+The architecture induces the package shape: a lean core (`pg`, `zod`-class
+deps only) exposing the layers — fact base / diff / plan / proof / apply —
+as independently usable entry points; pg-topo as a dev tool; the CLI as a
+consumer of the public API. No further package engineering is required to
+get a WASM-free, embeddable core.
 
 ---
 
-## 9. Risks & mitigations
+## 5. What survives from today
 
-| Risk | Mitigation |
+The north star is a re-plumbing, not a rewrite of the knowledge. Carried
+over nearly verbatim:
+
+- **The extractor SQL corpus** (`<type>.model.ts` queries) — years of
+  accumulated `pg_catalog` knowledge across PG versions; the single most
+  valuable asset in the repository. It becomes the fact-base producer.
+- **The `pg_depend` doctrine** — deepened from "the diff path's source of
+  truth" to "the only semantic engine, period" (P1).
+- **The normalization knowledge** in `stableSnapshot()` overrides (physical
+  attnums vs logical names, etc.) — it becomes the content-hash surface.
+- **Stable identity** as a concept — upgraded to typed values with a frozen
+  string form.
+- **The plan + fingerprint product contract** — plans as reviewable,
+  version-controllable artifacts with drift detection.
+- **Safety/risk classification** — generalized into per-action metadata
+  supplied by the rule table.
+- **The serialize/filter DSL surface** for integrations (Supabase rules) —
+  re-targeted at actions instead of change classes, same user-facing
+  contract.
+
+## 6. What is retired
+
+| Retired | Replaced by |
 |---|---|
-| **Serialized-SQL byte drift** during the registry migration silently changes real migrations | One type per PR; existing per-type diff tests + integration roundtrip suite as the oracle; a PR that changes any emitted byte fails by definition |
-| **Stable-ID wire-format drift** breaks persisted plan fingerprints and the SQL-side synthesis in `depend.ts` | Format frozen; `formatStableId` round-trip tests over every helper; the SQL-side format lives in one CTE mirrored against the TS helper |
-| **Filter DSL path breakage** — users' filters address `<objectType>/<field>` paths produced by `flatten.ts` | Key-set equality test asserting identical flattened paths before/after for every type |
-| **Registry type erosion** (heterogeneous spec list tempts `any`) | `ObjectTypeSpec<BasePgModel>` at the engine boundary; full model typing stays inside each spec module |
-| **Optional-dependency UX** (declarative apply with pg-topo absent) | Dynamic import with an explicit actionable error; documented in README + CLI help |
-| **Snapshot extraction vs poolers** (`pg_export_snapshot` requires session-level transactions; transaction-mode poolers break it) | Detect and fall back to single-connection serial extraction within one transaction (still consistent, just not parallel) |
-| **Shadow-DB parity is real work** — round-apply handles parser-blind cases today | Flag-gated rollout; round-apply retired only after the full integration matrix is green on the shadow path |
-| **Estimate risk** on the perf multipliers | Add a benchmark fixture (~10k objects) in phase 1 so every later phase measures rather than asserts |
+| 21 per-type diff functions + 106 change classes (256 files / 31,162 LOC) | generic hash diff + rule table (§3.3–3.4) |
+| Two-phase sort + `invalidates` side channel + cycle breakers + dependency filter + post-diff normalization-as-repair | one mixed graph, decomposition by construction, cosmetic compaction (§3.5–3.6) |
+| Round-based declarative apply ([round-apply.ts](../packages/pg-delta/src/core/declarative-apply/round-apply.ts)) | shadow-DB elaboration through the one plan path (§3.2) |
+| pg-topo in the apply path | pg-topo as dev-experience layer (§4.4) |
+| String stable-ID re-parsing | typed `StableId` (§3.1) |
+| `JSON.stringify` equality + triple extraction per apply | content hashes + single-snapshot extraction + proof-as-opt-in (§3.1, §3.2, §3.7) |
+| Hand-written per-type test matrix as primary safety net | generative roundtrip proof + thin integration ring (§4.3) |
+
+## 7. Honest costs
+
+- **Shadow DB requirement.** The SQL-file frontend and the proof loop need a
+  reachable Postgres. Template-cloned databases make it cheap; embedded
+  options (PGlite) may eventually make it serverless, but extension and
+  version parity rule it out of the trusted path today. Environments that
+  cannot reach any scratch database lose the declarative frontend — that is
+  a real constraint and is accepted.
+- **Rule-table expressiveness risk.** The gnarliest ALTER semantics resist
+  tabularization; rules can degenerate into code-in-disguise. Mitigations:
+  functions confined to predicate/template slots, and the proof loop as a
+  lie detector. If a kind genuinely cannot be expressed, the honest response
+  is a structured sub-rule vocabulary, not an imperative escape hatch —
+  escape hatches are how the current eight-forms situation happened.
+- **Verbosity when compaction is conservative.** Cosmetic by construction;
+  the compactor can improve forever without correctness risk.
+- **Proof costs an extra apply + extract.** Optional per environment; cheap
+  with templates and hashes.
+- **Output changes during migration.** Decomposition-by-default changes
+  emitted SQL relative to today. The oracle therefore shifts: refactor
+  phases keep byte-identical output; emission-changing phases are gated on
+  **state-proof equality** (apply both old and new plans to clones —
+  identical resulting fact bases) plus human review of the new shape. Byte
+  drift stops being the invariant; *state* drift becomes the invariant.
+
+## 8. Why the current design cannot simply be tuned into this
+
+The findings below (all verified at `115dde8`) are not isolated bugs — each
+is a direct consequence of an architectural commitment the north star
+removes:
+
+1. **No shared extraction snapshot** (consistency bug) — consequence of
+   extraction being a query fan-out rather than a state capture. §3.2.
+2. **O(n²)-flavored equality and sort costs**
+   ([base.model.ts:70-75](../packages/pg-delta/src/core/objects/base.model.ts),
+   [graph-builder.ts:26](../packages/pg-delta/src/core/sort/graph-builder.ts),
+   [topological-sort.ts:33-52](../packages/pg-delta/src/core/sort/topological-sort.ts))
+   — consequence of state not being content-addressed and the graph being
+   rebuilt as repair. §3.1, §3.6.
+3. **31K LOC of structurally identical per-type code** — consequence of
+   knowledge-in-eight-forms; every object type re-states the same machinery.
+   §3.4 / P2.
+4. **A growing cycle-breaker registry, each entry a field-discovered bug** —
+   consequence of compact-by-default emission + repair-on-detection. §3.5.
+5. **Three semantic engines that must agree but cannot** (exact catalog,
+   approximate parser, retry loop) — consequence of not committing to P1.
+   §3.2, §4.4.
+6. **45-job CI matrix defending hand-written cases** — consequence of
+   lacking a proof loop; correctness must be asserted per-case because it
+   cannot be checked per-run. §3.7.
+
+## 9. The path from here
+
+Each phase is independently shippable, independently valuable, and strictly
+reduces distance to the north star. Standing gates: refactor phases =
+byte-identical SQL (existing tests as oracle); emission-changing phases =
+state-proof equality (§7); every behavior change carries a changeset and a
+RED→GREEN regression test per repository policy.
+
+| # | Phase | North-star component it builds | Notes |
+|---|---|---|---|
+| 1 | Single-snapshot parallel extraction; memoized content hashes on models; hash-based `equals`; post-apply verify becomes explicit proof opt-in | Fact base §3.1–3.2 | Fixes the consistency bug on day one; hashes later power fingerprints, renames, proof |
+| 2 | Typed `StableId` (frozen canonical string form, parse/format round-trip tested); kill regex re-parsing | Fact base identity §3.1 | Wire format byte-frozen — persisted in plan fingerprints |
+| 3 | `provePlan(plan, source)` as a first-class API: template-cloned scratch, apply, extract, hash-compare. Adopt as CI oracle; begin generative roundtrip tests; shrink the hand-written integration matrix as proof coverage grows | Proof loop §3.7, §4.3 | **Do this before touching emission** — it is the safety net for phases 5–8 |
+| 4 | Sort hygiene while the old sort still exists: depend-row pre-filtering to the change set, single graph build per phase, heap queue | Interim perf | Pure wins now; code is absorbed by phase 6 |
+| 5 | Decomposition-by-default emission + the compaction pass; delete cycle breakers by attrition as their cycle classes become unconstructible | §3.5–3.6 | First emission-changing phase; gated on state-proof + review |
+| 6 | One mixed graph (old-state edges + new-state edges + identity conflicts) replaces two-phase + `invalidates` + repair loop | §3.6 | A surviving cycle after 5+6 is a rule/emission bug — fix the rule, never add a breaker |
+| 7 | Rule table: migrate kinds from per-type diff+classes to rules consumed by the generic engine — cookie-cutter kinds first, table/view/procedure as structured conditional rules last; delete the per-type dispatch switches and the change-class union | §3.3–3.4 / P2 | Largest phase; per-kind PRs; proof loop is the oracle |
+| 8 | Shadow-DB frontend for SQL files through the one plan path; round-apply demoted to fallback, then removed; pg-topo repositioned as dev-experience layer; WASM leaves the core install | §3.2, §4.4 | The declarative workflow's correctness becomes the diff engine's correctness |
+| 9 | Rename detection (hash-equal candidates, policy-gated); layered public API finalized (fact base / diff / plan / proof / apply); packaging falls out | §4.1, §4.5 | The visible product payoff |
+
+Ordering rationale: 1–3 build the measurement and safety instruments; 4 is
+opportunistic; 5–7 are the structural inversion under proof protection; 8–9
+are the product payoff. Phases 1, 2, 4 can start immediately and in
+parallel.
+
+## 10. Decision log
+
+- **2026-06-12** — This document supersedes the earlier incremental-roadmap
+  framing of itself. The maintainer's direction: define the **technical
+  optimum without regard to past choices**; it is the project's north star.
+  Earlier scoping decisions made under the incremental framing (e.g.
+  "moderate packaging") are superseded where this document derives a
+  different answer; the shadow-DB convergence decision is unchanged and now
+  central (P1).
+- Open questions intentionally left to their phases: compaction's default
+  aggressiveness (phase 5), rename-policy default (phase 9), the minimum
+  integration-test ring kept alongside generative proof (phase 3).
 
 ---
 
-## Appendix: baseline metrics
+## Appendix: baseline metrics (commit `115dde8`)
 
-| Metric | Value (commit `115dde8`) |
+| Metric | Value |
 |---|---|
 | pg-delta source (src/) | ~88K LOC, ~511 files |
 | `src/core/objects/` | 256 source files / 31,162 LOC; 127 test files / 18,505 LOC |
 | Object-type directories / concrete change classes | 21 / 106 |
 | `depend.ts` | 1,895 LOC, 2 functions, 30+ CTEs |
-| `sort/` | ~4.6K LOC across 15 files |
+| `sort/` | ~4.6K LOC across 15 files (incl. 3 cycle breakers) |
 | Integration tests | 63 files × 3 PG versions, 15 CI shards (45 jobs) |
-| pg-topo source | ~4.4K LOC, 18 modules; 38 statement classes, 28 object kinds, 6 phases |
+| pg-topo source | ~4.4K LOC, 18 modules; 38 statement classes, 28 object kinds |
 | Library hard deps | `pg`, `zod`, `@ts-safeql/sql-tag`, `picomatch`, `debug`, `@stricli/core`, `chalk`, `@supabase/pg-topo` (→ libpg-query WASM) |

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -156,7 +156,7 @@ interface FactBase {
 }
 ```
 
-Five properties define it:
+Six properties define it:
 
 - **Typed identity, structured end-to-end.** IDs are a discriminated union
   (`{kind: "procedure", schema, name, args}` …) everywhere — including at
@@ -392,7 +392,7 @@ together. Edges come from three sources: the old state's edge facts
 X), the new state's edge facts (build ordering: an action producing Y
 precedes everything consuming Y), and identity conflicts (remove of `X`
 before add of new `X`). One deterministic Kahn pass (heap-based ready queue,
-tie-break by phase weight → kind weight → name) replaces a two-phase sort, an
+tie-break by kind weight → canonical identity) replaces a two-phase sort, an
 `invalidates` side channel, and a repair loop: an in-place mutation is simply
 an action that destroys the old fact and produces the new one, and the mixed
 graph orders its dependents' teardown and rebuild around it naturally.
@@ -607,7 +607,9 @@ authoring declarative schemas, lint, cycle diagnostics. Its approximate
 nothing downstream depends on it. (Consequence: the libpg-query WASM
 dependency leaves the core install —
 [package.json:80-89](../packages/pg-delta/package.json) currently forces it
-on every consumer.)
+on every consumer.) The dev layer is today's pg-topo continuing as-is; its
+evolution is deliberately **outside the staged build** (§9) — stage 7 treats
+it as an optional, degradable assist, never a dependency.
 
 ### 4.5 Packaging that falls out instead of being debated
 
@@ -730,7 +732,7 @@ is imported as data and SQL; none of its *mechanisms* — and none of its
 
 The findings below (all verified at `115dde8`) are not isolated bugs — each
 is a direct consequence of an architectural commitment the north star
-removes:
+removes. (Findings are cited elsewhere in this document as §8.1–§8.7.)
 
 1. **No shared extraction snapshot** (consistency bug) — consequence of
    extraction being a query fan-out rather than a state capture. §3.2.
@@ -787,14 +789,22 @@ old-codebase mining maps, pitfalls, and the gate in checkable form.
 | 0 | **The red test suite, first**: scenario corpus ported from the existing integration tests; target API as typed stubs; fixture-validity layer green from day one; engine tests red on `NotImplementedError`, pinned by an explicit list; old-engine baselines captured | §4.3 | Fixture validity green on all PG versions; 100% of old integration files accounted for; every red explained |
 | 1 | Identity codec + fact-base core: typed IDs, identity-free payload hashing, Merkle rollups (facts + edges), snapshot format v1 (version-tagged) | §3.1 | Property tests: codec round-trip, rollup algebra, hash stability |
 | 2 | Extractor port: re-key the extractor SQL corpus to return structured identity parts and fact rows + edges; snapshot-consistent parallel capture | §3.1–3.2 | Extractor fixture ring per PG version; pg_dump observer; content cross-check against old-engine catalogs |
-| 3 | Proof harness + corpus: `provePlan` (state + data-preservation checks, both materialization forms); port the integration scenarios as the seed corpus; stand up the differential runner against the old engine | §3.7, §4.3 | Harness proves extract → materialize → re-extract fidelity over the corpus |
+| 3 | Proof harness + corpus: `provePlan` (state + data-preservation checks; template-clone materialization — the render-from-fact-base form lands in stage 6); port the integration scenarios as the seed corpus; stand up the differential runner against the old engine | §3.7, §4.3 | Harness proves extract → clone → re-extract fidelity and snapshot round-trips over the corpus |
 | 4 | Generic diff: rollup-guided descent emitting fact and edge deltas | §3.3 | Fixture diffs; `diff(A, A) = ∅` generatively |
 | 5 | The planner: rule table, atomic actions, one-graph sort, compaction | §3.4–3.6 | Corpus green under proof; differential vs old engine (state-equivalent plans, divergences triaged); generative soak; zero cycles |
 | 6 | Execution + plan artifact v1: ordered deltas, rollup-hash fingerprints, safety report (proven / observed / vetted tiers) | §3.7–3.8 | End-to-end proof on the corpus, including segmented non-transactional actions |
 | 7 | Frontends: shadow-DB SQL loader (fail-safe ordering, body validation, cluster isolation, DML rejection); snapshot frontend | §3.2 | Declarative scenarios in the corpus; loader rejection tests |
 | 8 | Policy layer: DSL v2 over facts/deltas; Supabase integration as a data package with platform baseline | §3.9 | Policy scenarios; baseline-subtraction proof against a real platform image |
-| 9 | Renames (leaf + structural-rollup matching, policy-gated); public API and CLI finalized | §4.1, §4.5 | Rename corpus; API review |
+| 9 | Renames (leaf + structural-rollup matching, policy-gated); declarative export; drift detection surfaced; public API and CLI finalized | §4.1, §4.2, §4.5 | Rename corpus; export round-trip `load(export(fb)) ≡ fb`; API review |
 | 10 | **Cutover at the parity bar**: full corpus green; differential clean-or-explained; generative soak quota met; extractor ring green on all supported PG versions. Old library enters maintenance; consumer migration guide ships | — | The parity bar itself |
+
+**Supported PostgreSQL versions.** The build targets the set the old
+engine's CI matrix tests today: **15, 17, 18** (16 is absent because the
+current product never supported it; that is inherited, not re-decided).
+Adding or retiring a version is a product decision recorded in this decision
+log; mechanically it is P2's promise — extraction-query updates, rules, and
+a new fixture-ring lane (stage 2 owns the lanes; stage 10's bar runs on the
+then-current set).
 
 Stage 0 builds the definition of done before any engine code exists — the
 corpus is the contract, and "all red" is sound because red is pinned to
@@ -888,7 +898,8 @@ code.
   The document is considered ready; further refinement happens through
   implementation contact and decision-log amendments.
 - **2026-06-12 (e)** — External review (PR #297, 13 findings — all
-  verified against the codebase and accepted, some with refined fixes):
+  verified against the codebase; every *finding* accepted, one suggested
+  *mitigation* replaced with a different fix, noted at the end):
   collision-resistant identity-free hashing with edges folded into rollups
   and `link`/`unlink` deltas (§3.1, §3.3); shadow-loader specifics —
   fail-safe ordering, restored body validation, cluster isolation for
@@ -925,10 +936,24 @@ code.
   API stubs, old-engine baselines — with one refinement: red must mean
   *engine missing* (pinned `NotImplementedError` list), never *fixture
   broken* (the fixture-validity layer is green from day one).
+- **2026-06-12 (h)** — Final pre-handoff review (two independent audit
+  passes over all 12 documents). Consistency fixes: §3.1 property count;
+  §3.6 tie-break aligned with stage 5 (kind weight → canonical identity —
+  no phase tier in a one-graph sort); §9 stage-3 row no longer overstates
+  materialization (render-from-fact-base is stage 6); §9 stage-9 row gains
+  export + drift; stage-doc dependency headers and wording corrected.
+  Ownership gaps closed: drift detection (stage 9), the
+  dangling-requirement-from-policy check (stage 5, graph build), the vetted
+  lock-class table (stage 5), the ≥10k benchmark fixture (stage 5),
+  generator-coverage growth (stage 5 + stage 10 bar), the new package's CI
+  lane (stage 0), plan-artifact version rejection (stage 6), shared
+  diagnostic type (stage 1), and the supported-PG-versions policy (§9).
+  Rename-policy default is no longer open — stage 9 sets `prompt` (CLI) /
+  `off` (library), revisit after field experience.
 - Open questions intentionally left to their stages: compaction's default
-  aggressiveness (stage 5), rename-policy default (stage 9), how
-  aggressively to prune the ported corpus once generative coverage matures
-  (stage 3), new-major vs new-package-name (stage 10, product decision).
+  aggressiveness (stage 5), how aggressively to prune the ported corpus
+  once generative coverage matures (stage 3), new-major vs new-package-name
+  (stage 10, product decision).
 
 ---
 

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -11,9 +11,11 @@ it got here: the current design is the strongest in its class (it is the only
 tool in the migra/pg-schema-diff family that treats `pg_depend` as the source
 of ordering truth), and its accumulated PostgreSQL knowledge is the asset the
 north star is built from. But the north star is derived from the problem, not
-from the codebase — §9 then re-derives an incremental path from today's code
-toward it. When a local decision conflicts with this document, this document
-wins or this document gets amended.
+from the codebase — and it is a **clean-room library**: the old engine
+donates assets (§5) and serves as a differential oracle (§9), and nothing
+else. No format, API, or mechanism carries over for compatibility's sake.
+§9 defines the build-and-cutover plan. When a local decision conflicts with
+this document, this document wins or this document gets amended.
 
 ---
 
@@ -156,10 +158,20 @@ interface FactBase {
 
 Five properties define it:
 
-- **Typed identity.** Stable IDs are a parsed discriminated union
-  (`{kind: "procedure", schema, name, args}` …) with a frozen canonical
-  string form for persistence and graph keys. Structure is accessed by
-  field, never recovered by regex.
+- **Typed identity, structured end-to-end.** IDs are a discriminated union
+  (`{kind: "procedure", schema, name, args}` …) everywhere — including at
+  the SQL boundary: extraction queries return identity *parts* (kind,
+  schema, name, args, parent) as structured columns and never synthesize
+  identity strings, so the encoding exists in exactly **one codec**, on the
+  library side. (The current system maintains the format twice — TS helpers
+  plus `format()` literals inside the dependency mega-query — a divergence
+  risk the structured boundary removes outright.) A canonical string
+  encoding — one escaping rule, one version tag — is derived from the
+  structure and appears only where persistence demands it: snapshots, plan
+  artifacts, fingerprints. In memory, graph keys are interned. Structure is
+  accessed by field, never recovered by regex. **No format is frozen**:
+  persisted artifacts carry a format version, making compatibility a
+  versioning concern instead of a design constraint.
 - **One granularity everywhere.** Facts, dependency edges, diff deltas, and
   actions all live at the same grain. A `pg_depend` edge that points at a
   column points at a fact that *exists*; nothing maps between coarse state
@@ -478,8 +490,10 @@ instruments, all data:
   provenance edges of §3.1. "Hide everything owned by extension X" or
   "never touch schema `auth`" become provenance/identity predicates instead
   of extraction-time suppression: the engine sees everything; policy decides
-  visibility. The user-facing DSL contract (declarative patterns,
-  first-match-wins rules) carries over, re-targeted at deltas.
+  visibility. The DSL is designed fresh for the fact model — typed
+  predicates over fact kinds, identities, provenance edges, and delta
+  verbs. What carries over from the current DSL is its proven *evaluation
+  model* (declarative rules, first-match-wins), not its pattern syntax.
 - **Serialization options = rule parameterization.** Options like
   `skipAuthorization` stop being per-change-class plumbing and become named
   parameters that a serialize rule passes into the rule table's templates.
@@ -562,7 +576,7 @@ The test architecture is P2 applied to testing itself: **one proof harness
   action, not a replace"; "≤ N actions"), never SQL bytes. Byte snapshots
   die with the old engine: they assert emission shape, which decomposition
   (§3.5) intentionally changes and the compactor may change again.
-- **Differential testing during migration.** Until retired, the old engine
+- **Differential testing until cutover.** Until retired, the old engine
   is itself an oracle: run both engines over the corpus and assert
   state-equivalent plans. Every divergence is a bug in one of them — and
   either finding is valuable.
@@ -612,12 +626,17 @@ static-analysis engine, §3.2); only explicitly dev-facing commands (lint,
 file-ordering help) touch it, and those degrade with a clear install hint
 rather than failing obscurely.
 
+The new library ships as a new major (or a new package name — a product
+decision, not an architectural one). The existing library enters
+maintenance and is retired at the cutover bar (§9).
+
 ---
 
-## 5. What survives from today
+## 5. Imported assets: what the new library takes from the old
 
-The north star is a re-plumbing, not a rewrite of the knowledge. Carried
-over nearly verbatim:
+This is a clean-room build, but not amnesia. The old system's *knowledge*
+is imported as data and SQL; none of its *mechanisms* — and none of its
+*formats* — constrain the new design:
 
 - **The extractor SQL corpus** (`<type>.model.ts` queries) — years of
   accumulated `pg_catalog` knowledge across PG versions; the single most
@@ -634,16 +653,20 @@ over nearly verbatim:
 - **The normalization knowledge** in `stableSnapshot()` overrides (physical
   attnums vs logical names, canonical `pg_get_*def()` comparison forms) —
   it becomes the fact payload normalization, i.e. the content-hash surface.
-- **Stable identity** as a concept — upgraded to typed values with a frozen
-  string form, extended to every fact kind.
-- **The plan + fingerprint product contract** — plans as reviewable,
-  version-controllable artifacts with drift detection; fingerprints become
-  rollup hashes.
+- **Stable identity** as a concept — redesigned, not carried: structured
+  end-to-end, with a version-tagged canonical encoding used only in
+  persisted artifacts (§3.1). Nothing about today's string format is
+  retained.
+- **The plan + fingerprint product contract** — the *concept* is kept
+  (plans as reviewable, version-controllable artifacts with drift
+  detection); the format is new: ordered deltas plus rollup-hash
+  fingerprints, version-tagged from v1.
 - **Safety/risk classification** — generalized into per-action metadata
   supplied by the rule table.
-- **The serialize/filter DSL surface** for integrations (Supabase rules) —
-  re-targeted at deltas/actions instead of change classes, same user-facing
-  contract, strengthened by provenance facts; specified in §3.9.
+- **Policy-as-data for integrations** — the filter/serialize DSL's proven
+  ideas (declarative rules, first-match-wins evaluation) are kept; the
+  surface itself is redesigned for facts and deltas with no compatibility
+  with the old pattern syntax; specified in §3.9.
 
 ## 6. What is retired
 
@@ -695,12 +718,13 @@ over nearly verbatim:
   apply — before production, not in it; and the dev layer (§4.4) can lint
   bodies for ordering hints. What is explicitly not done: re-parsing
   bodies in the trusted path to synthesize edges (P1).
-- **Output changes during migration.** Decomposition-by-default changes
-  emitted SQL relative to today. The oracle therefore shifts: refactor
-  phases keep byte-identical output; emission-changing phases are gated on
-  **state-proof equality** (apply both old and new plans to clones —
-  identical resulting fact bases) plus human review of the new shape. Byte
-  drift stops being the invariant; *state* drift becomes the invariant.
+- **Consumers migrate once.** A clean-room library means a new major: new
+  API, new plan/snapshot formats (version-tagged), new SQL output shape.
+  There is no in-place compatibility layer — that is the point. The cost
+  is bounded by the cutover bar (§9): the old library keeps working, in
+  maintenance, until the new one has proven itself against the corpus, the
+  differential oracle, and the generative soak. **State equivalence —
+  never byte equivalence — is the invariant throughout.**
 
 ## 8. Why the current design cannot simply be tuned into this
 
@@ -743,43 +767,49 @@ removes:
    base removes the translation by removing the disagreement: one
    granularity for state, dependencies, deltas, and actions. §3.1, §3.3.
 
-## 9. The path from here
+## 9. The path: build clean, prove against old, cut over
 
-Each phase is independently shippable, independently valuable, and strictly
-reduces distance to the north star. Standing gates: refactor phases =
-byte-identical SQL (existing tests as oracle); emission-changing phases =
-state-proof equality (§7); every behavior change carries a changeset and a
-RED→GREEN regression test per repository policy.
+The new library is built **clean-room beside the old one**. No engine code
+is shared. The old engine has exactly two roles: *asset donor* (extractor
+SQL, normalization knowledge, scenario corpus, safety tables — §5) and
+*differential oracle* (it runs unmodified next to the new engine until
+cutover). There are no byte-compatibility gates anywhere — every stage
+ships behind proof-based gates only. Repository discipline (changesets,
+RED→GREEN regressions) applies as usual.
 
-| # | Phase | North-star component it builds | Notes |
+| # | Stage | Builds | Gate |
 |---|---|---|---|
-| 1 | Single-snapshot parallel extraction; memoized content hashes on models; hash-based `equals`; post-apply verify becomes explicit proof opt-in | Fact base capture & hashing §3.1–3.2 | Fixes the consistency bug on day one; hashes later power fingerprints, renames, proof |
-| 2 | Typed `StableId` (frozen canonical string form, parse/format round-trip tested); kill regex re-parsing | Fact identity §3.1 | Wire format byte-frozen — persisted in plan fingerprints |
-| 3 | `provePlan(plan, source)` as a first-class API: template-cloned scratch, apply, extract, hash-compare — plus the data-preservation check (seeded rows). Port the integration scenarios into the seed corpus behind one harness; replace load-bearing SQL snapshots with semantic plan assertions; stand up old-vs-new differential runs; begin generative roundtrip tests | Proof loop §3.7, test architecture §4.3 | **Do this before touching emission** — it is the safety net for phases 5–8 |
-| 4 | Sort hygiene while the old sort still exists: depend-row pre-filtering to the change set, single graph build per phase, heap queue | Interim perf | Pure wins now; code is absorbed by phase 6 |
-| 5 | Decomposition-by-default emission + the compaction pass; delete cycle breakers by attrition as their cycle classes become unconstructible | §3.5–3.6 | First emission-changing phase; gated on state-proof + review |
-| 6 | One mixed graph (old-state edges + new-state edges + identity conflicts) replaces two-phase + `invalidates` + repair loop | §3.6 | A surviving cycle after 5+6 is a rule/emission bug — fix the rule, never add a breaker |
-| 7 | Fact-model normalization: flatten sub-entities (columns, constraints, defaults, ACL entries, comments, labels) into facts with parent relations and Merkle rollups, kind by kind; document views become render-time joins; rollup hashes preserve whole-object equality during transition | Fact base §3.1, generic diff §3.3 | Internal refactor — byte-identical SQL gate; enables phase 8 |
-| 8 | Rule table: migrate kinds from per-type diff+classes to delta rules consumed by the generic engine — global metadata rules (comment/ACL/label) first, cookie-cutter kinds next, table/view/procedure as structured conditional + delta-set rules last; delete the per-type dispatch switches and the change-class union | §3.3–3.4 / P2 | Largest phase; per-kind PRs; proof loop is the oracle |
-| 9 | Shadow-DB frontend for SQL files through the one plan path; round-apply demoted to fallback, then removed; pg-topo repositioned as dev-experience layer; WASM leaves the core install | §3.2, §4.4 | The declarative workflow's correctness becomes the diff engine's correctness |
-| 10 | Rename detection (object- and fact-level hash-equal candidates, policy-gated); layered public API finalized (fact base / diff / plan / proof / apply); packaging falls out | §4.1, §4.5 | The visible product payoff |
+| 1 | Identity codec + fact-base core: typed IDs, identity-free payload hashing, Merkle rollups (facts + edges), snapshot format v1 (version-tagged) | §3.1 | Property tests: codec round-trip, rollup algebra, hash stability |
+| 2 | Extractor port: re-key the extractor SQL corpus to return structured identity parts and fact rows + edges; snapshot-consistent parallel capture | §3.1–3.2 | Extractor fixture ring per PG version; pg_dump observer; content cross-check against old-engine catalogs |
+| 3 | Proof harness + corpus: `provePlan` (state + data-preservation checks, both materialization forms); port the integration scenarios as the seed corpus; stand up the differential runner against the old engine | §3.7, §4.3 | Harness proves extract → materialize → re-extract fidelity over the corpus |
+| 4 | Generic diff: rollup-guided descent emitting fact and edge deltas | §3.3 | Fixture diffs; `diff(A, A) = ∅` generatively |
+| 5 | The planner: rule table, atomic actions, one-graph sort, compaction | §3.4–3.6 | Corpus green under proof; differential vs old engine (state-equivalent plans, divergences triaged); generative soak; zero cycles |
+| 6 | Execution + plan artifact v1: ordered deltas, rollup-hash fingerprints, safety report (proven / observed / vetted tiers) | §3.7–3.8 | End-to-end proof on the corpus, including segmented non-transactional actions |
+| 7 | Frontends: shadow-DB SQL loader (fail-safe ordering, body validation, cluster isolation, DML rejection); snapshot frontend | §3.2 | Declarative scenarios in the corpus; loader rejection tests |
+| 8 | Policy layer: DSL v2 over facts/deltas; Supabase integration as a data package with platform baseline | §3.9 | Policy scenarios; baseline-subtraction proof against a real platform image |
+| 9 | Renames (leaf + structural-rollup matching, policy-gated); public API and CLI finalized | §4.1, §4.5 | Rename corpus; API review |
+| 10 | **Cutover at the parity bar**: full corpus green; differential clean-or-explained; generative soak quota met; extractor ring green on all supported PG versions. Old library enters maintenance; consumer migration guide ships | — | The parity bar itself |
 
-Ordering rationale: 1–3 build the measurement and safety instruments; 4 is
-opportunistic; 5–8 are the structural inversion under proof protection —
-emission first (5–6), then state (7), then knowledge (8); 9–10 are the
-product payoff. Phases 1, 2, 4 can start immediately and in parallel.
+Stages 1–4 are bottom-up construction with no user-visible surface; 5–6 are
+the engine; 7–9 are the product; 10 is the switch. The old engine is never
+modified beyond what the differential runner needs. Consumers migrate once,
+at cutover, to a new major — there is no in-place compatibility layer.
 
 ## 10. Guardrails for implementers
 
-This document will be executed phase by phase, likely by different people
+This document will be executed stage by stage, likely by different people
 and different agents, each holding only part of the context. The invariants
 below are absolute. When one seems to block progress, the correct move is to
 amend this document (with a decision-log entry) — never to make a local
 exception:
 
-1. **The stable-ID wire format is frozen.** The canonical string form is
-   persisted in plan fingerprints and synthesized inside extraction SQL. Any
-   change to it is a breaking product decision, not a refactor.
+1. **Identity has exactly one codec.** Extraction SQL returns structured
+   identity parts — it never synthesizes identity strings; only the
+   library-side codec produces the canonical encoding, and every persisted
+   artifact (snapshot, plan, fingerprint) carries a format version.
+   Hand-building an identity string anywhere, TS or SQL, reintroduces the
+   §8.7 disease. Formats are never frozen — they are versioned; freezing
+   was the old library's constraint, not this one's.
 2. **No static SQL parsing in the trusted path** — extraction, diffing,
    planning, proof, apply. If a feature seems to need a parser, it belongs
    in the dev-experience layer (§4.4) or the design is wrong (P1).
@@ -790,16 +820,16 @@ exception:
 4. **A cycle is always a rule or emission bug.** Fix the rule or decompose
    the emission. Adding a cycle breaker — any runtime repair of the graph —
    is forbidden (§3.5–3.6).
-5. **No emission-changing work before `provePlan` exists** (phase 3 lands
-   before phases 5–8 start). The proof loop is the safety net; building the
+5. **No planner work before the proof harness exists** (stage 3 lands
+   before stage 5 starts). The proof loop is the safety net; building the
    trapeze act first is not faster.
 6. **Never assert SQL bytes in new tests.** Assert state (proof), data
    survival (proof), or action kinds/budgets (semantic plan assertions,
    §4.3). Byte assertions re-couple tests to emission shape.
-7. **Gates are non-negotiable.** Refactor phases ship byte-identical SQL;
-   emission-changing phases ship state-proof equality plus human review of
-   the new shape (§7, §9). Every behavior change carries a changeset and a
-   RED→GREEN regression per repository policy.
+7. **Gates are non-negotiable.** Every stage ships behind its §9 gate —
+   proof, differential, fixture ring; never byte equivalence. Cutover
+   happens only at the parity bar. Every behavior change carries a
+   changeset and a RED→GREEN regression per repository policy.
 8. **Granularity is one.** State, dependencies, deltas, and actions all live
    at fact grain. Any new structure that nests sub-entities back into
    documents — or any map that translates between grains — is §8.7
@@ -865,10 +895,23 @@ code.
   suggestion was rejected on technical grounds: a deep-compare fallback on
   hash matches would reinstate the full-compare cost on the unchanged
   majority — the accepted fix is a collision-resistant digest instead.
-- Open questions intentionally left to their phases: compaction's default
-  aggressiveness (phase 5), rename-policy default (phase 10), how
+- **2026-06-12 (f)** — Maintainer direction: full breaking changes allowed;
+  this is a **brand-new library**, not an evolution of the current one.
+  Revised accordingly: the stable-ID wire format is no longer frozen —
+  identity is structured end-to-end with a single library-side codec and
+  version-tagged canonical encoding, and extraction SQL returns identity
+  parts instead of synthesizing strings (§3.1, guardrail 1); the policy DSL
+  is designed fresh for facts/deltas rather than carrying the old pattern
+  syntax (§3.9); plan and snapshot formats are new and version-tagged
+  (§5); §9 is rewritten from in-place migration phases to a clean-room
+  build-and-cutover plan — byte-identical SQL gates are gone entirely,
+  replaced by proof/differential/fixture gates; consumers migrate once, at
+  the cutover parity bar (§7). Entries (a)–(e) above predate this and any
+  in-place-migration framing in them is superseded.
+- Open questions intentionally left to their stages: compaction's default
+  aggressiveness (stage 5), rename-policy default (stage 9), how
   aggressively to prune the ported corpus once generative coverage matures
-  (phase 3).
+  (stage 3), new-major vs new-package-name (stage 10, product decision).
 
 ---
 

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -30,9 +30,9 @@ space must answer all five: state capture, comparison, action synthesis,
 ordering, execution. Every serious tool (pg_dump/pg_restore itself, migra,
 pg-schema-diff, atlas, skeema) converges on this staged shape; the
 architectural freedom — and where this design differs from the current
-codebase — is *within* the stages: where semantic knowledge lives, who is
-trusted to elaborate PostgreSQL semantics, how cycles are handled, and how
-correctness is established.
+codebase — is *within* the stages: how state is represented, where semantic
+knowledge lives, who is trusted to elaborate PostgreSQL semantics, how cycles
+are handled, and how correctness is established.
 
 Out of scope, permanently: data migrations (DML). The tool's contract is
 schema state, not data movement.
@@ -78,16 +78,23 @@ new PostgreSQL version or object type touches most of them.
 
 The north star has **two**:
 
-1. **Extraction queries** — catalog → facts (the existing extractor SQL
-   corpus, the most valuable code in the repository, survives nearly
-   verbatim).
-2. **The rule table** — fact-deltas → actions (§3.3).
+1. **Extraction queries** — catalog → normalized facts (§3.1). The existing
+   extractor SQL corpus, the most valuable code in the repository, survives
+   nearly verbatim as the fact producer.
+2. **The rule table** — fact-deltas → actions (§3.4).
 
 Everything between — diffing, ordering, planning, verification — is generic
 machinery that never changes when Postgres evolves. Supporting PostgreSQL 19
 means updating extraction queries and adding rules. **That is the
 scalability that matters most over a decade: scaling with PostgreSQL's
 evolution, not only with schema size.**
+
+A corollary that the rest of the design depends on: the two forms can only
+stay two if state, diff, dependencies, and actions all share **one
+granularity** — the fact. The moment state is stored at a coarser grain than
+dependencies point at, hand-written translation code reappears (§8.7 shows
+this is exactly what happened). The fact base below is therefore not a
+storage detail; it is what makes P2 hold.
 
 ---
 
@@ -96,55 +103,91 @@ evolution, not only with schema size.**
 ```text
 frontends:   live DB ──(single-snapshot extract)──┐
              SQL files ──(shadow-DB elaboration)──┼──▶  FACT BASE
-             snapshot JSON ───────────────────────┘     typed facts + dependency edges,
-                                                        content-addressed (hash per object)
+             snapshot JSON ───────────────────────┘     normalized fact rows + parent &
+                                                        dependency edges; content hash per
+                                                        fact, Merkle rollups along parents
                                   │
-                     generic set-diff (hash compare — zero per-type code)
-                                  │
-                              DELTA SET
+                  generic diff: rollup-guided descent → fact-level DELTAS
+                  (hash compare — zero per-type code, O(changed))
                                   │
                      RULE TABLE  ◀── the only per-type logic in the system
                                   │
-                          ATOMIC ACTIONS
-              maximally decomposed; each declares produces / consumes /
-              destroys, lock class, rewrite risk, data-loss class,
-              transactionality
+                          ATOMIC ACTIONS  (≈ 1:1 with deltas)
+              each declares produces / consumes / destroys, lock class,
+              rewrite risk, data-loss class, transactionality
                                   │
               ONE dependency graph → one deterministic topological sort
               (a cycle is a rule bug caught by CI, not a runtime repair job)
                                   │
               optional COMPACTION: merge adjacent actions into idiomatic DDL
-              only where no edge crosses the merge (cosmetics; off for machines)
+              by joining facts along parent relations, only where no edge
+              crosses the merge (cosmetics; off for machines)
                                   │
-                   PLAN = actions + fingerprints + safety report
+                   PLAN = ordered deltas + fingerprints + safety report
                                   │
             ┌── PROOF: apply to scratch clone, re-extract, hash-compare ──┐
             └──────────── apply (lock-aware segmented txns) ──────────────┘
 ```
 
-### 3.1 The fact base
+### 3.1 The fact base: a normalized, content-addressed relation
 
-One normalized, immutable representation of "a schema state," identical
-regardless of origin. Three properties define it:
+**Normalized, not nested.** PostgreSQL's own catalog is relational —
+`pg_attribute`, `pg_constraint`, `pg_attrdef` are rows referencing their
+parents, not sub-documents of `pg_class`. The optimal state representation
+mirrors that shape instead of re-imposing a document hierarchy on it: every
+addressable thing — table, column, constraint, default, index, trigger,
+policy, ACL entry, comment, security label, role membership, extension
+membership — is its **own fact**:
+
+```ts
+interface Fact {
+  id: StableId;             // typed union: column:, constraint:, default:, acl:, comment: …
+  parent?: StableId;        // hierarchy as a relation, not as containment
+  payload: NormalizedAttrs; // cooked attributes (names not attnums, canonical pg_get_*def)
+  hash: ContentHash;        // content hash of the normalized payload
+}
+
+interface FactBase {
+  facts: Map<StableId, Fact>;
+  edges: Set<DependencyEdge>;   // pg_depend-derived + ACL/membership/ownership, as data
+  rollup: Map<StableId, Hash>;  // Merkle: parent hash folds children's hashes
+}
+```
+
+Five properties define it:
 
 - **Typed identity.** Stable IDs are a parsed discriminated union
   (`{kind: "procedure", schema, name, args}` …) with a frozen canonical
   string form for persistence and graph keys. Structure is accessed by
-  field, never recovered by regex (today:
-  [expand-replace-dependencies.ts:419-425](../packages/pg-delta/src/core/expand-replace-dependencies.ts)
-  slices `"procedure:"` strings apart).
-- **Content addressing.** Every object carries a content hash computed once
-  at construction from its normalized equality surface (the existing
-  `stableSnapshot()` normalizations — the "physical attnums vs logical
-  names" doctrine — carry over intact). A catalog is effectively a Merkle
-  set: equality checks, fingerprints, no-op detection, and caching are all
-  O(1) per object. (Today equality is a double `JSON.stringify` per shared
-  object per diff —
-  [base.model.ts:70-75](../packages/pg-delta/src/core/objects/base.model.ts),
-  [objects/utils.ts:36-37](../packages/pg-delta/src/core/objects/utils.ts).)
-- **Dependencies as facts.** `pg_depend`-derived edges (plus the synthesized
-  ACL/membership/ownership edges) are part of the state, extracted under the
-  same snapshot as everything else.
+  field, never recovered by regex.
+- **One granularity everywhere.** Facts, dependency edges, diff deltas, and
+  actions all live at the same grain. A `pg_depend` edge that points at a
+  column points at a fact that *exists*; nothing maps between coarse state
+  and fine dependencies, because there is no coarse state.
+- **Content addressing with Merkle rollups.** Every fact hashes its
+  normalized payload; every parent's rollup hash folds its children's. Two
+  consequences: equality at any granularity is one comparison, and diffing
+  is **O(changed)** — subtrees whose rollups match are skipped wholesale.
+  Fingerprints, no-op detection, drift detection, and caching are the same
+  mechanism.
+- **Hierarchy is a view, not the storage.** Renderers and the compactor that
+  need "a table with its columns and inlineable constraints" *join* facts
+  along the parent relation at render time. The document shape exists where
+  documents are useful — output — and nowhere else.
+- **Cross-cutting metadata is not special.** A comment is a fact whose
+  target is another fact's ID; so is an ACL entry, a security label, a
+  membership. There is no "scope" dimension in the system — one global rule
+  per metadata kind (§3.4) replaces per-object-type reimplementation.
+- **Provenance is data.** "Owned by extension X" is an edge fact, not an
+  extraction-time filter. Downstream policy (integrations, vendor filtering)
+  decides what to do with provenance instead of extraction deciding what to
+  hide.
+
+The payload normalization doctrine carries over from today unchanged
+(logical names instead of physical attnums; canonical `pg_get_*def()` output
+as the comparison form where Postgres provides it): it answers *what we
+know* correctly. The fact model changes *how it is keyed* — which is where
+the current design pays (§8.7).
 
 ### 3.2 Frontends: one elaborator, three doors
 
@@ -162,48 +205,83 @@ regardless of origin. Three properties define it:
   (template-cloned; `check_function_bodies = off`), then extracted. The
   desired state is whatever Postgres actually builds — no fuzzy reference
   matching, no retry heuristics. This *is* the declarative workflow.
-- **Snapshots**: the serialized fact base round-trips losslessly (exists
-  today as `serializeCatalog`/`deserializeCatalog`; becomes the contract for
-  offline diffing, fixtures, and caching).
+- **Snapshots**: the serialized fact base round-trips losslessly and is the
+  contract for offline diffing, fixtures, and caching. A flat fact relation
+  serializes, filters, and streams trivially — properties a nested document
+  model resists.
 
-### 3.3 Generic diff
+### 3.3 Generic diff: rollup-guided descent to fact-level deltas
 
-With content addressing, comparison is set algebra on `(stableId → hash)`:
-added, removed, changed. **Zero per-type diff code** — no `table.diff.ts`
-(1,034 lines today), no per-type diff functions at all. Per-type knowledge is
-not needed to detect *that* something changed; it is needed only to decide
-*what to do about it* — which is the rule table's job.
+Comparison is hash algebra, top-down: compare rollups; where they match,
+skip the entire subtree; where they differ, descend and compare fact hashes;
+where a fact differs, compare payload attributes. The output is the system's
+central data type:
+
+```ts
+type Delta =
+  | { verb: "add";    fact: Fact }
+  | { verb: "remove"; fact: Fact }
+  | { verb: "set";    id: StableId; attr: string; from: unknown; to: unknown };
+```
+
+**Zero per-type diff code — structurally, not aspirationally.** The differ
+never knows what a table is. Because state is normalized at fact grain, the
+generic differ already produces "the default of `column:public.users.email`
+changed" — there is no nested document for per-type code to re-walk. (In a
+document model, "generic diff" can only say *this table changed somehow*,
+and a second, hand-written diff engine per type must rediscover what — that
+is precisely the 1,034 lines of
+[table.diff.ts](../packages/pg-delta/src/core/objects/table/table.diff.ts)
+today, see §8.7.)
+
+Deltas — not statements, not class instances — are also what plans persist:
+a delta list is diffable, replayable, and storable by construction.
 
 ### 3.4 The rule table
 
-The only per-type logic in the system. For each object kind, structured data
-declares:
+The only per-type logic in the system: structured data mapping deltas to
+actions.
 
 ```ts
 // sketch — rules are data with functions in narrow slots only
-interface KindRules<M> {
-  kind: ObjectKind;
-  identitySql(m: M): string;
-  createTemplate(m: M): string;                    // bare object only (§3.5)
-  attributes: Record<string, AttributeRule<M>>;    // per changed attribute:
-  //   { alter: (old, new) => string }             //   in-place ALTER
-  //   | { replace: true }                         //   forces drop+create
-  //   | { replace: (old, new) => boolean }        //   conditional (e.g. column type)
-  implicitlyDrops(m: M): StableId[];               // cascade knowledge (DROP TABLE → its
-                                                   // constraints, columns, owned sequences)
-  lockClass(action: Action): LockClass;
-  rewriteRisk(action: Action): boolean;
-  dataLossClass(action: Action): DataLoss;
+interface KindRules<P> {
+  kind: FactKind;
+  identitySql(p: P): string;
+  createTemplate(p: P, view: FactView): string;     // bare object only (§3.5)
+  attributes: Record<string, AttributeRule<P>>;     // per changed attribute:
+  //   { alter: (from, to, view) => string }        //   in-place ALTER
+  //   | { replace: true }                          //   forces drop+create
+  //   | { replace: (from, to) => boolean }         //   conditional (e.g. column type)
+  implicitlyRemoves(p: P, view: FactView): StableId[]; // cascade knowledge
+  lockClass(a: Action): LockClass;
+  rewriteRisk(a: Action): boolean;
+  dataLossClass(a: Action): DataLoss;
 }
 ```
 
-Hard cases — column type changes, view replacement chains, procedure
-signature identity — are *conditional rules with more structure*, not
-imperative escape hatches. The discipline that keeps rules from degenerating
-into code-in-disguise: functions appear only in predicate and template
-slots, and every rule's claims are checked by the proof loop (§3.7) — a rule
-that lies about cascades or alterability produces a state mismatch in CI,
-not a latent bug.
+Three structural consequences of operating on fact deltas:
+
+- **Cross-cutting kinds get one rule, globally.** `comment(target) = text`
+  is a single rule for the entire system — not 21 per-object-type comment
+  implementations. Same for ACL entries, security labels, memberships. The
+  rule count tracks PostgreSQL's *concepts*, not the cross product of
+  concepts × object types.
+- **Rules receive fact views, not documents.** A rule that renders
+  `CREATE TABLE` asks the view API for the children it may inline; the
+  hierarchy it needs is computed, not stored.
+- **Multi-fact semantic atoms are delta-set rules.** `ALTER COLUMN … TYPE`
+  touches the column fact, possibly its default fact, and invalidates
+  dependent index/view facts. A rule may match a *set* of related deltas and
+  emit the composite action with the correct teardown/rebuild edges — the
+  declarative form of the knowledge that today lives in the `invalidates`
+  side channel and the expand-replace pass.
+
+Hard cases remain *conditional rules with more structure*, never imperative
+escape hatches — escape hatches are how today's eight-forms situation
+happened. The discipline that keeps rules honest: functions confined to
+predicate/template slots, and the proof loop (§3.7) as a lie detector — a
+rule that misdeclares cascades or alterability produces a state mismatch in
+CI the day it is written.
 
 This replaces, outright: 21 per-type diff functions, 106 change classes, the
 five per-`objectType` dispatch switches
@@ -212,75 +290,68 @@ five per-`objectType` dispatch switches
 [fingerprint.ts:88](../packages/pg-delta/src/core/fingerprint.ts),
 [change.types.ts:65](../packages/pg-delta/src/core/change.types.ts),
 [file-mapper.ts:59](../packages/pg-delta/src/core/export/file-mapper.ts)),
-and the shared privilege/comment/security-label wrapper classes. Today that
-surface is 256 files / 31,162 LOC of source in `objects/` alone; the rule
-table plus models is estimated at a third of it.
+and the per-type privilege/comment/security-label wrappers — today 256
+files / 31,162 LOC of source in `objects/` alone.
 
-### 3.5 Atomic actions: maximal decomposition
+### 3.5 Atomic actions: decomposition mirrors normalization
 
-Every action is the smallest valid DDL unit: bare `CREATE TABLE`; every
-constraint, default, FK, index, grant, comment, ownership change as its own
-action. Each action declares `produces` / `consumes` / `destroys` (stable
-IDs), plus the safety metadata from its rule.
+Actions are ≈1:1 with deltas: bare `CREATE TABLE`; every constraint,
+default, FK, index, grant, comment, ownership change as its own action. Each
+action declares `produces` / `consumes` / `destroys` (fact IDs) plus the
+safety metadata from its rule. **Maximal decomposition in the action space
+is the same principle as normalization in the state space — one idea seen
+from two sides.** A normalized state diffed at fact grain *naturally* yields
+atomic actions; the impedance mismatch of decomposed actions over
+document-shaped state cannot arise.
 
-This is pg_dump's deep trick, adopted wholesale: **pg_dump has no
+This is also pg_dump's deep trick, adopted wholesale: **pg_dump has no
 cycle-breaker module because at this granularity, cycles structurally cannot
 form** for entire categories of dependencies (mutual FKs, FK-vs-drop
-interleavings). The current codebase already half-believes this — the create
-phase emits constraints as separate `AlterTableAddConstraint` changes
-([table.diff.ts:84](../packages/pg-delta/src/core/objects/table/table.diff.ts)),
-which is exactly why all three cycle breakers
-([cycle-breakers.ts](../packages/pg-delta/src/core/sort/cycle-breakers.ts):
-`tryBreakFkCycle`, `tryBreakPublicationColumnCycle`,
-`tryBreakPublicationFkConstraintDropCycle`) live in the **drop phase**, where
-compound `DROP TABLE` semantics create implicit edges. Worse, the system
-currently fights itself: post-diff normalization *prunes* constraint drops
-for compactness, then the cycle breaker *re-injects* them when compactness
-creates a cycle. The north star resolves the tension in one direction:
-decomposed by construction, compacted only where provably safe (§3.6 output
-stage).
+interleavings). Compound semantics stop being implicit: `DROP TABLE`'s
+cascade becomes explicit fact-removals related by edges, ordered by the
+graph like everything else.
 
-Failure-mode analysis is the argument: with repair, a new cycle class means
-a wrong/unsortable plan in production and a new hand-written breaker (the
-git history is a string of exactly these fixes). With avoidance, the
-worst case is a more verbose script. Verbosity is recoverable; wrongness is
-not.
+Failure-mode analysis is the argument for avoidance over repair: with
+repair, a new cycle class means a wrong or unsortable plan in production and
+a new hand-written breaker (the current registry —
+[cycle-breakers.ts](../packages/pg-delta/src/core/sort/cycle-breakers.ts):
+`tryBreakFkCycle`, `tryBreakPublicationColumnCycle`,
+`tryBreakPublicationFkConstraintDropCycle` — each added after a
+field-discovered cycle; the codebase even fights itself, with post-diff
+normalization *pruning* constraint drops for compactness that the drop-phase
+breaker then *re-injects*). With avoidance, the worst case is a more verbose
+script. Verbosity is recoverable; wrongness is not.
 
 ### 3.6 One graph, one sort, then cosmetic compaction
 
 A single dependency graph over all atomic actions — drops, creates, alters
-together. Edges come from three sources: the old state's dependency facts
+together. Edges come from three sources: the old state's edge facts
 (teardown ordering: an action destroying X follows everything that consumes
-X), the new state's dependency facts (build ordering: an action producing Y
-precedes everything consuming Y), and identity conflicts (drop of `X` before
-create of new `X`). One deterministic Kahn pass (heap-based ready queue,
-tie-break by phase weight → kind weight → name) replaces today's two-phase
-sort + `invalidates` side channel + repair loop: an in-place mutation is
-simply an action that destroys the old fact and produces the new one, and
-the mixed graph orders its dependents' teardown and rebuild around it
-naturally.
+X), the new state's edge facts (build ordering: an action producing Y
+precedes everything consuming Y), and identity conflicts (remove of `X`
+before add of new `X`). One deterministic Kahn pass (heap-based ready queue,
+tie-break by phase weight → kind weight → name) replaces a two-phase sort, an
+`invalidates` side channel, and a repair loop: an in-place mutation is simply
+an action that destroys the old fact and produces the new one, and the mixed
+graph orders its dependents' teardown and rebuild around it naturally.
 
 **A cycle is a rule bug.** Cycle detection remains as an assertion with a
 high-quality diagnostic, and as a property-test target — never as a runtime
-repair subsystem. (Today: graph rebuilt from scratch on every repair round,
-[sort-changes.ts:161-289](../packages/pg-delta/src/core/sort/sort-changes.ts);
-full catalog depend-row scan regardless of diff size,
-[graph-builder.ts:26](../packages/pg-delta/src/core/sort/graph-builder.ts);
-O(V²) ready queue,
-[topological-sort.ts:33-52](../packages/pg-delta/src/core/sort/topological-sort.ts).
-All of it dissolves rather than getting optimized.)
+repair subsystem.
 
 **Compaction** is the final, optional stage: merge adjacent actions into
 idiomatic compound DDL (constraints inlined into `CREATE TABLE`, column
-clauses folded) only when no graph edge crosses the merge boundary. It is a
-peephole optimization on an already-correct sorted script — it can produce
-ugliness, never wrongness. On by default for humans, off for machines.
+clauses folded) by joining facts along parent relations, only when no graph
+edge crosses the merge boundary. It is a peephole optimization on an
+already-correct sorted script — it can produce ugliness, never wrongness. On
+by default for humans, off for machines.
 
 ### 3.7 Plan and proof
 
-A plan is: ordered actions + source/target fingerprints (which are now just
-fact-base hashes — same machinery as equality) + the safety report
-aggregated from per-action metadata (locks, rewrites, data loss).
+A plan is: ordered deltas (with their rendered actions) + source/target
+fingerprints — which are now just fact-base rollup hashes, the same
+machinery as equality — + the safety report aggregated from per-action
+metadata (locks, rewrites, data loss).
 
 **The proof loop is the architecture's keystone.** Because any state can be
 materialized (template-cloned scratch DB) and re-extracted, the planner can
@@ -318,22 +389,24 @@ attribution replaces the joined-string megaquery.
 These are not cleanups — they are features the current architecture cannot
 express:
 
-### 4.1 Rename detection
+### 4.1 Rename detection, down to sub-entities
 
-Content addressing makes renames visible: an object removed on one side and
-added on the other **with the same content hash** is a rename candidate →
-emit `ALTER … RENAME` (data-preserving) instead of drop+create
-(data-destroying), governed by policy (`auto` / `prompt` / `off`) since
-hash-equality is necessary but not sufficient evidence of intent. Every tool
-in this class punts on renames; here it falls out of the state
-representation.
+Content addressing makes renames visible at every grain: a fact removed on
+one side and added on the other **with the same content hash** is a rename
+candidate. At object grain that means `ALTER TABLE … RENAME TO`
+(data-preserving) instead of drop+create (data-destroying). At fact grain it
+extends to the case that destroys data in practice: **column renames** —
+same payload hash, same parent, different name. Governed by policy
+(`auto` / `prompt` / `off`), since hash-equality is necessary but not
+sufficient evidence of intent. Every tool in this class punts on renames;
+here they fall out of the state representation.
 
 ### 4.2 Proof-certified plans
 
-"This plan was applied to a clone and produced a byte-identical desired
+"This plan was applied to a clone and produced a hash-identical desired
 state" is a product claim no comparable tool makes. It also gives drift
-detection for free: fingerprint comparison between any environment and any
-snapshot is two hash sets.
+detection for free: comparing any environment against any snapshot is a
+rollup-hash walk.
 
 ### 4.3 Generative testing as the safety net
 
@@ -369,30 +442,36 @@ over nearly verbatim:
 
 - **The extractor SQL corpus** (`<type>.model.ts` queries) — years of
   accumulated `pg_catalog` knowledge across PG versions; the single most
-  valuable asset in the repository. It becomes the fact-base producer.
+  valuable asset in the repository. It becomes the fact producer; what
+  changes is the keying of its output (fact rows instead of nested
+  documents), not its content.
 - **The `pg_depend` doctrine** — deepened from "the diff path's source of
   truth" to "the only semantic engine, period" (P1).
 - **The normalization knowledge** in `stableSnapshot()` overrides (physical
-  attnums vs logical names, etc.) — it becomes the content-hash surface.
+  attnums vs logical names, canonical `pg_get_*def()` comparison forms) —
+  it becomes the fact payload normalization, i.e. the content-hash surface.
 - **Stable identity** as a concept — upgraded to typed values with a frozen
-  string form.
+  string form, extended to every fact kind.
 - **The plan + fingerprint product contract** — plans as reviewable,
-  version-controllable artifacts with drift detection.
+  version-controllable artifacts with drift detection; fingerprints become
+  rollup hashes.
 - **Safety/risk classification** — generalized into per-action metadata
   supplied by the rule table.
 - **The serialize/filter DSL surface** for integrations (Supabase rules) —
-  re-targeted at actions instead of change classes, same user-facing
-  contract.
+  re-targeted at deltas/actions instead of change classes, same user-facing
+  contract, strengthened by provenance facts (§3.1).
 
 ## 6. What is retired
 
 | Retired | Replaced by |
 |---|---|
-| 21 per-type diff functions + 106 change classes (256 files / 31,162 LOC) | generic hash diff + rule table (§3.3–3.4) |
+| Document-shaped catalog models (columns/constraints/privileges/labels nested in `dataFields`, [table.model.ts:211-230](../packages/pg-delta/src/core/objects/table/table.model.ts)) | normalized fact rows with parent relations + Merkle rollups (§3.1) |
+| 21 per-type diff functions + 106 change classes (256 files / 31,162 LOC) | rollup-guided generic diff + rule table (§3.3–3.4) |
+| Per-type comment/privilege/security-label implementations (the "scope" axis) | one global rule per metadata kind over target-referencing facts (§3.4) |
 | Two-phase sort + `invalidates` side channel + cycle breakers + dependency filter + post-diff normalization-as-repair | one mixed graph, decomposition by construction, cosmetic compaction (§3.5–3.6) |
 | Round-based declarative apply ([round-apply.ts](../packages/pg-delta/src/core/declarative-apply/round-apply.ts)) | shadow-DB elaboration through the one plan path (§3.2) |
 | pg-topo in the apply path | pg-topo as dev-experience layer (§4.4) |
-| String stable-ID re-parsing | typed `StableId` (§3.1) |
+| String stable-ID re-parsing ([expand-replace-dependencies.ts:419-425](../packages/pg-delta/src/core/expand-replace-dependencies.ts)) | typed `StableId` (§3.1) |
 | `JSON.stringify` equality + triple extraction per apply | content hashes + single-snapshot extraction + proof-as-opt-in (§3.1, §3.2, §3.7) |
 | Hand-written per-type test matrix as primary safety net | generative roundtrip proof + thin integration ring (§4.3) |
 
@@ -404,12 +483,18 @@ over nearly verbatim:
   version parity rule it out of the trusted path today. Environments that
   cannot reach any scratch database lose the declarative frontend — that is
   a real constraint and is accepted.
+- **Fact-count growth.** Normalization multiplies object count ~10–30× (a
+  10k-table schema becomes a few hundred thousand facts). Memory impact is
+  trivial; diff cost tracks *changes*, not facts, because of rollup
+  skipping. The real cost is conceptual: contributors think in facts and
+  views instead of convenient pre-joined documents.
 - **Rule-table expressiveness risk.** The gnarliest ALTER semantics resist
   tabularization; rules can degenerate into code-in-disguise. Mitigations:
-  functions confined to predicate/template slots, and the proof loop as a
-  lie detector. If a kind genuinely cannot be expressed, the honest response
-  is a structured sub-rule vocabulary, not an imperative escape hatch —
-  escape hatches are how the current eight-forms situation happened.
+  functions confined to predicate/template slots, delta-set rules for
+  multi-fact atoms, and the proof loop as a lie detector. If a kind
+  genuinely cannot be expressed, the honest response is a structured
+  sub-rule vocabulary, not an imperative escape hatch — escape hatches are
+  how the current eight-forms situation happened.
 - **Verbosity when compaction is conservative.** Cosmetic by construction;
   the compactor can improve forever without correctness risk.
 - **Proof costs an extra apply + extract.** Optional per environment; cheap
@@ -446,6 +531,21 @@ removes:
 6. **45-job CI matrix defending hand-written cases** — consequence of
    lacking a proof loop; correctness must be asserted per-case because it
    cannot be checked per-run. §3.7.
+7. **Three granularities that don't agree.** Equality lives at the document
+   level (`dataFields` nests columns, constraints, privileges, labels —
+   [table.model.ts:211-230](../packages/pg-delta/src/core/objects/table/table.model.ts)),
+   dependencies live at the sub-entity level (`pg_depend` targets columns
+   and constraints), and actions live at the statement level. Most
+   hand-written code is translation between the three:
+   [table.create.ts:36-43](../packages/pg-delta/src/core/objects/table/changes/table.create.ts)
+   re-enumerates column IDs out of the nested array so the graph can see
+   them; the graph builder maintains reverse multimaps to map IDs back onto
+   changes; and the 1,034 lines of
+   [table.diff.ts](../packages/pg-delta/src/core/objects/table/table.diff.ts)
+   exist to re-discover *which nested part* of a "changed" document actually
+   changed — a second, per-type diff engine inside each document. The fact
+   base removes the translation by removing the disagreement: one
+   granularity for state, dependencies, deltas, and actions. §3.1, §3.3.
 
 ## 9. The path from here
 
@@ -457,32 +557,44 @@ RED→GREEN regression test per repository policy.
 
 | # | Phase | North-star component it builds | Notes |
 |---|---|---|---|
-| 1 | Single-snapshot parallel extraction; memoized content hashes on models; hash-based `equals`; post-apply verify becomes explicit proof opt-in | Fact base §3.1–3.2 | Fixes the consistency bug on day one; hashes later power fingerprints, renames, proof |
-| 2 | Typed `StableId` (frozen canonical string form, parse/format round-trip tested); kill regex re-parsing | Fact base identity §3.1 | Wire format byte-frozen — persisted in plan fingerprints |
+| 1 | Single-snapshot parallel extraction; memoized content hashes on models; hash-based `equals`; post-apply verify becomes explicit proof opt-in | Fact base capture & hashing §3.1–3.2 | Fixes the consistency bug on day one; hashes later power fingerprints, renames, proof |
+| 2 | Typed `StableId` (frozen canonical string form, parse/format round-trip tested); kill regex re-parsing | Fact identity §3.1 | Wire format byte-frozen — persisted in plan fingerprints |
 | 3 | `provePlan(plan, source)` as a first-class API: template-cloned scratch, apply, extract, hash-compare. Adopt as CI oracle; begin generative roundtrip tests; shrink the hand-written integration matrix as proof coverage grows | Proof loop §3.7, §4.3 | **Do this before touching emission** — it is the safety net for phases 5–8 |
 | 4 | Sort hygiene while the old sort still exists: depend-row pre-filtering to the change set, single graph build per phase, heap queue | Interim perf | Pure wins now; code is absorbed by phase 6 |
 | 5 | Decomposition-by-default emission + the compaction pass; delete cycle breakers by attrition as their cycle classes become unconstructible | §3.5–3.6 | First emission-changing phase; gated on state-proof + review |
 | 6 | One mixed graph (old-state edges + new-state edges + identity conflicts) replaces two-phase + `invalidates` + repair loop | §3.6 | A surviving cycle after 5+6 is a rule/emission bug — fix the rule, never add a breaker |
-| 7 | Rule table: migrate kinds from per-type diff+classes to rules consumed by the generic engine — cookie-cutter kinds first, table/view/procedure as structured conditional rules last; delete the per-type dispatch switches and the change-class union | §3.3–3.4 / P2 | Largest phase; per-kind PRs; proof loop is the oracle |
-| 8 | Shadow-DB frontend for SQL files through the one plan path; round-apply demoted to fallback, then removed; pg-topo repositioned as dev-experience layer; WASM leaves the core install | §3.2, §4.4 | The declarative workflow's correctness becomes the diff engine's correctness |
-| 9 | Rename detection (hash-equal candidates, policy-gated); layered public API finalized (fact base / diff / plan / proof / apply); packaging falls out | §4.1, §4.5 | The visible product payoff |
+| 7 | Fact-model normalization: flatten sub-entities (columns, constraints, defaults, ACL entries, comments, labels) into facts with parent relations and Merkle rollups, kind by kind; document views become render-time joins; rollup hashes preserve whole-object equality during transition | Fact base §3.1, generic diff §3.3 | Internal refactor — byte-identical SQL gate; enables phase 8 |
+| 8 | Rule table: migrate kinds from per-type diff+classes to delta rules consumed by the generic engine — global metadata rules (comment/ACL/label) first, cookie-cutter kinds next, table/view/procedure as structured conditional + delta-set rules last; delete the per-type dispatch switches and the change-class union | §3.3–3.4 / P2 | Largest phase; per-kind PRs; proof loop is the oracle |
+| 9 | Shadow-DB frontend for SQL files through the one plan path; round-apply demoted to fallback, then removed; pg-topo repositioned as dev-experience layer; WASM leaves the core install | §3.2, §4.4 | The declarative workflow's correctness becomes the diff engine's correctness |
+| 10 | Rename detection (object- and fact-level hash-equal candidates, policy-gated); layered public API finalized (fact base / diff / plan / proof / apply); packaging falls out | §4.1, §4.5 | The visible product payoff |
 
 Ordering rationale: 1–3 build the measurement and safety instruments; 4 is
-opportunistic; 5–7 are the structural inversion under proof protection; 8–9
-are the product payoff. Phases 1, 2, 4 can start immediately and in
-parallel.
+opportunistic; 5–8 are the structural inversion under proof protection —
+emission first (5–6), then state (7), then knowledge (8); 9–10 are the
+product payoff. Phases 1, 2, 4 can start immediately and in parallel.
 
 ## 10. Decision log
 
-- **2026-06-12** — This document supersedes the earlier incremental-roadmap
-  framing of itself. The maintainer's direction: define the **technical
-  optimum without regard to past choices**; it is the project's north star.
-  Earlier scoping decisions made under the incremental framing (e.g.
-  "moderate packaging") are superseded where this document derives a
-  different answer; the shadow-DB convergence decision is unchanged and now
-  central (P1).
+- **2026-06-12 (a)** — This document supersedes the earlier
+  incremental-roadmap framing of itself. The maintainer's direction: define
+  the **technical optimum without regard to past choices**; it is the
+  project's north star. Earlier scoping decisions made under the incremental
+  framing (e.g. "moderate packaging") are superseded where this document
+  derives a different answer; the shadow-DB convergence decision is
+  unchanged and now central (P1).
+- **2026-06-12 (b)** — Following maintainer review ("are the change-based
+  data structures and captured data the optimum?"), the fact base is
+  specified as **fully normalized with Merkle rollup hashing** (§3.1), the
+  diff output as fact-level deltas (§3.3), and cross-cutting metadata as
+  ordinary target-referencing facts. This unifies state, dependency, delta,
+  and action granularity — the property that makes P2's "two forms of
+  knowledge" structurally true (§8.7) — and extends rename detection to
+  sub-entities (§4.1). The captured *data* (extractor SQL, normalization
+  doctrine) is affirmed as correct; the reshaping concerns its keying, plus
+  provenance (extension membership) captured as edge facts instead of
+  extraction-time filtering.
 - Open questions intentionally left to their phases: compaction's default
-  aggressiveness (phase 5), rename-policy default (phase 9), the minimum
+  aggressiveness (phase 5), rename-policy default (phase 10), the minimum
   integration-test ring kept alongside generative proof (phase 3).
 
 ---

--- a/docs/target-architecture.md
+++ b/docs/target-architecture.md
@@ -397,6 +397,33 @@ execution stays rejected — `ACCESS EXCLUSIVE` locks make it a deadlock
 machine, and the transaction is the atomicity contract. Per-statement error
 attribution replaces the joined-string megaquery.
 
+### 3.9 Integrations: a policy layer over deltas
+
+Vendor-specific behavior (the Supabase integration today) is policy, not
+engine: it decides *which* deltas a user sees and *how* actions render —
+never how state is captured, diffed, or ordered. The policy layer has three
+instruments, all data:
+
+- **Filtering = predicates over deltas and facts.** A filter rule matches
+  delta fields (kind, verb, identity) and fact context — including the
+  provenance edges of §3.1. "Hide everything owned by extension X" or
+  "never touch schema `auth`" become provenance/identity predicates instead
+  of extraction-time suppression: the engine sees everything; policy decides
+  visibility. The user-facing DSL contract (declarative patterns,
+  first-match-wins rules) carries over, re-targeted at deltas.
+- **Serialization options = rule parameterization.** Options like
+  `skipAuthorization` stop being per-change-class plumbing and become named
+  parameters that a serialize rule passes into the rule table's templates.
+- **Baselines = fact-base subtraction.** An "empty catalog" for a managed
+  platform (what a fresh Supabase project already contains) is just a fact
+  base; "diff against the platform baseline" is set subtraction before
+  planning, replacing hand-maintained empty-catalog special cases.
+
+A vendor integration is therefore a data package: predicates + rule
+parameters + a baseline snapshot. It is versioned, authored without touching
+engine code, and tested with the same proof harness (policy scenarios in the
+corpus, §4.3).
+
 ---
 
 ## 4. Capabilities the design unlocks
@@ -518,7 +545,7 @@ over nearly verbatim:
   supplied by the rule table.
 - **The serialize/filter DSL surface** for integrations (Supabase rules) —
   re-targeted at deltas/actions instead of change classes, same user-facing
-  contract, strengthened by provenance facts (§3.1).
+  contract, strengthened by provenance facts; specified in §3.9.
 
 ## 6. What is retired
 
@@ -632,7 +659,51 @@ opportunistic; 5–8 are the structural inversion under proof protection —
 emission first (5–6), then state (7), then knowledge (8); 9–10 are the
 product payoff. Phases 1, 2, 4 can start immediately and in parallel.
 
-## 10. Decision log
+## 10. Guardrails for implementers
+
+This document will be executed phase by phase, likely by different people
+and different agents, each holding only part of the context. The invariants
+below are absolute. When one seems to block progress, the correct move is to
+amend this document (with a decision-log entry) — never to make a local
+exception:
+
+1. **The stable-ID wire format is frozen.** The canonical string form is
+   persisted in plan fingerprints and synthesized inside extraction SQL. Any
+   change to it is a breaking product decision, not a refactor.
+2. **No static SQL parsing in the trusted path** — extraction, diffing,
+   planning, proof, apply. If a feature seems to need a parser, it belongs
+   in the dev-experience layer (§4.4) or the design is wrong (P1).
+3. **No imperative escape hatches in the rule table.** If a kind cannot be
+   expressed, extend the rule vocabulary with a structured sub-rule form and
+   record it in the decision log. One escape hatch is how eight forms of
+   knowledge happen again (P2).
+4. **A cycle is always a rule or emission bug.** Fix the rule or decompose
+   the emission. Adding a cycle breaker — any runtime repair of the graph —
+   is forbidden (§3.5–3.6).
+5. **No emission-changing work before `provePlan` exists** (phase 3 lands
+   before phases 5–8 start). The proof loop is the safety net; building the
+   trapeze act first is not faster.
+6. **Never assert SQL bytes in new tests.** Assert state (proof), data
+   survival (proof), or action kinds/budgets (semantic plan assertions,
+   §4.3). Byte assertions re-couple tests to emission shape.
+7. **Gates are non-negotiable.** Refactor phases ship byte-identical SQL;
+   emission-changing phases ship state-proof equality plus human review of
+   the new shape (§7, §9). Every behavior change carries a changeset and a
+   RED→GREEN regression per repository policy.
+8. **Granularity is one.** State, dependencies, deltas, and actions all live
+   at fact grain. Any new structure that nests sub-entities back into
+   documents — or any map that translates between grains — is §8.7
+   returning.
+9. **The proof loop is the arbiter.** A change that passes state +
+   data-preservation proof over the corpus and the generative engine is
+   presumed correct; a change that cannot be proven that way is presumed
+   wrong, however plausible it looks.
+
+This document wins conflicts. If implementation contact shows an invariant
+is genuinely wrong, amend the document first — decision-log entry, then
+code.
+
+## 11. Decision log
 
 - **2026-06-12 (a)** — This document supersedes the earlier
   incremental-roadmap framing of itself. The maintainer's direction: define
@@ -661,6 +732,11 @@ product payoff. Phases 1, 2, 4 can start immediately and in parallel.
   schema-state proof; convergent-but-non-minimal plans are covered by
   semantic plan assertions. The old engine serves as a differential oracle
   until retired.
+- **2026-06-12 (d)** — Pre-handoff review: added the integration policy
+  layer specification (§3.9) and the implementer guardrails (§10), in
+  preparation for implementation planning being delegated phase by phase.
+  The document is considered ready; further refinement happens through
+  implementation contact and decision-log amendments.
 - Open questions intentionally left to their phases: compaction's default
   aggressiveness (phase 5), rename-policy default (phase 10), how
   aggressively to prune the ported corpus once generative coverage matures


### PR DESCRIPTION
## Summary

Adds `docs/target-architecture.md` — the project's **north star**: the technically optimal architecture for the problem space, derived from first principles rather than from the current code, built **clean-room** beside the old engine (which serves only as asset donor and differential oracle), with a build-and-cutover plan. Every code claim carries a `path:line` citation verified against `115dde8`.

**The two principles:**
1. **Postgres is the only elaborator** — one semantic engine (snapshot extraction + shadow-DB elaboration + proof-by-application) instead of today's three (exact catalog, pg-topo's approximate parser, round-based retry).
2. **PostgreSQL knowledge in exactly two forms** — extraction queries + a declarative rule table, replacing today's eight (extractors, models, diff functions, 106 change classes, serializers, custom constraints, cycle breakers, normalization passes).

**Key design points:**
- **Normalized, content-addressed fact base** mirroring pg_catalog's relational shape: every addressable thing (column, constraint, default, ACL entry, comment, label) is its own fact with a parent *relation*, not a sub-document; Merkle rollup hashes give O(changed) diffing. This unifies the three granularities that disagree today (document-level equality, sub-entity dependencies, statement-level actions — §8.7) and makes **zero per-type diff code** structurally true.
- Diff output = fact-level **deltas** (add/remove/set) — diffable, replayable, storable plans
- Cross-cutting metadata (comments, ACLs, labels) = ordinary target-referencing facts → **one global rule per kind** instead of 21 per-type implementations
- **Maximal decomposition + cosmetic compaction**: cycles become structurally unconstructible (pg_dump's trick) — failure mode shifts from "unsortable plan, write a new breaker" to "more verbose script"
- One mixed dependency graph replaces two-phase sort + `invalidates` + the repair loop
- **First-class proof loop with two checks** — state convergence (apply to clone → re-extract → hash-compare) **and data preservation** (seeded rows must survive wherever the plan claims `dataLoss: none`): the data-loss column of the safety report becomes a verified claim; rewrite risk is observed via relfilenode, lock classes stay vetted-not-proven
- **Test architecture (§4.3)**: existing integration scenarios survive as the **seed corpus** behind one proof harness; generative exploration on top; semantic plan assertions (action kinds/budgets, never SQL bytes) for minimality; old-vs-new differential testing during migration
- **Rename detection down to columns** (hash-equal fact candidates, policy-gated) — the case that destroys data in practice
- pg-topo exits the trusted path → dev-experience layer; WASM leaves the core install
- **Integrations as a policy layer (§3.9)**: filtering = predicates over deltas/facts (provenance edges), serialize options = rule parameterization, platform baselines = fact-base subtraction — a vendor integration becomes a versionable data package
- **Implementer guardrails (§10)**: nine absolute invariants for phase-by-phase delegated implementation, with the amend-the-doc-first rule

**What survives:** the extractor SQL corpus, the pg_depend doctrine, stableSnapshot normalization knowledge (becomes the fact payload / hash surface), the plan+fingerprint contract, risk classification — the knowledge stays, the plumbing between it is replaced.

**Full breaking changes (decision log f):** this is a brand-new library — nothing carries over for compatibility's sake. The stable-ID wire format is unfrozen: identity is structured end-to-end (extraction SQL returns identity *parts*, never synthesized strings — one codec instead of mirrored TS/SQL formats), persisted artifacts are version-tagged instead of frozen, the policy DSL and plan/snapshot formats are designed fresh.

**Per-stage implementation guides:** `docs/stage-00-test-suite.md` … `docs/stage-10-cutover.md` — deliverables, old-codebase mining maps, pitfalls, and checkable gates per stage. The path gains **stage 0 (corpus first)**: the test suite is built before any engine code — scenario corpus ported from the existing integration tests, fixture-validity layer green from day one, engine tests red on a pinned `NotImplementedError` list, old-engine baselines captured.

**The path (§9):** an 11-stage clean-room build (0–10) — fact-base core → extractor port → proof harness + corpus → generic diff → planner → execution → frontends → policy layer → renames/API → **cutover at the parity bar** (corpus green, differential clean-or-explained, generative soak, extractor ring green). No byte-compatibility gates anywhere; proof/differential/fixture gates only. Consumers migrate once, at cutover, to a new major.

Docs-only — no package behavior change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
