### PR TITLE
fix(pg-delta): replay pg_cron database/username/active via schedule_in_database

### DIFF
--- a/.changeset/fix-pg-cron-schedule-in-database.md
+++ b/.changeset/fix-pg-cron-schedule-in-database.md
@@ -1,0 +1,15 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): replay pg_cron database/username/active via schedule_in_database
+
+The pg_cron job intent captures a job's `database`, `username`, and `active`
+fields, but the replay emitted the 3-arg `cron.schedule(name, schedule, command)`
+form, which always (re)creates the job in the current database, active, owned by
+the executing user. A job that was inactive, targeted another database, or had a
+non-current username therefore never converged. The create rule now emits the
+6-arg `cron.schedule_in_database(name, schedule, command, database, username,
+active)` so all captured fields replay deterministically. The signature has been
+stable since pg_cron 1.4, which every supported PostgreSQL image (and the
+supabase/postgres image) ships.

--- a/packages/pg-delta/src/frontends/export-intent.test.ts
+++ b/packages/pg-delta/src/frontends/export-intent.test.ts
@@ -45,7 +45,7 @@ describe("schema export forwards intent rules to the internal plan()", () => {
     const dump = exportSqlFiles(fb, { layout: "by-object", intentRules })
       .map((f) => f.sql)
       .join("\n");
-    expect(dump).toContain("cron.schedule('nightly_prune'");
+    expect(dump).toContain("cron.schedule_in_database('nightly_prune'");
   });
 
   test("WITHOUT intentRules, export throws the unregistered-rule error (the bug this guards)", () => {

--- a/packages/pg-delta/src/policy/extensions/pg-cron.test.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-cron.test.ts
@@ -224,7 +224,7 @@ describe("pgCronHandler.intentKinds.job", () => {
     ]);
   });
 
