### PR TITLE
fix(pg-delta): preserve REVOKE EXECUTE FROM PUBLIC

### DIFF
--- a/.changeset/preserve-public-execute-revoke.md
+++ b/.changeset/preserve-public-execute-revoke.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Preserve explicit `REVOKE EXECUTE FROM PUBLIC` statements when diffing functions and procedures.

--- a/packages/pg-delta/src/core/objects/procedure/procedure.diff.test.ts
+++ b/packages/pg-delta/src/core/objects/procedure/procedure.diff.test.ts
@@ -12,6 +12,10 @@ import {
 import { CreateCommentOnProcedure } from "./changes/procedure.comment.ts";
 import { CreateProcedure } from "./changes/procedure.create.ts";
 import { DropProcedure } from "./changes/procedure.drop.ts";
+import {
+  GrantProcedurePrivileges,
+  RevokeProcedurePrivileges,
+} from "./changes/procedure.privilege.ts";
 import { diffProcedures } from "./procedure.diff.ts";
 import { Procedure, type ProcedureProps } from "./procedure.model.ts";
 
@@ -54,6 +58,88 @@ const testContext = {
   defaultPrivilegeState: new DefaultPrivilegeState({}),
   mainRoles: {},
 };
+
+function procedure(overrides: Partial<ProcedureProps> = {}): Procedure {
+  return new Procedure({
+    ...base,
+    owner: "postgres",
+    privileges: [],
+    ...overrides,
+  });
+}
+
+function publicExecutePrivilege() {
+  return [{ grantee: "PUBLIC", privilege: "EXECUTE", grantable: false }];
+}
+
+function defaultPrivilegesWithPublicExecute(): DefaultPrivilegeState {
+  const defaultPrivilegeState = new DefaultPrivilegeState({});
+  defaultPrivilegeState.applyGrant("postgres", "f", null, "PUBLIC", [
+    { privilege: "EXECUTE", grantable: false },
+  ]);
+  return defaultPrivilegeState;
+}
+
+function defaultPrivilegesWithSchemaRoutineGrant(): DefaultPrivilegeState {
+  const defaultPrivilegeState = defaultPrivilegesWithPublicExecute();
+  defaultPrivilegeState.applyGrant("postgres", "f", "public", "anon", [
+    { privilege: "EXECUTE", grantable: false },
+  ]);
+  return defaultPrivilegeState;
+}
+
+function contextWith(
+  overrides: Partial<typeof testContext> & {
+    skipDefaultPrivilegeSubtraction?: boolean;
+  } = {},
+) {
+  return {
+    ...testContext,
+    defaultPrivilegeState: new DefaultPrivilegeState({}),
+    ...overrides,
+  };
+}
+
+function expectPublicRevoke(
+  changes: ReturnType<typeof diffProcedures>,
+  expectedSql = "REVOKE ALL ON FUNCTION public.fn1() FROM PUBLIC",
+): RevokeProcedurePrivileges {
+  const revokes = changes.filter(
+    (change) => change instanceof RevokeProcedurePrivileges,
+  ) as RevokeProcedurePrivileges[];
+
+  expect(revokes).toHaveLength(1);
+  expect(revokes[0].grantee).toBe("PUBLIC");
+  expect(
+    revokes[0].privileges.map(({ privilege, grantable }) => ({
+      privilege,
+      grantable,
+    })),
+  ).toEqual([{ privilege: "EXECUTE", grantable: false }]);
+  expect(revokes[0].serialize()).toBe(expectedSql);
+  return revokes[0];
+}
+
+function expectPublicGrant(
+  changes: ReturnType<typeof diffProcedures>,
+): GrantProcedurePrivileges {
+  const grants = changes.filter(
+    (change) => change instanceof GrantProcedurePrivileges,
+  ) as GrantProcedurePrivileges[];
+
+  expect(grants).toHaveLength(1);
+  expect(grants[0].grantee).toBe("PUBLIC");
+  expect(
+    grants[0].privileges.map(({ privilege, grantable }) => ({
+      privilege,
+      grantable,
+    })),
+  ).toEqual([{ privilege: "EXECUTE", grantable: false }]);
+  expect(grants[0].serialize()).toBe(
+    "GRANT ALL ON FUNCTION public.fn1() TO PUBLIC",
+  );
+  return grants[0];
+}
 
 describe.concurrent("procedure.diff", () => {
   test("create and drop", () => {
@@ -280,5 +366,141 @@ describe.concurrent("procedure.diff", () => {
     expect(
       changes.some((change) => change instanceof CreateCommentOnProcedure),
     ).toBe(true);
+  });
+
+  test("create emits PUBLIC EXECUTE revoke when the default is absent in the target", () => {
+    const p = procedure();
+    const changes = diffProcedures(
+      contextWith({
+        defaultPrivilegeState: defaultPrivilegesWithPublicExecute(),
+      }),
+      {},
+      { [p.stableId]: p },
+    );
+
+    expect(changes[0]).toBeInstanceOf(CreateProcedure);
+    expectPublicRevoke(changes);
+  });
+
+  test("create emits PUBLIC EXECUTE revoke for procedures as well as functions", () => {
+    const p = procedure({
+      name: "proc1",
+      kind: "p",
+      return_type: "void",
+      definition:
+        "CREATE PROCEDURE public.proc1() LANGUAGE sql AS $$ SELECT 1 $$",
+    });
+    const changes = diffProcedures(
+      contextWith({
+        defaultPrivilegeState: defaultPrivilegesWithPublicExecute(),
+      }),
+      {},
+      { [p.stableId]: p },
+    );
+
+    expect(changes[0]).toBeInstanceOf(CreateProcedure);
+    expectPublicRevoke(
+      changes,
+      "REVOKE ALL ON PROCEDURE public.proc1() FROM PUBLIC",
+    );
+  });
+
+  test("create does not emit PUBLIC EXECUTE grant when the target keeps the built-in default", () => {
+    const p = procedure({ privileges: publicExecutePrivilege() });
+    const changes = diffProcedures(
+      contextWith({
+        defaultPrivilegeState: defaultPrivilegesWithPublicExecute(),
+      }),
+      {},
+      { [p.stableId]: p },
+    );
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toBeInstanceOf(CreateProcedure);
+  });
+
+  test("create combines global routine defaults with schema-specific routine defaults", () => {
+    const p = procedure({ privileges: publicExecutePrivilege() });
+    const changes = diffProcedures(
+      contextWith({
+        defaultPrivilegeState: defaultPrivilegesWithSchemaRoutineGrant(),
+      }),
+      {},
+      { [p.stableId]: p },
+    );
+
+    const revokes = changes.filter(
+      (change) => change instanceof RevokeProcedurePrivileges,
+    ) as RevokeProcedurePrivileges[];
+
+    expect(changes[0]).toBeInstanceOf(CreateProcedure);
+    expect(
+      changes.some((change) => change instanceof GrantProcedurePrivileges),
+    ).toBe(false);
+    expect(revokes).toHaveLength(1);
+    expect(revokes[0].grantee).toBe("anon");
+    expect(revokes[0].serialize()).toBe(
+      "REVOKE ALL ON FUNCTION public.fn1() FROM anon",
+    );
+  });
+
+  test("alter emits PUBLIC EXECUTE revoke when an existing routine removes the built-in default", () => {
+    const main = procedure({ privileges: publicExecutePrivilege() });
+    const branch = procedure();
+    const changes = diffProcedures(
+      contextWith(),
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+
+    expectPublicRevoke(changes);
+  });
+
+  test("alter emits PUBLIC EXECUTE grant when an existing routine restores the built-in default", () => {
+    const main = procedure();
+    const branch = procedure({ privileges: publicExecutePrivilege() });
+    const changes = diffProcedures(
+      contextWith(),
+      { [main.stableId]: main },
+      { [branch.stableId]: branch },
+    );
+
+    expectPublicGrant(changes);
+  });
+
+  test("create after a global default privilege revoke does not emit a redundant routine revoke", () => {
+    const p = procedure();
+    const changes = diffProcedures(
+      contextWith({ defaultPrivilegeState: new DefaultPrivilegeState({}) }),
+      {},
+      { [p.stableId]: p },
+    );
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toBeInstanceOf(CreateProcedure);
+  });
+
+  test("declarative create does not emit PUBLIC EXECUTE grant when the target keeps the built-in default", () => {
+    const p = procedure({ privileges: publicExecutePrivilege() });
+    const changes = diffProcedures(
+      contextWith({ skipDefaultPrivilegeSubtraction: true }),
+      {},
+      { [p.stableId]: p },
+    );
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toBeInstanceOf(CreateProcedure);
+  });
+
+  test("declarative create emits PUBLIC EXECUTE revoke when the target removes the built-in default", () => {
+    const p = procedure();
+    const changes = diffProcedures(
+      contextWith({ skipDefaultPrivilegeSubtraction: true }),
+      {},
+      { [p.stableId]: p },
+    );
+
+    expect(changes[0]).toBeInstanceOf(CreateProcedure);
+    expectPublicRevoke(changes);
   });
 });

--- a/packages/pg-delta/src/core/objects/procedure/procedure.diff.ts
+++ b/packages/pg-delta/src/core/objects/procedure/procedure.diff.ts
@@ -2,8 +2,8 @@ import { diffObjects } from "../base.diff.ts";
 import {
   diffPrivileges,
   emitObjectPrivilegeChanges,
-  filterPublicBuiltInDefaults,
 } from "../base.privilege-diff.ts";
+import type { PrivilegeProps } from "../base.privilege-diff.ts";
 import type { ObjectDiffContext } from "../diff-context.ts";
 import { diffSecurityLabels } from "../security-label.types.ts";
 import { deepEqual, hasNonAlterableChanges } from "../utils.ts";
@@ -34,6 +34,32 @@ import {
 import type { ProcedureChange } from "./changes/procedure.types.ts";
 import type { Procedure } from "./procedure.model.ts";
 
+const PUBLIC_EXECUTE_DEFAULT: PrivilegeProps = {
+  grantee: "PUBLIC",
+  privilege: "EXECUTE",
+  grantable: false,
+  columns: null,
+};
+
+function privilegeKey(privilege: PrivilegeProps): string {
+  return [
+    privilege.grantee,
+    privilege.privilege,
+    String(privilege.grantable),
+    [...(privilege.columns ?? [])].sort().join(","),
+  ].join(":");
+}
+
+function deduplicatePrivileges<T extends PrivilegeProps>(privileges: T[]): T[] {
+  const seen = new Set<string>();
+  return privileges.filter((privilege) => {
+    const key = privilegeKey(privilege);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 /**
  * Diff two sets of procedures from main and branch catalogs.
  *
@@ -45,7 +71,10 @@ import type { Procedure } from "./procedure.model.ts";
 export function diffProcedures(
   ctx: Pick<
     ObjectDiffContext,
-    "version" | "currentUser" | "defaultPrivilegeState"
+    | "version"
+    | "currentUser"
+    | "defaultPrivilegeState"
+    | "skipDefaultPrivilegeSubtraction"
   >,
   main: Record<string, Procedure>,
   branch: Record<string, Procedure>,
@@ -85,28 +114,45 @@ export function diffProcedures(
     // so objects are created with the default privileges state in effect.
     // We compare default privileges against desired privileges to generate REVOKE/GRANT statements
     // needed to reach the final desired state.
-    const effectiveDefaults = ctx.defaultPrivilegeState.getEffectiveDefaults(
-      ctx.currentUser,
-      "procedure",
-      proc.schema ?? "",
-    );
+    // Declarative/self-contained output intentionally ignores role-configured
+    // defaults, but PostgreSQL still creates routines with PUBLIC EXECUTE.
+    const effectiveDefaults = (() => {
+      if (ctx.skipDefaultPrivilegeSubtraction) {
+        return [PUBLIC_EXECUTE_DEFAULT];
+      }
+
+      const schema = proc.schema ?? "";
+      // getEffectiveDefaults returns a schema's own ALTER DEFAULT PRIVILEGES
+      // entries OR, as a fallback, the global ones -- never both. In PostgreSQL
+      // per-schema entries are additive to the global routine defaults and can
+      // only add privileges, never subtract ones granted globally (including the
+      // built-in PUBLIC EXECUTE), so fetch the global defaults separately and
+      // union them in rather than letting a schema-specific entry mask them.
+      const schemaDefaults = ctx.defaultPrivilegeState.getEffectiveDefaults(
+        ctx.currentUser,
+        "procedure",
+        schema,
+      );
+      const globalDefaults = schema
+        ? ctx.defaultPrivilegeState.getEffectiveDefaults(
+            ctx.currentUser,
+            "procedure",
+            "",
+          )
+        : [];
+
+      return deduplicatePrivileges([...globalDefaults, ...schemaDefaults]);
+    })();
     const creatorFilteredDefaults =
       proc.owner !== ctx.currentUser
         ? effectiveDefaults.filter((p) => p.grantee !== ctx.currentUser)
         : effectiveDefaults;
-    // Filter out PUBLIC's built-in default EXECUTE privilege (PostgreSQL grants it automatically)
-    // Reference: https://www.postgresql.org/docs/17/ddl-priv.html Table 5.2
-    // This prevents generating unnecessary "GRANT EXECUTE TO PUBLIC" statements
-    const desiredPrivileges = filterPublicBuiltInDefaults(
-      "procedure",
-      proc.privileges,
-    );
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Note: we use the final owner (proc.owner), not the
     // current user, because ownership change happens before privilege diffing.
     const privilegeResults = diffPrivileges(
-      filterPublicBuiltInDefaults("procedure", creatorFilteredDefaults),
-      desiredPrivileges,
+      creatorFilteredDefaults,
+      proc.privileges,
       proc.owner,
     );
 
@@ -364,22 +410,11 @@ export function diffProcedures(
       // a name change would be handled as drop + create by diffObjects()
 
       // PRIVILEGES
-      // Filter out PUBLIC's built-in default EXECUTE privilege from main catalog
-      // (PostgreSQL grants it automatically, so we shouldn't compare it)
-      const mainPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "procedure",
-        mainProcedure.privileges,
-      );
-      // Filter out PUBLIC's built-in default EXECUTE privilege from branch catalog
-      const branchPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "procedure",
-        branchProcedure.privileges,
-      );
       // Filter out owner privileges - owner always has ALL privileges implicitly
       // and shouldn't be compared. Use branch owner as the reference.
       const privilegeResults = diffPrivileges(
-        mainPrivilegesFiltered,
-        branchPrivilegesFiltered,
+        mainProcedure.privileges,
+        branchProcedure.privileges,
         branchProcedure.owner,
       );
 

--- a/packages/pg-delta/tests/integration/revoke-execute-from-public.test.ts
+++ b/packages/pg-delta/tests/integration/revoke-execute-from-public.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import dedent from "dedent";
+import type { Pool } from "pg";
+import { createPlan } from "../../src/core/plan/create.ts";
+import { flattenPlanStatements } from "../../src/core/plan/render.ts";
+import { POSTGRES_VERSIONS } from "../constants.ts";
+import { roundtripFidelityTest } from "../integration/roundtrip.ts";
+import { withDbIsolated } from "../utils.ts";
+
+const FUNCTION_SIGNATURE = "public.secret_fn()";
+const CHECK_FUNCTION_BODIES = "SET check_function_bodies = false";
+
+function createFunctionSql(name: string): string {
+  return [
+    `CREATE FUNCTION public.${name}()`,
+    " RETURNS integer",
+    " LANGUAGE sql",
+    "AS $function$ SELECT 1 $function$",
+  ].join("\n");
+}
+
+async function generatedSql(
+  main: Pool,
+  branch: Pool,
+  options: Parameters<typeof createPlan>[2] = {},
+): Promise<string[]> {
+  const planResult = await createPlan(main, branch, options);
+  return planResult ? flattenPlanStatements(planResult.plan) : [];
+}
+
+async function publicCanExecute(db: Pool): Promise<boolean> {
+  const { rows } = await db.query(
+    `SELECT has_function_privilege('probe_nopriv', '${FUNCTION_SIGNATURE}', 'EXECUTE') AS ok`,
+  );
+  return rows[0].ok === true;
+}
+
+for (const pgVersion of POSTGRES_VERSIONS) {
+  describe(`revoke execute from PUBLIC (pg${pgVersion})`, () => {
+    test(
+      "create preserves REVOKE EXECUTE FROM PUBLIC and applies the locked-down behavior",
+      withDbIsolated(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: "CREATE ROLE probe_nopriv NOLOGIN",
+          testSql: dedent`
+            CREATE FUNCTION ${FUNCTION_SIGNATURE}
+            RETURNS int
+            LANGUAGE sql
+            AS $$ SELECT 1 $$;
+
+            REVOKE EXECUTE ON FUNCTION ${FUNCTION_SIGNATURE} FROM PUBLIC;
+          `,
+          assertSqlStatements: (statements) => {
+            expect(statements).toEqual([
+              CHECK_FUNCTION_BODIES,
+              createFunctionSql("secret_fn"),
+              "REVOKE ALL ON FUNCTION public.secret_fn() FROM PUBLIC",
+            ]);
+          },
+        });
+
+        expect(await publicCanExecute(db.branch)).toBe(false);
+        expect(await publicCanExecute(db.main)).toBe(false);
+      }),
+    );
+
+    test(
+      "alter emits REVOKE EXECUTE FROM PUBLIC for an existing function",
+      withDbIsolated(pgVersion, async (db) => {
+        const setup = dedent`
+          CREATE FUNCTION ${FUNCTION_SIGNATURE}
+          RETURNS int
+          LANGUAGE sql
+          AS $$ SELECT 1 $$;
+        `;
+        await db.main.query(setup);
+        await db.branch.query(setup);
+        await db.branch.query(
+          `REVOKE EXECUTE ON FUNCTION ${FUNCTION_SIGNATURE} FROM PUBLIC`,
+        );
+
+        const sql = await generatedSql(db.main, db.branch);
+
+        expect(sql).toEqual([
+          CHECK_FUNCTION_BODIES,
+          "REVOKE ALL ON FUNCTION public.secret_fn() FROM PUBLIC",
+        ]);
+      }),
+    );
+
+    test(
+      "planned global default revoke prevents redundant per-function revoke on create",
+      withDbIsolated(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          testSql: dedent`
+            ALTER DEFAULT PRIVILEGES
+              REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+
+            CREATE FUNCTION ${FUNCTION_SIGNATURE}
+            RETURNS int
+            LANGUAGE sql
+            AS $$ SELECT 1 $$;
+          `,
+          assertSqlStatements: (statements) => {
+            expect(statements).toEqual([
+              CHECK_FUNCTION_BODIES,
+              "ALTER DEFAULT PRIVILEGES FOR ROLE postgres REVOKE ALL ON ROUTINES FROM PUBLIC",
+              createFunctionSql("secret_fn"),
+            ]);
+            expect(
+              statements.filter((statement) =>
+                statement.startsWith("REVOKE ALL ON FUNCTION"),
+              ),
+            ).toEqual([]);
+          },
+        });
+      }),
+    );
+
+    test(
+      "self-contained plan emits only the explicit PUBLIC revoke needed for locked-down functions",
+      withDbIsolated(pgVersion, async (db) => {
+        await db.branch.query(dedent`
+          CREATE FUNCTION public.open_fn()
+          RETURNS int
+          LANGUAGE sql
+          AS $$ SELECT 1 $$;
+
+          CREATE FUNCTION public.secret_fn()
+          RETURNS int
+          LANGUAGE sql
+          AS $$ SELECT 1 $$;
+
+          REVOKE EXECUTE ON FUNCTION public.secret_fn() FROM PUBLIC;
+        `);
+
+        const sql = await generatedSql(db.main, db.branch, {
+          skipDefaultPrivilegeSubtraction: true,
+        });
+
+        expect(sql).toEqual([
+          CHECK_FUNCTION_BODIES,
+          createFunctionSql("open_fn"),
+          createFunctionSql("secret_fn"),
+          "REVOKE ALL ON FUNCTION public.secret_fn() FROM PUBLIC",
+        ]);
+        expect(sql.join("\n")).not.toContain(
+          "GRANT ALL ON FUNCTION public.open_fn() TO PUBLIC",
+        );
+      }),
+    );
+  });
+}


### PR DESCRIPTION
Closes #308

### What's wrong

`CREATE FUNCTION` grants `EXECUTE` to `PUBLIC` by default, and PostgreSQL's `SECURITY DEFINER` guidance recommends revoking that default and granting `EXECUTE` selectively. pg-delta dropped that `REVOKE EXECUTE ... FROM PUBLIC` from generated migrations, so a function the target schema locks down stayed PUBLIC-executable after the migration ran. It showed up two ways:

- **create-from-empty** — `CREATE FUNCTION` was emitted but the `REVOKE` was omitted, leaving the function PUBLIC-executable.
- **function already exists** — a lone new revoke produced an *empty* diff ("no changes").

### Root cause

The raw catalogs preserve the negative state correctly (`procedure.model.ts` expands `proacl IS NULL` to the built-in `PUBLIC/EXECUTE` row; an explicit revoke materializes an ACL *without* that row). The loss happened in the diff: `procedure.diff.ts` applied `filterPublicBuiltInDefaults("procedure", …)` to **both** sides of the create and alter comparisons before `diffPrivileges` ran. Once `PUBLIC/EXECUTE` was stripped from both sides, an explicit `REVOKE … FROM PUBLIC` (represented as the *absence* of that default) became invisible, so no statement was emitted.

### The fix

Stop filtering the built-in out of both sides; compare the **real** ACL the routine will have against the desired ACL:

- **Existing routines (alter path):** pass the raw source/target privilege arrays to `diffPrivileges`. Default-on-both cancels; default→revoked emits a `REVOKE`; revoked→default emits a `GRANT`.
- **New routines (create path):** compare the desired ACL against the ACL the routine actually has right after creation:
  - *normal plan* — use the effective default-privilege state. Per-schema `ALTER DEFAULT PRIVILEGES` entries are **additive** to the global routine defaults in PostgreSQL (a per-schema entry can't subtract the global built-in `PUBLIC EXECUTE`), so global and schema defaults are unioned rather than letting a schema entry mask the global built-in.
  - *self-contained / `skipDefaultPrivilegeSubtraction`* — declarative output intentionally ignores role-configured defaults, but PostgreSQL still creates routines with `PUBLIC EXECUTE`, so a minimal built-in baseline (`PUBLIC/EXECUTE/not grantable`) is used as the comparison floor.
  - the existing owner-privilege filtering (creator privileges on ownership transfer) is preserved.

The change is local to `procedure.diff.ts` (plus a small typed `PUBLIC_EXECUTE_DEFAULT` constant and a private de-dup helper); no changes to `base.privilege-diff.ts` or other object diffs.

### Scope

pg-delta's `procedure` diff path covers **both functions and procedures**, so the fix applies to both even though the issue's reproducer is a function. Aggregates have a separate diff and are unchanged. The same `filterPublicBuiltInDefaults` helper also strips PUBLIC `USAGE` for types and languages; those paths are **not** touched here — they're unverified and out of scope for #308.

### Tests

Authored test-first (RED → GREEN); the two commits are split so the `test:` commit can be checked out and watched to fail.

- **Unit** (`procedure.diff.test.ts`): create→revoke-when-target-absent; create-for-procedures (not just functions); no-redundant-grant when the built-in is kept; global+schema default union; alter revoke; alter restore (grant); create-after-global-ADP-revoke emits nothing redundant; declarative create (both keep-default and revoke-default).
- **Integration** (`tests/integration/revoke-execute-from-public.test.ts`, PG15/17/18): create preserves the revoke *and* `has_function_privilege` confirms an unprivileged role can't execute on either DB; alter-only revoke; planned global default revoke avoids a redundant per-function revoke; self-contained plan emits only the needed explicit revoke.
- A changeset (`patch`, `@supabase/pg-delta`) is included.

### Verification

Reproduces from the CLI with `pgdelta plan --target <url> --format sql` (create-from-empty omits `--source`); also via `pgdelta sync` / `declarative-apply` and Supabase's `db schema declarative sync`. Environment: macOS 26.5.1 (Darwin, Apple Silicon), Bun 1.3.14, Docker 29.5.3, PostgreSQL 15/17/18 via Alpine testcontainers.

**RED** — at the `test:` commit (production unchanged from base):

```
unit:                     18 pass, 5 fail   (the PUBLIC create/alter/declarative cases; "expected revoke length 1, received 0")
integration (PG17):        1 pass, 3 fail   (create / alter / self-contained)
```

**GREEN** — after the `fix:` commit:

```
unit:                     23 pass, 0 fail
integration (PG17):        4 pass, 0 fail
default-privileges-edge-case (PG17, adjacent regression): 17 pass, 0 fail
bun run test:pg-delta:    2663 pass, 10 skip, 0 fail   (full suite, PG15/17/18)
bun run build / check-types / format-and-lint / knip:    all clean
```

### Disclosure

- This is my **first contribution** to pg-toolbelt.
- It was implemented with assistance from **Claude Opus 4.8** and **GPT-5.5**. I'm flagging this so reviewers can scrutinize it accordingly — I verified the reproduction and every claim against a real PostgreSQL instance, and the diff is small enough to review line-by-line.
