### PR TITLE
chore(pg-delta): restore local coverage instrumentation and document it

### DIFF
--- a/.github/agents/pg-toolbelt.md
+++ b/.github/agents/pg-toolbelt.md
@@ -165,6 +165,33 @@ When changing shard count or PG versions, update all of these locations:
 - `.github/workflows/tests.yml` — the `postgres_version` list and `shard` list in `pg-delta-corpus`, and the `postgres_version` list in `pg-delta-integration`.
 - This file (`AGENTS.md` / `CLAUDE.md`) — both the CI section and the Testing Discipline section.
 
+### Coverage
+
+Local coverage is produced by the `@supabase/bun-istanbul-coverage` preload,
+which instruments the source globs in `.nycrc.json` (both packages' `src/`) and
+writes per-process istanbul JSON to `NYC_OUTPUT_DIR`. Each package's
+`scripts/run-tests.ts` injects that preload **only when `BUN_COVERAGE=1`** and is
+otherwise a transparent passthrough to `bun test` (so CI, which calls `bun test`
+directly, is unaffected).
+
+```bash
+bun run coverage                         # pg-topo + pg-delta (unit + integration + corpus), then nyc report
+bun run coverage --unit-only             # skip pg-delta's slow integration + corpus (pg-topo still runs; Docker required)
+bun run coverage --pg-image postgres:17-alpine   # pin the PG image for pg-delta integration/corpus
+bun run coverage --skip-tests            # regenerate the report from an existing .nyc_output
+```
+
+Reports land in `.coverage-artifacts/` (HTML/lcov/json-summary). Docker is
+required — pg-topo and pg-delta integration/corpus use testcontainers.
+
+CI uploads **pg-topo coverage only** (`pg-delta-*` jobs run without
+`BUN_COVERAGE`); pg-delta coverage is a local-on-demand tool by choice, because
+instrumenting the corpus PG-version × shard matrix in CI is disproportionately
+costly. To restore pg-delta coverage in CI, set `BUN_COVERAGE=1` +
+`NYC_OUTPUT_DIR` on the `pg-delta-*` jobs and upload their `.nyc_output` as a
+`coverage-*` artifact (the aggregation job already merges everything matching
+`coverage-*`).
+
 ## Agent Workflow
 
 ### Plan Before Acting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ bun run build
 bun run check-types
 bun run format-and-lint
 bun run test
+bun run coverage
 ```
 
 Always use `bun run test`, not bare `bun test`, so the repository's test wrapper and flags are preserved.
@@ -48,7 +49,7 @@ Always use `bun run test`, not bare `bun test`, so the repository's test wrapper
 ## Contribution expectations
 
 - Keep changes focused and scoped to the approved issue.
-- Add or update tests for code changes.
+- Add or update tests for code changes. **New code is expected to come with test coverage** — cover the lines and branches your change introduces. Check locally with `bun run coverage` (HTML report in `.coverage-artifacts/`; use `--unit-only` for a quick pass that skips pg-delta's slow integration + corpus suites).
 - Add a changeset for user-facing fixes or features.
 - Prefer targeted package tests while iterating, then run broader validation before finishing.
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,27 @@ bun run build           # Build all packages
 bun run test            # Test all packages
 bun run test:pg-delta   # Test pg-delta only
 bun run test:pg-topo    # Test pg-topo only
+bun run coverage        # Test coverage report (all packages)
 bun run check-types     # Type check all packages
 bun run format-and-lint # Format and lint all code
 ```
+
+### Test coverage
+
+`bun run coverage` runs both packages' suites with Istanbul instrumentation and
+writes an HTML/lcov report to `.coverage-artifacts/` (open
+`.coverage-artifacts/index.html`). Docker is required (the suites use
+testcontainers).
+
+```bash
+bun run coverage                               # everything (unit + integration + corpus)
+bun run coverage --unit-only                   # skip pg-delta's slow integration + corpus suites
+bun run coverage --pg-image postgres:17-alpine # pin the PostgreSQL image for pg-delta
+bun run coverage --skip-tests                  # regenerate the report from the last run
+```
+
+New code is expected to come with test coverage — see
+[CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ### Working with individual packages
 

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "pg": "^8.17.2",
       },
       "devDependencies": {
+        "@supabase/bun-istanbul-coverage": "workspace:*",
         "@supabase/pg-topo": "^1.0.0-alpha.2",
         "@types/bun": "^1.3.9",
         "@types/debug": "^4.1.12",

--- a/packages/pg-delta/package.json
+++ b/packages/pg-delta/package.json
@@ -118,9 +118,9 @@
     "format-and-lint:fix": "oxfmt . && oxlint --fix",
     "knip": "knip",
     "pgdelta": "bun src/cli/main.ts",
-    "test": "bun test src/",
-    "test:integration": "bun test tests/",
-    "test:all": "bun test src/ tests/",
+    "test": "bun scripts/run-tests.ts src/",
+    "test:integration": "bun scripts/run-tests.ts tests/",
+    "test:all": "bun scripts/run-tests.ts src/ tests/",
     "docker:clean": "bun scripts/clean-testcontainers.ts",
     "sync-base-images": "bun scripts/sync-supabase-base-images.ts"
   },
@@ -129,6 +129,7 @@
     "pg": "^8.17.2"
   },
   "devDependencies": {
+    "@supabase/bun-istanbul-coverage": "workspace:*",
     "@supabase/pg-topo": "^1.0.0-alpha.2",
     "@types/bun": "^1.3.9",
     "@types/debug": "^4.1.12",

--- a/packages/pg-delta/scripts/run-tests.ts
+++ b/packages/pg-delta/scripts/run-tests.ts
@@ -1,0 +1,30 @@
+/**
+ * Test runner wrapper. With `BUN_COVERAGE` unset it is a transparent
+ * passthrough to `bun test <args>`, so `bun run test` / `test:integration` /
+ * `test:all` behave exactly as a bare `bun test src/` etc. When `BUN_COVERAGE=1`
+ * it injects the `@supabase/bun-istanbul-coverage` preload so source files are
+ * Istanbul-instrumented and per-process coverage JSON is written to
+ * `NYC_OUTPUT_DIR` (consumed by `nyc report` via the root `bun run coverage`).
+ *
+ * This mirrors `packages/pg-topo/scripts/run-tests.ts`. pg-delta tests manage
+ * their own containers (`tests/containers.ts`) and need no global-setup preload,
+ * so the wrapper adds nothing else — CI keeps invoking `bun test` directly.
+ */
+import { fileURLToPath } from "node:url";
+
+const args = process.argv.slice(2);
+
+const coveragePreload = fileURLToPath(
+  import.meta.resolve("@supabase/bun-istanbul-coverage/preload"),
+);
+const coverageArgs =
+  process.env.BUN_COVERAGE === "1" ? ["--preload", coveragePreload] : [];
+
+const proc = Bun.spawn({
+  cmd: ["bun", "test", ...coverageArgs, ...args],
+  cwd: fileURLToPath(new URL("..", import.meta.url)),
+  stdio: ["inherit", "inherit", "inherit"],
+});
+
+const exitCode = await proc.exited;
+process.exit(exitCode);

--- a/scripts/coverage.ts
+++ b/scripts/coverage.ts
@@ -1,13 +1,21 @@
 /**
- * Local coverage runner: runs pg-topo, pg-delta unit, and pg-delta integration
- * shards with Istanbul instrumentation, then generates reports via nyc.
+ * Local coverage runner: runs pg-topo and pg-delta test suites with Istanbul
+ * instrumentation (via each package's `BUN_COVERAGE`-aware `run-tests.ts`), then
+ * generates a merged report via nyc.
  *
- * Usage: bun run coverage [--pg-versions 15,17] [--shards 15] [--skip-tests]
+ * Coverage is produced by the `@supabase/bun-istanbul-coverage` preload, which
+ * instruments the source globs in `.nycrc.json` and writes per-process JSON to
+ * `NYC_OUTPUT_DIR`. nyc then merges every `.nyc_output/*.json` into one report.
+ *
+ * Usage: bun run coverage [--pg-image postgres:17-alpine] [--unit-only] [--skip-tests]
  *
  * Options:
- *   --pg-versions  Comma-separated PG versions for integration (default: 17)
- *   --shards       Number of integration shards (default: 15)
- *   --skip-tests   Use existing .nyc_output only; no test runs (report only)
+ *   --pg-image    PostgreSQL image for pg-delta integration + corpus
+ *                 (default: engine/container default; forwarded as PGDELTA_TEST_IMAGE)
+ *   --unit-only   Skip pg-delta's slow integration + corpus suites; run only
+ *                 pg-delta src/ unit tests plus the pg-topo suite. (pg-topo has
+ *                 no no-Docker subset, so a Docker daemon is still required.)
+ *   --skip-tests  Use existing .nyc_output only; no test runs (report only)
  */
 import { existsSync } from "node:fs";
 import { mkdir, readdir, rm } from "node:fs/promises";
@@ -41,54 +49,38 @@ async function run(
   return proc.exited;
 }
 
-async function listPgDeltaTestFiles(): Promise<string[]> {
-  const files: string[] = [];
-  async function walk(dir: string, prefix: string) {
-    const entries = await readdir(dir, { withFileTypes: true });
-    for (const e of entries) {
-      const rel = `${prefix}${e.name}`;
-      if (e.isDirectory()) {
-        await walk(join(dir, e.name), `${rel}/`);
-      } else if (e.name.endsWith(".test.ts")) {
-        files.push(rel);
-      }
-    }
-  }
-  await walk(join(pgDeltaRoot, "tests"), "tests/");
-  files.sort();
-  return files;
-}
-
 function parseArgs() {
   const args = process.argv.slice(2);
-  let pgVersions = [17];
-  let shards = 15;
+  let pgImage: string | undefined;
+  let unitOnly = false;
   let skipTests = false;
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--pg-versions" && args[i + 1]) {
-      pgVersions = args[++i].split(",").map((v) => Number(v.trim()));
-      if (pgVersions.some((v) => Number.isNaN(v)))
-        fail("--pg-versions must be comma-separated numbers (e.g. 15,17)");
-    } else if (args[i] === "--shards" && args[i + 1]) {
-      shards = Number(args[++i]);
-      if (Number.isNaN(shards) || shards < 1)
-        fail("--shards must be a positive number");
+    if (args[i] === "--pg-image" && args[i + 1]) {
+      pgImage = args[++i];
+    } else if (args[i] === "--unit-only") {
+      unitOnly = true;
     } else if (args[i] === "--skip-tests") {
       skipTests = true;
     }
   }
 
-  return { pgVersions, shards, skipTests };
+  return { pgImage, unitOnly, skipTests };
 }
 