-  test("create: renders select cron.schedule(...) with quoted literals", () => {
+  test("create: renders select cron.schedule_in_database(...) with quoted literals", () => {
     const fact: Fact = {
       id: jobIntentId("nightly"),
       payload: {
@@ -238,7 +238,25 @@ describe("pgCronHandler.intentKinds.job", () => {
     const actions = jobRule?.create(fact, undefined as never);
     expect(actions).toHaveLength(1);
     expect(actions?.[0]?.sql).toMatchInlineSnapshot(
-      `"select cron.schedule('nightly', '0 0 * * *', 'select 1')"`,
+      `"select cron.schedule_in_database('nightly', '0 0 * * *', 'select 1', 'postgres', 'postgres', true)"`,
+    );
+  });
+
+  test("create: replays database, username, and active via cron.schedule_in_database", () => {
+    const fact: Fact = {
+      id: jobIntentId("reports"),
+      payload: {
+        schedule: "0 0 * * *",
+        command: "select 1",
+        database: "analytics",
+        username: "reporter",
+        active: false,
+      },
+    };
+    const actions = jobRule?.create(fact, undefined as never);
+    expect(actions).toHaveLength(1);
+    expect(actions?.[0]?.sql).toMatchInlineSnapshot(
+      `"select cron.schedule_in_database('reports', '0 0 * * *', 'select 1', 'analytics', 'reporter', false)"`,
     );
   });
 
@@ -255,7 +273,7 @@ describe("pgCronHandler.intentKinds.job", () => {
     };
     const actions = jobRule?.create(fact, undefined as never);
     expect(actions?.[0]?.sql).toMatchInlineSnapshot(
-      `"select cron.schedule('bob''s job', '0 0 * * *', 'select ''hi'' from t where x = ''y''')"`,
+      `"select cron.schedule_in_database('bob''s job', '0 0 * * *', 'select ''hi'' from t where x = ''y''', 'postgres', 'postgres', true)"`,
     );
   });
 
@@ -272,9 +290,11 @@ describe("pgCronHandler.intentKinds.job", () => {
     };
     const actions = jobRule?.create(fact, undefined as never);
     // the whole statement is never wrapped in $$ ... $$ dollar-quoting
-    expect(actions?.[0]?.sql.startsWith("select cron.schedule(")).toBe(true);
+    expect(
+      actions?.[0]?.sql.startsWith("select cron.schedule_in_database("),
+    ).toBe(true);
     expect(actions?.[0]?.sql).toMatchInlineSnapshot(
-      `"select cron.schedule('dollar', '0 0 * * *', 'select ''$$not a dollar quote$$''')"`,
+      `"select cron.schedule_in_database('dollar', '0 0 * * *', 'select ''$$not a dollar quote$$''', 'postgres', 'postgres', true)"`,
     );
   });
 

--- a/packages/pg-delta/src/policy/extensions/pg-cron.ts
+++ b/packages/pg-delta/src/policy/extensions/pg-cron.ts
@@ -157,16 +157,29 @@ export const pgCronHandler: ExtensionHandler = {
       create(fact) {
         const key = (fact.id as Extract<StableId, { kind: "extensionIntent" }>)
           .key;
-        const p = fact.payload as { schedule: string; command: string };
-        // v1 limitation: `database` and `active` are captured (so a changed
-        // value replays as unschedule+reschedule) but the 3-arg cron.schedule
-        // form always (re)creates the job in the CURRENT database, active.
-        // Cross-database jobs and inactive jobs are a known gap for this
-        // slice — the middleware-db dogfood target only has same-db, active,
-        // postgres-owned jobs, so it is exact there.
+        const p = fact.payload as {
+          schedule: string;
+          command: string;
+          database: string;
+          username: string;
+          active: boolean;
+        };
+        // Replay ALL captured fields deterministically via the 6-arg
+        // `cron.schedule_in_database(job_name, schedule, command, database,
+        // username, active)`. The 3-arg `cron.schedule` form would always
+        // (re)create the job in the CURRENT database, active, owned by the
+        // executing user — so a job that is inactive, targets another
+        // database, or has a non-current username would never converge. The
+        // 6-arg signature has been stable since pg_cron 1.4 (2021), which
+        // every supported PostgreSQL image and the supabase/postgres image
+        // ship, so this stays compatible across the pg_cron versions we
+        // target. String args keep `lit()` quoting; `active` is a bare
+        // boolean literal.
         return [
           {
-            sql: `select cron.schedule(${lit(key)}, ${lit(p.schedule)}, ${lit(p.command)})`,
+            sql:
+              `select cron.schedule_in_database(${lit(key)}, ${lit(p.schedule)}, ` +
+              `${lit(p.command)}, ${lit(p.database)}, ${lit(p.username)}, ${p.active})`,
           },
         ];
       },

--- a/packages/pg-delta/tests/extension-intent-cron.test.ts
+++ b/packages/pg-delta/tests/extension-intent-cron.test.ts
@@ -49,7 +49,7 @@ describe.skipIf(!runSupabaseBareTests)(
       await cluster.adminPool.query(`DELETE FROM cron.job`);
     });
 
-    test("create: a named job in the desired state plans a select cron.schedule(...) action, and applying it creates the job", async () => {
+    test("create: a named job in the desired state plans a select cron.schedule_in_database(...) action, and applying it creates the job", async () => {
       const cluster = await supabaseCluster();
       const pool = cluster.adminPool;
       await pool.query(`CREATE EXTENSION IF NOT EXISTS pg_cron`);
@@ -71,7 +71,7 @@ describe.skipIf(!runSupabaseBareTests)(
       });
 
       const scheduleAction = thePlan.actions.find((a) =>
-        /select cron\.schedule\('vac_create'/.test(a.sql),
+        /select cron\.schedule_in_database\('vac_create'/.test(a.sql),
       );
       expect(scheduleAction).toBeDefined();
       expect(scheduleAction?.verb).toBe("create");
@@ -120,7 +120,9 @@ describe.skipIf(!runSupabaseBareTests)(
         /select cron\.unschedule\('vac_edit'\)/.test(a.sql),
       );
       const scheduleIdx = thePlan.actions.findIndex((a) =>
-        /select cron\.schedule\('vac_edit', '\*\/5 \* \* \* \*'/.test(a.sql),
+        /select cron\.schedule_in_database\('vac_edit', '\*\/5 \* \* \* \*'/.test(
+          a.sql,
+        ),
       );
       expect(unscheduleIdx).toBeGreaterThanOrEqual(0);
       expect(scheduleIdx).toBeGreaterThanOrEqual(0);
@@ -223,6 +225,134 @@ describe.skipIf(!runSupabaseBareTests)(
       expect(secondPlan.actions.length).toBe(0);
     }, 180_000);
 
+    test("convergence: an inactive job replays via schedule_in_database and stays inactive", async () => {
+      const cluster = await supabaseCluster();
+      const pool = cluster.adminPool;
+      await pool.query(`CREATE EXTENSION IF NOT EXISTS pg_cron`);
+
+      const ctx = await resolveProfile(pool, cronProfile);
+
+      // SOURCE snapshot: clean, no jobs.
+      const sourceFb = (await ctx.extract(pool)).factBase;
+
+      // DESIRED snapshot: an INACTIVE job. The 3-arg cron.schedule form cannot
+      // express this (it always creates the job active), so this is the case
+      // the schedule_in_database replay exists for.
+      await pool.query(
+        `SELECT cron.schedule_in_database('vac_inactive', '0 0 * * *', 'VACUUM', current_database(), 'postgres', false)`,
+      );
+      const desiredFb = (await ctx.extract(pool)).factBase;
+
+      const thePlan = plan(sourceFb, desiredFb, {
+        ...ctx.planOptions,
+        renames: "off",
+      });
+
+      const scheduleAction = thePlan.actions.find((a) =>
+        /select cron\.schedule_in_database\('vac_inactive'/.test(a.sql),
+      );
+      expect(scheduleAction).toBeDefined();
+      expect(scheduleAction?.verb).toBe("create");
+      // active=false is replayed as the 6th argument.
+      expect(scheduleAction?.sql).toContain(", false)");
+
+      // reset the DB to exactly the SOURCE state before apply. Delete directly
+      // (not cron.unschedule, which filters by username = current_user) because
+      // the job is owned by `postgres` while adminPool connects as
+      // `supabase_admin`.
+      await pool.query(`DELETE FROM cron.job WHERE jobname = 'vac_inactive'`);
+
+      const report = await apply(thePlan, pool, ctx.applyOptions);
+      expect(report.status).toBe("applied");
+
+      // the applied job is inactive AND owned by `postgres` — both the 6-arg
+      // replay's whole point (the 3-arg form would create it active, owned by
+      // the executing `supabase_admin`).
+      const { rows } = await pool.query<{ active: boolean; username: string }>(
+        `SELECT active, username FROM cron.job WHERE jobname = 'vac_inactive'`,
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.active).toBe(false);
+      expect(rows[0]?.username).toBe("postgres");
+
+      // convergence: re-extracting the applied DB and re-planning against the
+      // same desired state is a no-op (with the old 3-arg form the reapplied
+      // job would be active=true, so this plan would NOT be empty).
+      const reappliedFb = (await ctx.extract(pool)).factBase;
+      const secondPlan = plan(reappliedFb, desiredFb, {
+        ...ctx.planOptions,
+        renames: "off",
+      });
+      expect(secondPlan.actions.length).toBe(0);
+    }, 180_000);
+
+    test("convergence: a job targeting another database replays that database via schedule_in_database", async () => {
+      const cluster = await supabaseCluster();
+      const pool = cluster.adminPool;
+      await pool.query(`CREATE EXTENSION IF NOT EXISTS pg_cron`);
+      // A distinct target database the job runs in. pg_cron metadata still lives
+      // in the cron database (postgres); only the job's `database` column points
+      // elsewhere — exactly what the 3-arg cron.schedule form cannot reproduce.
+      await pool.query(
+        `DROP DATABASE IF EXISTS pgdelta_cron_target WITH (FORCE)`,
+      );
+      await pool.query(`CREATE DATABASE pgdelta_cron_target`);
+      try {
+        const ctx = await resolveProfile(pool, cronProfile);
+
+        // SOURCE snapshot: clean, no jobs.
+        const sourceFb = (await ctx.extract(pool)).factBase;
+
+        // DESIRED snapshot: a job whose command runs in the other database.
+        await pool.query(
+          `SELECT cron.schedule_in_database('vac_xdb', '0 0 * * *', 'VACUUM', 'pgdelta_cron_target', 'postgres', true)`,
+        );
+        const desiredFb = (await ctx.extract(pool)).factBase;
+
+        const thePlan = plan(sourceFb, desiredFb, {
+          ...ctx.planOptions,
+          renames: "off",
+        });
+
+        const scheduleAction = thePlan.actions.find((a) =>
+          /select cron\.schedule_in_database\('vac_xdb'/.test(a.sql),
+        );
+        expect(scheduleAction).toBeDefined();
+        expect(scheduleAction?.verb).toBe("create");
+        expect(scheduleAction?.sql).toContain("'pgdelta_cron_target'");
+
+        // reset the DB to exactly the SOURCE state before apply. Delete
+        // directly (not cron.unschedule, which filters by current_user) since
+        // the job is owned by `postgres`, not the `supabase_admin` connection.
+        await pool.query(`DELETE FROM cron.job WHERE jobname = 'vac_xdb'`);
+
+        const report = await apply(thePlan, pool, ctx.applyOptions);
+        expect(report.status).toBe("applied");
+
+        // the applied job targets the other database — the whole point.
+        const { rows } = await pool.query<{ database: string }>(
+          `SELECT database FROM cron.job WHERE jobname = 'vac_xdb'`,
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.database).toBe("pgdelta_cron_target");
+
+        // convergence: re-planning against the same desired state is a no-op
+        // (with the old 3-arg form the job's database would be `postgres`).
+        const reappliedFb = (await ctx.extract(pool)).factBase;
+        const secondPlan = plan(reappliedFb, desiredFb, {
+          ...ctx.planOptions,
+          renames: "off",
+        });
+        expect(secondPlan.actions.length).toBe(0);
+      } finally {
+        // afterEach clears cron.job; drop the extra target database so it does
+        // not leak across tests (FORCE terminates the cron launcher's backend).
+        await pool.query(
+          `DROP DATABASE IF EXISTS pgdelta_cron_target WITH (FORCE)`,
+        );
+      }
+    }, 180_000);
+
     test("an unnamed job in the desired state makes plan() throw the unkeyed error", async () => {
       const cluster = await supabaseCluster();
       const pool = cluster.adminPool;
@@ -284,7 +414,9 @@ describe.skipIf(!runSupabaseBareTests)(
 
       // the cron intent survives the supabase policy + baseline projection.
       const scheduleAction = thePlan.actions.find((a) =>
-        /select cron\.schedule\('pgdelta_e2e_supa_prune'/.test(a.sql),
+        /select cron\.schedule_in_database\('pgdelta_e2e_supa_prune'/.test(
+          a.sql,
+        ),
       );
       expect(scheduleAction).toBeDefined();
       expect(scheduleAction?.verb).toBe("create");


### PR DESCRIPTION
Follow-up from PR #318 review (Codex P2 on `packages/pg-delta/src/policy/extensions/pg-cron.ts`).

## Problem

The `pgCronHandler` captures a cron job's `database`, `username`, and `active` into the hashed, replace-driving intent payload, but the `intentKinds.job.create` rule emitted the 3-arg `select cron.schedule(name, schedule, command)`, which always recreates the job in the **current** database, **active**, owned by the **executing** user. So a job that is inactive, targets another database, or has a non-current username never converged — a rebuild-from-empty or any replace would drift.

## Fix

The create rule now emits the 6-arg `select cron.schedule_in_database(name, schedule, command, database, username, active)` so all captured fields replay deterministically. String args keep `lit()` quoting; `active` is a bare boolean literal (no dollar-quoting — the command stays a plain quoted literal). The 6-arg signature has been stable since **pg_cron 1.4** (2021), which every supported PostgreSQL image and the `supabase/postgres` image ship, so this stays compatible across the pg_cron versions we target. Removes the documented v1 limitation noted in `pg-cron.ts`.

## TDD (RED → GREEN)

Validated against `supabase/postgres:17.6.1.135` with `PGDELTA_NEXT_SUPABASE_TESTS=1`.

- **Unit RED:** `Expected "select cron.schedule_in_database('reports', …, 'analytics', 'reporter', false)"` / `Received "select cron.schedule('reports', '0 0 * * *', 'select 1')"`.
- **Integration RED:** both new convergence tests failed at `expect(scheduleAction).toBeDefined()` → `Received: undefined` (no `schedule_in_database` action planned by the old rule).
- **GREEN:** `bun test src/` → **667 pass**; `tests/extension-intent-cron.test.ts` → **9 pass**.

The two commits keep the RED/GREEN split — the `test(...)` commit fails on checkout; the `fix(...)` commit makes it pass.

## Tests added

- `src/policy/extensions/pg-cron.test.ts` — unit case for cross-db / non-default-user / inactive replay; updated the three existing snapshots + the dollar-collision `startsWith` assertion.
- `tests/extension-intent-cron.test.ts` — two end-to-end convergence cases:
  - an **inactive** job (also asserts `username='postgres'` while `adminPool` connects as `supabase_admin`, so it covers **username** replay too),
  - a **cross-database** job targeting a separate database.
- `src/frontends/export-intent.test.ts` — assertion updated to the new form (ripple caught by the full unit suite).

## Notes

- Per the chosen always-`schedule_in_database` approach, the floor is pg_cron 1.4 — fine for the PG 14–18 matrix and the Supabase image. A truly pre-1.4 target would fail to replay even a simple job, but that is the pre-existing documented gap and is not in the supported matrix.
- The corpus is unaffected — this is integration-layer code, and stock-alpine has no pg_cron.

Refs #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
