### PR TITLE
fix(pg-delta): preserve event/table clause when formatting triggers with quoted names

### DIFF
--- a/.changeset/fix-trigger-quoted-name-formatting.md
+++ b/.changeset/fix-trigger-quoted-name-formatting.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): preserve the event/table clause when formatting triggers with quoted names
+
+A trigger whose name must be double-quoted (e.g. it contains a dash, like a Supabase webhook named `send-chat-push`) had its generated DDL mangled: the SQL formatter dropped the `AFTER INSERT ON <table>` event/table clause, producing invalid migration SQL. The tokenizer skipped double-quoted identifiers entirely, so the trigger formatter mistook the next keyword for the trigger name and sliced away everything before the first recognized clause. The tokenizer now emits an atomic token for double-quoted identifiers, which also fixes the same latent issue for other object types whose names follow a keyword positionally (subscriptions, servers, foreign data wrappers, etc.).

--- a/packages/pg-delta/src/core/plan/sql-format/format-trigger-quoted-name.test.ts
+++ b/packages/pg-delta/src/core/plan/sql-format/format-trigger-quoted-name.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { formatSqlStatements } from "./index.ts";
+
+describe("formatCreateTrigger with quoted (dashed) names", () => {
+  // Regression: CLI-1820. A trigger whose name contains characters that force
+  // PostgreSQL to double-quote it (e.g. a dash) used to lose its event/table
+  // clause ("AFTER INSERT ON public.t1"). The tokenizer emitted no token for
+  // the quoted identifier, so the formatter mistook the next keyword for the
+  // name and sliced away everything before the first recognized clause.
+  it("preserves the event/table clause for a dashed trigger name", () => {
+    const sql = `CREATE TRIGGER "new-webhook-with-dashed-name" AFTER INSERT ON public.t1 FOR EACH ROW EXECUTE FUNCTION supabase_functions.http_request('https://example.com/x', 'POST', '{}', '{}', '5000')`;
+
+    const [formatted] = formatSqlStatements([sql], { keywordCase: "upper" });
+
+    expect(formatted).toContain("AFTER INSERT ON public.t1");
+    expect(formatted).toMatchInlineSnapshot(`
+      "CREATE TRIGGER "new-webhook-with-dashed-name"
+        AFTER INSERT ON public.t1
+        FOR EACH ROW
+        EXECUTE FUNCTION
+          supabase_functions.http_request('https://example.com/x', 'POST', '{}', '{}', '5000')"
+    `);
+  });
+
+  it("formats a dashed trigger name the same way as an unquoted one", () => {
+    const dashed = `CREATE TRIGGER "send-chat-push" AFTER INSERT ON public.chat_message FOR EACH ROW EXECUTE FUNCTION public.notify()`;
+    const plain = `CREATE TRIGGER send_chat_push AFTER INSERT ON public.chat_message FOR EACH ROW EXECUTE FUNCTION public.notify()`;
+
+    const [dashedOut] = formatSqlStatements([dashed], { keywordCase: "upper" });
+    const [plainOut] = formatSqlStatements([plain], { keywordCase: "upper" });
+
+    expect(dashedOut.replace('"send-chat-push"', "send_chat_push")).toBe(
+      plainOut,
+    );
+  });
+});

