### PR TITLE
feat(ci): add contribution gating workflow and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+name: 🐛 Bug report
+description: Report a defect in pg-delta or pg-topo
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug! Please open the issue **before** starting work — a
+        maintainer will add the `open-for-contribution` label once it is ready to be
+        worked on. See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and
+        [ISSUES.md](../blob/main/ISSUES.md).
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which package is affected?
+      options:
+        - "@supabase/pg-delta"
+        - "@supabase/pg-topo"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit / branch
+      description: The published version, commit SHA, or branch you tested.
+      placeholder: "e.g. @supabase/pg-delta@0.0.0-alpha.x or commit abc1234"
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: OS and runtime
+      description: Your OS and runtime (Bun / Node / Deno) versions, when relevant.
+      placeholder: "e.g. macOS 15, Bun 1.3.13"
+    validations:
+      required: false
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: |
+        The smallest steps or SQL that reproduce the problem. Prefer inline SQL/text over screenshots.
+      placeholder: |
+        Steps, commands, and/or SQL to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: The actual SQL, plan, error, or diff output (as text).
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### `pg-delta` reproductions
+        If this affects `pg-delta`, the fields below make the bug much easier to turn into a regression test.
+        Leave them blank for `pg-topo`.
+  - type: dropdown
+    id: pg-delta-flavor
+    attributes:
+      label: PostgreSQL flavor (pg-delta)
+      options:
+        - "Plain PostgreSQL"
+        - "Supabase (--integration supabase)"
+    validations:
+      required: false
+  - type: input
+    id: pg-delta-versions
+    attributes:
+      label: PostgreSQL version(s) (pg-delta)
+      placeholder: "e.g. 15, 17, 18 — or 'only 17'"
+    validations:
+      required: false
+  - type: dropdown
+    id: pg-delta-mode
+    attributes:
+      label: Command / mode (pg-delta)
+      options:
+        - plan
+        - apply
+        - sync
+        - catalog-export
+        - declarative export
+        - declarative apply
+        - other
+    validations:
+      required: false
+  - type: textarea
+    id: pg-delta-schema
+    attributes:
+      label: Schema input and exact command (pg-delta)
+      description: |
+        SQL to create the source and target state (or a minimal declarative schema
+        directory / catalog snapshot), plus the exact command and flags you ran. Include
+        any required extension, role, policy, trigger, or Supabase-managed object.
+      render: sql
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Contribution workflow
+    url: https://github.com/supabase/pg-toolbelt/blob/main/CONTRIBUTING.md
+    about: Read this before opening an issue or pull request — PRs must link a labeled, open issue.
+  - name: 💬 Supabase community
+    url: https://github.com/orgs/supabase/discussions
+    about: General questions and discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: ✨ Feature request
+description: Suggest a new capability or improvement for pg-delta or pg-topo
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please open the issue **before** starting work — a
+        maintainer will add the `open-for-contribution` label once it is triaged and ready.
+        See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      options:
+        - "@supabase/pg-delta"
+        - "@supabase/pg-topo"
+        - "Not sure / cross-cutting"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and what's the limitation today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What behavior or API would you like to see?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -1,0 +1,44 @@
+# Maintainers guide
+
+Internal notes for maintaining the pg-toolbelt contribution workflow. See
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) for the contributor-facing version.
+
+## The `open-for-contribution` gate
+
+External pull requests are only accepted when they link to an **open** GitHub issue
+that carries the **`open-for-contribution`** label. This is enforced by the
+[`Contribution Gate`](./workflows/contribution-gate.yml) workflow, whose decision logic
+lives in [`scripts/contribution-gate.ts`](./scripts/contribution-gate.ts).
+
+A pull request is **auto-closed with an explanatory comment** when the author is external
+and any of these is true:
+
+- no issue is linked (via a closing keyword such as `Closes #123`, or the PR's
+  Development sidebar), or
+- the linked issue is closed, or
+- the linked issue is missing the `open-for-contribution` label.
+
+Authors whose `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`, and bot
+accounts, are **exempt** — Supabase maintainers can keep working from Linear tickets that
+aren't public on GitHub.
+
+## Triage: applying the label (manual)
+
+During triage:
+
+1. Categorize the issue with one of `✨ Feature`, `🐛 Bug`, `📘 Docs`, or `🛠️ Chore`.
+2. When the issue is ready to be worked on, add the **`open-for-contribution`** label.
+
+New issues opened via the templates start with `needs-triage`.
+
+Applying `open-for-contribution` is currently a **manual step** — do it on the GitHub
+issue directly (from the GitHub UI, or from the Linear-linked issue).
+
+## Deferred: automatic Linear → GitHub label sync
+
+We considered auto-applying `open-for-contribution` when a Linear issue moves out of
+Triage/Backlog (e.g. to Todo). Linear's native GitHub automations are one-directional
+(GitHub events update Linear status) and cannot push a GitHub label, so this would need an
+external bridge (a scheduled job polling the Linear API, a Zapier/Make zap, or a Linear
+webhook → relay). It is **out of scope for now** and tracked separately; until then, apply
+the label manually as above.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Before opening this PR, confirm the linked issue is open and carries the
+`open-for-contribution` label. PRs from external contributors that don't follow the
+workflow in CONTRIBUTING.md are closed automatically.
+@supabase members working from Linear tickets are exempt.
+-->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+## Linked issue
+
+Closes #
+
+- [ ] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).
+
+## Checklist
+
+- [ ] Tests added or updated for the change
+- [ ] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
+- [ ] `bun run format-and-lint` and `bun run check-types` pass