-const coverageEnv = { BUN_COVERAGE: "1", NYC_OUTPUT_DIR: nycOutputDir };
-
 async function main(): Promise<void> {
-  const { pgVersions, shards, skipTests } = parseArgs();
+  const { pgImage, unitOnly, skipTests } = parseArgs();
+  const coverageEnv: Record<string, string> = {
+    BUN_COVERAGE: "1",
+    NYC_OUTPUT_DIR: nycOutputDir,
+  };
+  const pgDeltaEnv = pgImage
+    ? { ...coverageEnv, PGDELTA_TEST_IMAGE: pgImage }
+    : coverageEnv;
+
   log("Options");
-  console.log(`  pg-versions: ${pgVersions.join(", ")}`);
-  console.log(`  shards: ${shards}`);
+  console.log(`  pg-image:   ${pgImage ?? "(engine default)"}`);
+  console.log(`  unit-only:  ${unitOnly}`);
   console.log(`  skip-tests: ${skipTests}`);
 
   if (skipTests) {
@@ -112,38 +104,26 @@ async function main(): Promise<void> {
     });
     if (topoExit !== 0) fail("pg-topo tests failed");
 
-    log("Step 2: pg-delta unit");
-    const unitExit = await run(["bun", "run", "test:unit"], {
+    log("Step 2: pg-delta unit (src/)");
+    const unitExit = await run(["bun", "run", "test"], {
       cwd: pgDeltaRoot,
       env: coverageEnv,
     });
     if (unitExit !== 0) fail("pg-delta unit tests failed");
 
-    log("Step 3: pg-delta integration shards");
-    const allTestFiles = await listPgDeltaTestFiles();
-    console.log(`  Total test files: ${allTestFiles.length}`);
-    const failedShards: string[] = [];
-    for (const pgVer of pgVersions) {
-      for (let shardIndex = 1; shardIndex <= shards; shardIndex++) {
-        const index0 = shardIndex - 1;
-        const shardFiles = allTestFiles.filter((_, i) => i % shards === index0);
-        const name = `pg${pgVer}-shard-${shardIndex}`;
-        if (shardFiles.length === 0) continue;
-        console.log(`  ${name}: ${shardFiles.length} files`);
-        const shardExit = await run(["bun", "run", "test", ...shardFiles], {
-          cwd: pgDeltaRoot,
-          env: {
-            ...coverageEnv,
-            PGDELTA_TEST_POSTGRES_VERSIONS: String(pgVer),
-          },
-        });
-        if (shardExit !== 0) failedShards.push(name);
+    if (unitOnly) {
+      console.log("\n  --unit-only: skipping pg-delta integration + corpus");
+    } else {
+      log("Step 3: pg-delta integration + corpus (tests/)");
+      const integrationExit = await run(["bun", "run", "test:integration"], {
+        cwd: pgDeltaRoot,
+        env: pgDeltaEnv,
+      });
+      if (integrationExit !== 0) {
+        console.warn(
+          "\n  WARNING: pg-delta integration/corpus tests failed — report will reflect partial coverage",
+        );
       }
-    }
-    if (failedShards.length > 0) {
-      console.warn(
-        `\n  WARNING: ${failedShards.length} shard(s) failed: ${failedShards.join(", ")}`,
-      );
     }
   }
 


### PR DESCRIPTION
## Why

The clean-room engine was promoted into `packages/pg-delta` without the Istanbul coverage wiring pg-topo has, and `scripts/coverage.ts` still referenced the old engine's deleted `test:unit` script and 15-shard layout. Net result: `bun run coverage` was broken outright, and pg-delta was never instrumented (`.nycrc.json` listed its `src`, but nothing loaded the coverage plugin).

## What

- **Restore pg-delta's coverage-aware runner** — new `packages/pg-delta/scripts/run-tests.ts` mirroring pg-topo's: a transparent passthrough to `bun test` that injects the `@supabase/bun-istanbul-coverage` preload **only when `BUN_COVERAGE=1`**. Routed `test`/`test:integration`/`test:all` through it; added the devDep. CI (which calls `bun test` directly) is unaffected.
- **Rewrite `scripts/coverage.ts`** to the new layout: pg-topo + pg-delta (unit + integration + corpus) under `BUN_COVERAGE=1`, then `nyc report`. Dropped the dead `--shards`/`test:unit`/file-globbing; added `--unit-only`, `--pg-image`, kept `--skip-tests`.
- **Docs** — documented how to run coverage locally and that new code is expected to come with coverage, in `README.md`, `CONTRIBUTING.md`, and the agent guide (`.github/agents/pg-toolbelt.md`).

`.nycrc.json` is unchanged (already instruments both packages' `src`).

## Scope decision

Local-only, by choice: CI still uploads pg-topo coverage only. Instrumenting the pg-delta corpus PG-version × shard matrix in CI is disproportionately costly; the agent guide documents how to opt it in later if wanted.

## Validation

- **RED:** `bun run test:unit` in pg-delta → `error: Script not found "test:unit"` (runner was broken).
- **GREEN:** `bun run coverage --unit-only` → merged report now shows `pg-delta/src/**` alongside `pg-topo/src/**`.
- Wrapper + integration path: `tests/capability.test.ts` under `BUN_COVERAGE=1 PGDELTA_TEST_IMAGE=postgres:17-alpine` → preload activates, tests pass against Docker, coverage JSON written.
- Passthrough (`BUN_COVERAGE` unset) → no instrumentation, behavior unchanged.
- `bun run format-and-lint` ✅ and `bun run check-types` ✅ (after building pg-topo `dist` types, as the repo requires). `knip` shows only pre-existing findings; my new devDep/wrapper are not flagged.

No changeset — repo tooling + docs only, no published package behavior change.

> **Base branch:** targets `feat/pg-delta-next` (the promoted-engine branch), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)