### PR TITLE
fix(ci): build pg-topo before format-and-lint so oxlint-tsgolint resolves its types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup
         uses: ./.github/actions/setup
+      # pg-delta-next type-checks its optional @supabase/pg-topo peer through
+      # the `types` field (dist/*.d.ts), which is gitignored and not produced
+      # by install. oxlint-tsgolint does real type-checking, so it needs the
+      # same build pg-delta-next.yml's own type-check job already requires.
+      - name: Build @supabase/pg-topo (provides .d.ts for oxlint-tsgolint)
+        working-directory: packages/pg-topo
+        run: bun run build
       - name: Format and lint
         run: bun run format-and-lint
 


### PR DESCRIPTION
## What this fixes

PR #299's "Format and lint" check was failing:

```
packages/pg-delta-next/src/frontends/sql-order.ts:177:25: error typescript(no-redundant-type-constituents):
'AnalyzeOptions' is an 'error' type that acts as 'any' and overrides all other types in this union type.
```

The root-level `format-and-lint` job never builds `@supabase/pg-topo`, so its `dist/*.d.ts` (the package's `types` entry) doesn't exist. `oxlint-tsgolint` does real type-checking, and `packages/pg-delta-next/src/frontends/sql-order.ts` type-only imports `AnalyzeOptions` from `pg-topo`, so the import resolved to an error type and tripped `no-redundant-type-constituents` on `AnalyzeOptions | undefined`.

`pg-delta-next.yml`'s own type-check job already builds `pg-topo` first for exactly this reason (see its comment). This mirrors that step in `tests.yml`'s `format-and-lint` job.

I considered instead adding a `paths` override in `packages/pg-delta-next/tsconfig.json` (as `pg-delta`'s tsconfig does) to map `@supabase/pg-topo` straight to its source — but that type-checks pg-topo's source under pg-delta-next's stricter `exactOptionalPropertyTypes: true`, which breaks `check-types` with several `undefined`-not-assignable errors. Building pg-topo first avoids that entirely.

## Verification

- Cleared `packages/pg-topo/dist` and reproduced the exact `oxlint-tsgolint` failure locally.
- Ran `bun run build` in `packages/pg-topo`, then `bun run format-and-lint` from the repo root — passes clean.
- Confirmed `origin/feat/pg-delta-next` hasn't moved since branching, so this is a clean fast-forward equivalent onto the PR branch.

No changeset — this is a CI-only change with no package behavior impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HgL4fVchn2ZhyJD8kqvxuu)_