--- a/.github/scripts/contribution-gate.test.ts
+++ b/.github/scripts/contribution-gate.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { evaluateGate, GATE_LABEL } from "./contribution-gate.ts";
 
+const REPO = "supabase/pg-toolbelt";
+
 describe("evaluateGate", () => {
   test("skips bot authors", () => {
     const result = evaluateGate({
+      repository: REPO,
       authorAssociation: "NONE",
       isBot: true,
       linkedIssues: [],
@@ -16,6 +19,7 @@ describe("evaluateGate", () => {
     "skips internal author association %s",
     (authorAssociation) => {
       const result = evaluateGate({
+        repository: REPO,
         authorAssociation,
         isBot: false,
         linkedIssues: [],
@@ -27,6 +31,7 @@ describe("evaluateGate", () => {
 
   test("fails when no issue is linked", () => {
     const result = evaluateGate({
+      repository: REPO,
       authorAssociation: "NONE",
       isBot: false,
       linkedIssues: [],
@@ -39,9 +44,12 @@ describe("evaluateGate", () => {
 
   test("fails when the linked issue is open but not labeled", () => {
     const result = evaluateGate({
+      repository: REPO,
       authorAssociation: "CONTRIBUTOR",
       isBot: false,
-      linkedIssues: [{ number: 12, state: "OPEN", labels: ["🐛 Bug"] }],
+      linkedIssues: [
+        { repository: REPO, number: 12, state: "OPEN", labels: ["🐛 Bug"] },
+      ],
     });
     expect(result.pass).toBe(false);
     expect(result.reason).toBe("missing-label");
@@ -50,9 +58,12 @@ describe("evaluateGate", () => {
 
   test("fails when the only labeled issue is closed", () => {
     const result = evaluateGate({
+      repository: REPO,
       authorAssociation: "NONE",
       isBot: false,
-      linkedIssues: [{ number: 7, state: "CLOSED", labels: [GATE_LABEL] }],
+      linkedIssues: [
+        { repository: REPO, number: 7, state: "CLOSED", labels: [GATE_LABEL] },
+      ],
     });
     expect(result.pass).toBe(false);
     expect(result.reason).toBe("issue-closed");
@@ -60,10 +71,16 @@ describe("evaluateGate", () => {
 
   test("passes when a linked issue is open and carries the gate label", () => {
     const result = evaluateGate({
+      repository: REPO,
       authorAssociation: "NONE",
       isBot: false,
       linkedIssues: [
-        { number: 42, state: "OPEN", labels: [GATE_LABEL, "🐛 Bug"] },
+        {
+          repository: REPO,
+          number: 42,
+          state: "OPEN",
+          labels: [GATE_LABEL, "🐛 Bug"],
+        },
       ],
     });
     expect(result.pass).toBe(true);
@@ -72,12 +89,51 @@ describe("evaluateGate", () => {
 
   test("passes when any one of several linked issues qualifies", () => {
     const result = evaluateGate({
+      repository: REPO,
       authorAssociation: "FIRST_TIME_CONTRIBUTOR",
       isBot: false,
       linkedIssues: [
-        { number: 1, state: "CLOSED", labels: [GATE_LABEL] },
-        { number: 2, state: "OPEN", labels: ["✨ Feature"] },
-        { number: 3, state: "OPEN", labels: [GATE_LABEL] },
+        { repository: REPO, number: 1, state: "CLOSED", labels: [GATE_LABEL] },
+        { repository: REPO, number: 2, state: "OPEN", labels: ["✨ Feature"] },
+        { repository: REPO, number: 3, state: "OPEN", labels: [GATE_LABEL] },
+      ],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("ok");
+  });
+
+  test("ignores an open, labeled issue from a different repository", () => {
+    // Cross-repo closing keyword (e.g. `Closes attacker/repo#1`): the issue is
+    // controlled by the contributor, so it must not satisfy the gate.
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [
+        {
+          repository: "attacker/repo",
+          number: 1,
+          state: "OPEN",
+          labels: [GATE_LABEL],
+        },
+      ],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("no-linked-issue");
+  });
+
+  test("matches the repository case-insensitively", () => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [
+        {
+          repository: "Supabase/PG-Toolbelt",
+          number: 5,
+          state: "OPEN",
+          labels: [GATE_LABEL],
+        },
       ],
     });
     expect(result.pass).toBe(true);

--- a/.github/scripts/contribution-gate.test.ts
+++ b/.github/scripts/contribution-gate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { evaluateGate, GATE_LABEL } from "./contribution-gate.ts";
+
+describe("evaluateGate", () => {
+  test("skips bot authors", () => {
+    const result = evaluateGate({
+      authorAssociation: "NONE",
+      isBot: true,
+      linkedIssues: [],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("bot");
+  });
+
+  test.each(["OWNER", "MEMBER", "COLLABORATOR"])(
+    "skips internal author association %s",
+    (authorAssociation) => {
+      const result = evaluateGate({
+        authorAssociation,
+        isBot: false,
+        linkedIssues: [],
+      });
+      expect(result.pass).toBe(true);
+      expect(result.reason).toBe("internal");
+    },
+  );
+
+  test("fails when no issue is linked", () => {
+    const result = evaluateGate({
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("no-linked-issue");
+    expect(result.message).toContain(GATE_LABEL);
+    expect(result.message).toContain("CONTRIBUTING.md");
+  });
+
+  test("fails when the linked issue is open but not labeled", () => {
+    const result = evaluateGate({
+      authorAssociation: "CONTRIBUTOR",
+      isBot: false,
+      linkedIssues: [{ number: 12, state: "OPEN", labels: ["🐛 Bug"] }],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("missing-label");
+    expect(result.message).toContain(GATE_LABEL);
+  });
+
+  test("fails when the only labeled issue is closed", () => {
+    const result = evaluateGate({
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [{ number: 7, state: "CLOSED", labels: [GATE_LABEL] }],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("issue-closed");
+  });
+
+  test("passes when a linked issue is open and carries the gate label", () => {
+    const result = evaluateGate({
+      authorAssociation: "NONE",
+      isBot: false,
+      linkedIssues: [
+        { number: 42, state: "OPEN", labels: [GATE_LABEL, "🐛 Bug"] },
+      ],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("ok");
+  });
+
+  test("passes when any one of several linked issues qualifies", () => {
+    const result = evaluateGate({
+      authorAssociation: "FIRST_TIME_CONTRIBUTOR",
+      isBot: false,
+      linkedIssues: [
+        { number: 1, state: "CLOSED", labels: [GATE_LABEL] },
+        { number: 2, state: "OPEN", labels: ["✨ Feature"] },
+        { number: 3, state: "OPEN", labels: [GATE_LABEL] },
+      ],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.reason).toBe("ok");
+  });
+});

--- a/.github/scripts/contribution-gate.ts
+++ b/.github/scripts/contribution-gate.ts
@@ -18,12 +18,16 @@ export const GATE_LABEL = "open-for-contribution";
 const INTERNAL_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
 export interface LinkedIssue {
+  /** `owner/name` of the repo the issue lives in (from GraphQL nameWithOwner). */
+  repository: string;
   number: number;
   state: "OPEN" | "CLOSED";
   labels: string[];
 }
 
 export interface GateInput {
+  /** `owner/name` of this repository (from GITHUB_REPOSITORY). */
+  repository: string;
   authorAssociation: string;
   isBot: boolean;
   linkedIssues: LinkedIssue[];
@@ -91,7 +95,15 @@ export function evaluateGate(input: GateInput): GateResult {
     return { pass: true, reason: "internal" };
   }
 
-  if (input.linkedIssues.length === 0) {
+  // Only issues in THIS repository count. A cross-repository closing keyword
+  // (e.g. `Closes attacker/repo#1`) links an issue the contributor controls,
+  // so it must never satisfy the gate.
+  const repo = input.repository.toLowerCase();
+  const repoIssues = input.linkedIssues.filter(
+    (issue) => issue.repository.toLowerCase() === repo,
+  );
+
+  if (repoIssues.length === 0) {
     return {
       pass: false,
       reason: "no-linked-issue",
@@ -99,16 +111,14 @@ export function evaluateGate(input: GateInput): GateResult {
     };
   }
 
-  const qualifies = input.linkedIssues.some(
+  const qualifies = repoIssues.some(
     (issue) => issue.state === "OPEN" && issue.labels.includes(GATE_LABEL),
   );
   if (qualifies) {
     return { pass: true, reason: "ok" };
   }
 
-  const hasOpenIssue = input.linkedIssues.some(
-    (issue) => issue.state === "OPEN",
-  );
+  const hasOpenIssue = repoIssues.some((issue) => issue.state === "OPEN");
   const reason: GateReason = hasOpenIssue ? "missing-label" : "issue-closed";
   return { pass: false, reason, message: buildMessage(reason) };
 }
@@ -118,6 +128,7 @@ export function evaluateGate(input: GateInput): GateResult {
 interface GraphQLIssueNode {
   number: number;
   state: "OPEN" | "CLOSED";
+  repository: { nameWithOwner: string };
   labels: { nodes: Array<{ name: string }> };
 }
 
@@ -166,6 +177,7 @@ async function fetchLinkedIssues(
             nodes {
               number
               state
+              repository { nameWithOwner }
               labels(first: 50) { nodes { name } }
             }
           }
@@ -197,6 +209,7 @@ async function fetchLinkedIssues(
   const nodes =
     payload.data?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? [];
   return nodes.map((node) => ({
+    repository: node.repository.nameWithOwner,
     number: node.number,
     state: node.state,
     labels: node.labels.nodes.map((label) => label.name),
@@ -205,13 +218,19 @@ async function fetchLinkedIssues(
 
 async function main(): Promise<void> {
   const token = requireEnv("GITHUB_TOKEN");
-  const [owner, repo] = requireEnv("GITHUB_REPOSITORY").split("/");
+  const repository = requireEnv("GITHUB_REPOSITORY");
+  const [owner, repo] = repository.split("/");
   const prNumber = Number(requireEnv("PR_NUMBER"));
   const authorAssociation = process.env.PR_AUTHOR_ASSOCIATION ?? "NONE";
   const isBot = (process.env.PR_AUTHOR_TYPE ?? "User") === "Bot";
 
   const linkedIssues = await fetchLinkedIssues(token, owner!, repo!, prNumber);
-  const result = evaluateGate({ authorAssociation, isBot, linkedIssues });
+  const result = evaluateGate({
+    repository,
+    authorAssociation,
+    isBot,
+    linkedIssues,
+  });
 
   console.log(
     `Contribution gate for PR #${prNumber}: pass=${result.pass} reason=${result.reason} ` +

--- a/.github/scripts/contribution-gate.ts
+++ b/.github/scripts/contribution-gate.ts
@@ -1,0 +1,242 @@
+/**
+ * Contribution gate: enforces the pg-toolbelt contribution workflow on pull
+ * requests opened by external contributors.
+ *
+ * A PR passes only when it links to an OPEN GitHub issue that carries the
+ * `open-for-contribution` label. Members/collaborators/owners and bots are
+ * exempt (they work from Linear tickets or automation). PRs that do not follow
+ * the process are commented on and closed.
+ *
+ * Run in CI as: `bun .github/scripts/contribution-gate.ts`
+ * The pure `evaluateGate` decision function is unit-tested in
+ * `contribution-gate.test.ts`; `main()` performs the GitHub I/O.
+ */
+
+export const GATE_LABEL = "open-for-contribution";
+
+/** Author associations treated as internal (exempt from the gate). */
+const INTERNAL_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+export interface LinkedIssue {
+  number: number;
+  state: "OPEN" | "CLOSED";
+  labels: string[];
+}
+
+export interface GateInput {
+  authorAssociation: string;
+  isBot: boolean;
+  linkedIssues: LinkedIssue[];
+}
+
+export type GateReason =
+  | "bot"
+  | "internal"
+  | "ok"
+  | "no-linked-issue"
+  | "missing-label"
+  | "issue-closed";
+
+export interface GateResult {
+  pass: boolean;
+  reason: GateReason;
+  /** Explanatory comment body, present only when `pass` is false. */
+  message?: string;
+}
+
+const DOCS_FOOTER =
+  `\nSee [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for the full workflow. ` +
+  `Once a maintainer adds the \`${GATE_LABEL}\` label to a linked open issue, ` +
+  `reopen or open a new pull request and it will be accepted.`;
+
+function buildMessage(reason: GateReason): string {
+  switch (reason) {
+    case "no-linked-issue":
+      return (
+        `👋 Thanks for the contribution! This pull request isn't linked to a ` +
+        `tracked issue, so it's being closed automatically.\n\n` +
+        `Please open an issue first, wait for a maintainer to add the ` +
+        `\`${GATE_LABEL}\` label, then open a pull request that links the issue ` +
+        `with a closing keyword (e.g. \`Closes #123\`).${DOCS_FOOTER}`
+      );
+    case "missing-label":
+      return (
+        `👋 Thanks! The linked issue hasn't been marked \`${GATE_LABEL}\` yet, ` +
+        `so this pull request is being closed automatically.\n\n` +
+        `A maintainer adds that label once an issue is triaged and ready to be ` +
+        `worked on. Please wait for the label before opening a pull ` +
+        `request.${DOCS_FOOTER}`
+      );
+    case "issue-closed":
+      return (
+        `👋 The issue linked to this pull request is closed, so it's being ` +
+        `closed automatically.\n\n` +
+        `Please link an open issue that carries the \`${GATE_LABEL}\` ` +
+        `label.${DOCS_FOOTER}`
+      );
+    default:
+      return "";
+  }
+}
+
+/**
+ * Pure decision function for the contribution gate. Given the PR author context
+ * and its linked issues, returns whether the PR is allowed and why.
+ */
+export function evaluateGate(input: GateInput): GateResult {
+  if (input.isBot) {
+    return { pass: true, reason: "bot" };
+  }
+  if (INTERNAL_ASSOCIATIONS.has(input.authorAssociation)) {
+    return { pass: true, reason: "internal" };
+  }
+
+  if (input.linkedIssues.length === 0) {
+    return {
+      pass: false,
+      reason: "no-linked-issue",
+      message: buildMessage("no-linked-issue"),
+    };
+  }
+
+  const qualifies = input.linkedIssues.some(
+    (issue) => issue.state === "OPEN" && issue.labels.includes(GATE_LABEL),
+  );
+  if (qualifies) {
+    return { pass: true, reason: "ok" };
+  }
+
+  const hasOpenIssue = input.linkedIssues.some(
+    (issue) => issue.state === "OPEN",
+  );
+  const reason: GateReason = hasOpenIssue ? "missing-label" : "issue-closed";
+  return { pass: false, reason, message: buildMessage(reason) };
+}
+
+// --- GitHub I/O (only runs when executed directly) ---
+
+interface GraphQLIssueNode {
+  number: number;
+  state: "OPEN" | "CLOSED";
+  labels: { nodes: Array<{ name: string }> };
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+async function githubFetch(
+  url: string,
+  token: string,
+  init: Omit<RequestInit, "headers"> = {},
+): Promise<Response> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub request failed (${response.status}) for ${url}: ${body}`,
+    );
+  }
+  return response;
+}
+
+async function fetchLinkedIssues(
+  token: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<LinkedIssue[]> {
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          closingIssuesReferences(first: 20) {
+            nodes {
+              number
+              state
+              labels(first: 50) { nodes { name } }
+            }
+          }
+        }
+      }
+    }`;
+  const response = await githubFetch("https://api.github.com/graphql", token, {
+    method: "POST",
+    body: JSON.stringify({
+      query,
+      variables: { owner, repo, number: prNumber },
+    }),
+  });
+  const payload = (await response.json()) as {
+    errors?: Array<{ message: string }>;
+    data?: {
+      repository?: {
+        pullRequest?: {
+          closingIssuesReferences?: { nodes?: GraphQLIssueNode[] };
+        };
+      };
+    };
+  };
+  if (payload.errors?.length) {
+    throw new Error(
+      `GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`,
+    );
+  }
+  const nodes =
+    payload.data?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? [];
+  return nodes.map((node) => ({
+    number: node.number,
+    state: node.state,
+    labels: node.labels.nodes.map((label) => label.name),
+  }));
+}
+
+async function main(): Promise<void> {
+  const token = requireEnv("GITHUB_TOKEN");
+  const [owner, repo] = requireEnv("GITHUB_REPOSITORY").split("/");
+  const prNumber = Number(requireEnv("PR_NUMBER"));
+  const authorAssociation = process.env.PR_AUTHOR_ASSOCIATION ?? "NONE";
+  const isBot = (process.env.PR_AUTHOR_TYPE ?? "User") === "Bot";
+
+  const linkedIssues = await fetchLinkedIssues(token, owner!, repo!, prNumber);
+  const result = evaluateGate({ authorAssociation, isBot, linkedIssues });
+
+  console.log(
+    `Contribution gate for PR #${prNumber}: pass=${result.pass} reason=${result.reason} ` +
+      `(author_association=${authorAssociation}, bot=${isBot}, linked_issues=${linkedIssues.length})`,
+  );
+
+  if (result.pass) {
+    return;
+  }
+
+  const base = `https://api.github.com/repos/${owner}/${repo}`;
+  await githubFetch(`${base}/issues/${prNumber}/comments`, token, {
+    method: "POST",
+    body: JSON.stringify({ body: result.message }),
+  });
+  await githubFetch(`${base}/issues/${prNumber}`, token, {
+    method: "PATCH",
+    body: JSON.stringify({ state: "closed", state_reason: "not_planned" }),
+  });
+  console.log(`Closed PR #${prNumber} (reason=${result.reason}).`);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/workflows/contribution-gate.yml
+++ b/.github/workflows/contribution-gate.yml
@@ -1,0 +1,43 @@
+name: Contribution Gate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+
+permissions:
+  pull-requests: write
+  issues: read
+  contents: read
+
+concurrency:
+  group: contribution-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Contribution Gate
+    runs-on: ubuntu-latest
+    # Exempt maintainers/collaborators and bots. External contributors are gated.
+    if: >
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR' &&
+      github.event.pull_request.user.type != 'Bot'
+    steps:
+      # Checks out the base repo (default for pull_request_target), so the gate
+      # runs trusted code from main, never the untrusted PR head.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.13"
+      - name: Evaluate contribution gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+        run: bun .github/scripts/contribution-gate.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,16 +5,12 @@ Thanks for helping improve `pg-toolbelt`.
 ## Before you open a pull request
 
 1. **Open an issue first.**
-2. **Wait for maintainer triage.** An issue is ready for implementation only after a maintainer adds one of these labels:
-   - `✨ Feature`
-   - `🐛 Bug`
-   - `📘 Docs`
-   - `🛠️ Chore`
-3. **Open a pull request only after that approval.**
+2. **Wait for maintainer triage.** A maintainer categorizes the issue with one of `✨ Feature`, `🐛 Bug`, `📘 Docs`, or `🛠️ Chore`, and adds the **`open-for-contribution`** label once it is ready to be worked on.
+3. **Open a pull request only after the `open-for-contribution` label is set**, and link the issue with a closing keyword (for example `Closes #123`).
 
-Until one of those labels is set, the issue is considered untracked and still in triage, so work should not start and a pull request should not be opened.
+Until the `open-for-contribution` label is present, the issue is still in triage, so work should not start and a pull request should not be opened.
 
-Pull requests that do not follow this workflow are automatically closed by a bot.
+Pull requests from external contributors that do not follow this workflow are commented on and closed automatically by a bot. Supabase members are exempt, so they can work from Linear tickets that are not public on GitHub.
 
 When you open the issue, use the guidance in [`ISSUES.md`](./ISSUES.md), especially for `pg-delta` bugs and regressions.
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,13 +1,8 @@
 # Filing issues for pg-toolbelt
 
-Open an issue before opening a pull request. A pull request should only be opened after a maintainer adds one of these labels to that issue:
+Open an issue before opening a pull request. A maintainer categorizes each issue with one of `✨ Feature`, `🐛 Bug`, `📘 Docs`, or `🛠️ Chore`, and adds the **`open-for-contribution`** label once it is ready to be worked on. A pull request should only be opened after that label is present.
 
-- `✨ Feature`
-- `🐛 Bug`
-- `📘 Docs`
-- `🛠️ Chore`
-
-Until one of those labels is present, the issue is considered untracked and still waiting for triage, so work should not start and a pull request should not be opened.
+Until the `open-for-contribution` label is present, the issue is still waiting for triage, so work should not start and a pull request should not be opened.
 
 ## Start with the basics
 
@@ -20,7 +15,7 @@ Please include:
 - the expected result
 - the actual result
 
-If you already know the fix, still open the issue first and wait for maintainer triage into one of those labels before sending a pull request.
+If you already know the fix, still open the issue first and wait for the `open-for-contribution` label before sending a pull request.
 
 ## What to include for `pg-delta`
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ bunx changeset publish  # Publish to npm
 See [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull request.
 
 - Open an issue first.
-- Wait for maintainer triage via one of `✨ Feature`, `🐛 Bug`, `📘 Docs`, or `🛠️ Chore`.
-- Then open a pull request.
+- Wait for a maintainer to triage it and add the `open-for-contribution` label.
+- Then open a pull request that links the issue (for example `Closes #123`).
 
 Use [ISSUES.md](./ISSUES.md) for issue-writing guidance, especially for `pg-delta` reproductions.
 


### PR DESCRIPTION
## Summary

Implements the contribution-gating automation that `CONTRIBUTING.md` already promises ("Pull requests that do not follow this workflow are automatically closed by a bot") but which did not exist yet.

- **Contribution Gate workflow** (`.github/workflows/contribution-gate.yml`, `pull_request_target`): for **external** contributors, auto-closes + comments on a PR unless it links an **open** issue carrying the `open-for-contribution` label. `OWNER`/`MEMBER`/`COLLABORATOR` authors and bots are exempt (Supabase members work from Linear tickets). Linked issues are read via GraphQL `closingIssuesReferences`, so both `Closes #N` and the Development sidebar count.
- **Decision logic** in `.github/scripts/contribution-gate.ts` — pure, unit-tested `evaluateGate(...)` (TypeScript run with bun, zero deps) with a thin `fetch`-based `main()` for the GitHub I/O.
- **Issue templates** (`bug_report`, `feature_request`, `config`) auto-labeled `needs-triage`, mirroring `ISSUES.md`.
- **PR template** requiring a `Closes #N` link + the label confirmation.
- **Docs reconciliation**: `open-for-contribution` is now the ready-to-work gate the bot enforces; the `✨/🐛/📘/🛠️` labels remain categorization. Adds `.github/MAINTAINERS.md`.

## Test-Driven

RED → `contribution-gate.test.ts` first failed with `Cannot find module './contribution-gate.ts'`; GREEN → after implementing `evaluateGate`, **9 pass / 0 fail**.

Covered: no linked issue → close; linked-but-closed → close; open-but-unlabeled → close; open + `open-for-contribution` → pass; internal author → skip; bot → skip.

## Validation

- `bun test ./.github/scripts/contribution-gate.test.ts` → 9 pass
- `bun run format-and-lint` → clean
- `bun run check-types` → clean
- `actionlint .github/workflows/contribution-gate.yml` → clean

No changeset: this touches repo tooling/docs/`.github` only, not `@supabase/pg-delta` / `@supabase/pg-topo` package behavior.

## Notes

- The PR author is a Supabase member, so this PR is exempt from its own gate and will not self-close.
- Applying `open-for-contribution` is a manual maintainer step for now; automatic Linear→GitHub label sync is deferred (see `.github/MAINTAINERS.md`).

Closes #321
Refs CLI-1916

🤖 Generated with [Claude Code](https://claude.com/claude-code)