--- a/packages/pg-delta/src/core/plan/sql-format/sql-scanner.ts
+++ b/packages/pg-delta/src/core/plan/sql-format/sql-scanner.ts
@@ -29,6 +29,16 @@ type WalkSqlOptions = {
    * called once with the full sequence.
    */
   onSkipped?: (chunk: string) => void;
+  /**
+   * Called once for each top-level double-quoted identifier, after its closing
+   * quote, with the index of the opening quote (`start`), the index just past
+   * the closing quote (`end`), and the parenthesis depth at the quote.
+   *
+   * Lets callers treat a quoted identifier (e.g. `"my-trigger"`) as an atomic
+   * token even though its interior is reported via `onSkipped`. Returning
+   * `false` stops the walk early, like `onTopLevel`.
+   */
+  onQuotedIdentifier?: (start: number, end: number, depth: number) => boolean;
 };
 
 /**
@@ -104,10 +114,12 @@ export function walkSql(
   const trackDepth = options?.trackDepth ?? false;
   const startIndex = options?.startIndex ?? 0;
   const onSkipped = options?.onSkipped;
+  const onQuotedIdentifier = options?.onQuotedIdentifier;
 
   let inSingleQuote = false;
   let singleQuoteEscapeMode = false;
   let inDoubleQuote = false;
+  let doubleQuoteStart = -1;
   let inLineComment = false;
   let inBlockComment = false;
   let dollarTag: string | null = null;
@@ -187,6 +199,12 @@ export function walkSql(
           continue;
         }
         inDoubleQuote = false;
+        onSkipped?.(char);
+        if (onQuotedIdentifier?.(doubleQuoteStart, i + 1, depth) === false) {
+          return;
+        }
+        i += 1;
+        continue;
       }
       onSkipped?.(char);
       i += 1;
@@ -215,6 +233,7 @@ export function walkSql(
     }
     if (char === '"') {
       inDoubleQuote = true;
+      doubleQuoteStart = i;
       onSkipped?.(char);
       i += 1;
       continue;

--- a/packages/pg-delta/src/core/plan/sql-format/tokenizer.test.ts
+++ b/packages/pg-delta/src/core/plan/sql-format/tokenizer.test.ts
@@ -21,6 +21,22 @@ describe("scanTokens", () => {
     expect(inner[1].depth).toBe(1);
   });
 
+  it("emits a single token for a double-quoted identifier", () => {
+    const tokens = scanTokens('CREATE TRIGGER "send-chat-push" AFTER');
+    expect(tokens).toEqual([
+      { value: "CREATE", upper: "CREATE", start: 0, end: 6, depth: 0 },
+      { value: "TRIGGER", upper: "TRIGGER", start: 7, end: 14, depth: 0 },
+      {
+        value: '"send-chat-push"',
+        upper: '"SEND-CHAT-PUSH"',
+        start: 15,
+        end: 31,
+        depth: 0,
+      },
+      { value: "AFTER", upper: "AFTER", start: 32, end: 37, depth: 0 },
+    ]);
+  });
+
   it("ignores content in quotes, comments, and dollar-quotes", () => {
     const tokens = scanTokens("SELECT 'hello' -- comment\n FROM $$body$$ tbl");
     const uppers = tokens.map((t) => t.upper);

--- a/packages/pg-delta/src/core/plan/sql-format/tokenizer.ts
+++ b/packages/pg-delta/src/core/plan/sql-format/tokenizer.ts
@@ -27,7 +27,26 @@ export function scanTokens(statement: string): Token[] {
       }
       return true;
     },
-    { trackDepth: true },
+    {
+      trackDepth: true,
+      // Double-quoted identifiers (e.g. `"my-trigger"`) are atomic tokens too.
+      // Without this, the walker skips their interior entirely and positional
+      // token logic (e.g. "the name follows the TRIGGER keyword") lands on the
+      // wrong token. The value keeps the surrounding quotes; a quoted
+      // identifier never matches a keyword, which is correct.
+      onQuotedIdentifier: (start, end, depth) => {
+        const value = statement.slice(start, end);
+        tokens.push({
+          value,
+          upper: value.toUpperCase(),
+          start,
+          end,
+          depth,
+        });
+        skipUntil = end;
+        return true;
+      },
+    },
   );
 
   return tokens;

--- a/packages/pg-delta/tests/integration/trigger-operations.test.ts
+++ b/packages/pg-delta/tests/integration/trigger-operations.test.ts
@@ -127,6 +127,49 @@ for (const pgVersion of POSTGRES_VERSIONS) {
       }),
     );
 
+    // Regression: CLI-1820. A trigger whose name must be double-quoted (it
+    // contains a dash) had its formatted DDL mangled — the SQL formatter
+    // dropped the "AFTER INSERT ON ..." event/table clause, producing invalid
+    // migration SQL. The generated statement must keep the full clause.
+    test(
+      "trigger with a double-quoted (dashed) name keeps its event/table clause",
+      withDb(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+          CREATE SCHEMA test_schema;
+          CREATE TABLE test_schema.t1 (
+            id serial PRIMARY KEY,
+            name text NOT NULL
+          );
+          CREATE FUNCTION test_schema.notify_change()
+          RETURNS trigger
+          LANGUAGE plpgsql
+          AS $$
+          BEGIN
+            RETURN NEW;
+          END;
+          $$;
+        `,
+          testSql: `
+          CREATE TRIGGER "new-webhook-with-dashed-name"
+          AFTER INSERT ON test_schema.t1
+          FOR EACH ROW
+          EXECUTE FUNCTION test_schema.notify_change();
+        `,
+          assertSqlStatements: (statements) => {
+            const triggerStatement = statements.find((statement) =>
+              statement.includes('"new-webhook-with-dashed-name"'),
+            );
+            expect(triggerStatement).toContain(
+              "AFTER INSERT ON test_schema.t1",
+            );
+          },
+        });
+      }),
+    );
+
     test(
       "multi-event trigger",
       withDb(pgVersion, async (db) => {


### PR DESCRIPTION
## Summary

Fixes a regression where triggers with double-quoted names (e.g., containing dashes like `"send-chat-push"`) had their event/table clause (`AFTER INSERT ON <table>`) dropped during SQL formatting, producing invalid migration DDL.

## Root Cause

The SQL tokenizer skipped double-quoted identifiers entirely, treating their interior as whitespace. This caused the trigger formatter's positional logic (which assumes the trigger name follows the `TRIGGER` keyword) to land on the wrong token and slice away the event/table clause.

## Changes

- **tokenizer.ts**: Added `onQuotedIdentifier` callback to `walkSql` options to emit atomic tokens for double-quoted identifiers, preserving their position in the token stream
- **sql-scanner.ts**: Implemented the `onQuotedIdentifier` callback in `walkSql` to track and report double-quoted identifier boundaries
- **tokenizer.test.ts**: Added test verifying double-quoted identifiers are emitted as single tokens
- **format-trigger-quoted-name.test.ts**: Added regression tests confirming the event/table clause is preserved for dashed trigger names
- **trigger-operations.test.ts**: Added integration test covering the full roundtrip for a trigger with a dashed name
- **fix-trigger-quoted-name-formatting.md**: Changeset documenting the fix

## Implementation Details

The fix treats double-quoted identifiers as atomic tokens by:
1. Tracking the start position when entering a double-quoted identifier
2. Calling `onQuotedIdentifier` when exiting the quote, passing the full span (including quotes)
3. Storing the quoted identifier as a single token with its original value (quotes included)

This approach also fixes the same latent issue for other object types whose names follow a keyword positionally (subscriptions, servers, foreign data wrappers, etc.).

https://claude.ai/code/session_01UBbwyEQFqydHcCUpn9e98J