### PR TITLE
feat(ci): add on-demand all-open-PRs sweep to contribution gate

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -10,6 +10,13 @@ that carries the **`open-for-contribution`** label. This is enforced by the
 [`Contribution Gate`](./workflows/contribution-gate.yml) workflow, whose decision logic
 lives in [`scripts/contribution-gate.ts`](./scripts/contribution-gate.ts).
 
+The gate runs as a **periodic sweep over every open PR** (a `schedule` cron, currently
+every 15 minutes) and **on demand** via the workflow's *Run workflow* button
+(`workflow_dispatch`). It deliberately does **not** use `pull_request_target`: it only
+ever runs trusted base-branch code with the repository token and never checks out or
+executes a fork's code. The tradeoff is latency — a non-conforming PR is closed within
+one sweep interval rather than instantly.
+
 A pull request is **auto-closed with an explanatory comment** when the author is external
 and any of these is true:
 
@@ -21,6 +28,14 @@ and any of these is true:
 Authors whose `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`, and bot
 accounts, are **exempt** — Supabase maintainers can keep working from Linear tickets that
 aren't public on GitHub.
+
+### Running the gate manually
+
+Use **Actions → Contribution Gate → Run workflow** to sweep all open PRs on demand — for
+example right after bulk-applying `open-for-contribution` labels, so the backlog is
+re-evaluated without waiting for the next scheduled tick. Set the **`dry_run`** input to
+`true` first to log each PR's decision in the run output without commenting on or closing
+anything; run again with `dry_run` unchecked to apply the decisions.
 
 ## Triage: applying the label (manual)
 

--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -10,12 +10,12 @@ that carries the **`open-for-contribution`** label. This is enforced by the
 [`Contribution Gate`](./workflows/contribution-gate.yml) workflow, whose decision logic
 lives in [`scripts/contribution-gate.ts`](./scripts/contribution-gate.ts).
 
-The gate runs as a **periodic sweep over every open PR** (a `schedule` cron, currently
-every 15 minutes) and **on demand** via the workflow's *Run workflow* button
-(`workflow_dispatch`). It deliberately does **not** use `pull_request_target`: it only
-ever runs trusted base-branch code with the repository token and never checks out or
-executes a fork's code. The tradeoff is latency — a non-conforming PR is closed within
-one sweep interval rather than instantly.
+The gate runs **reactively on each PR** via `pull_request_target`
+(`opened`/`reopened`/`edited`) so a non-conforming PR is closed right away, and can also
+be **swept across every open PR on demand** via the workflow's *Run workflow* button
+(`workflow_dispatch`). Both paths only ever run trusted base-branch code with the
+repository token: `pull_request_target` checks out the base branch (not the PR head), and
+the script only makes GitHub API calls — it never checks out or executes a fork's code.
 
 A pull request is **auto-closed with an explanatory comment** when the author is external
 and any of these is true:
@@ -32,10 +32,10 @@ aren't public on GitHub.
 ### Running the gate manually
 
 Use **Actions → Contribution Gate → Run workflow** to sweep all open PRs on demand — for
-example right after bulk-applying `open-for-contribution` labels, so the backlog is
-re-evaluated without waiting for the next scheduled tick. Set the **`dry_run`** input to
-`true` first to log each PR's decision in the run output without commenting on or closing
-anything; run again with `dry_run` unchecked to apply the decisions.
+example right after bulk-applying `open-for-contribution` labels, so the whole backlog is
+re-evaluated at once instead of waiting for each PR's next edit. Set the **`dry_run`**
+input to `true` first to log each PR's decision in the run output without commenting on or
+closing anything; run again with `dry_run` unchecked to apply the decisions.
 
 ## Triage: applying the label (manual)
 

--- a/.github/scripts/contribution-gate.test.ts
+++ b/.github/scripts/contribution-gate.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { evaluateGate, GATE_LABEL } from "./contribution-gate.ts";
+import {
+  evaluateAllOpenPrs,
+  evaluateGate,
+  GATE_LABEL,
+  type GateIo,
+  type LinkedIssue,
+  type OpenPr,
+} from "./contribution-gate.ts";
 
 const REPO = "supabase/pg-toolbelt";
 
@@ -138,5 +145,75 @@ describe("evaluateGate", () => {
     });
     expect(result.pass).toBe(true);
     expect(result.reason).toBe("ok");
+  });
+});
+
+describe("evaluateAllOpenPrs", () => {
+  function makeIo(
+    openPrs: OpenPr[],
+    linkedByPr: Record<number, LinkedIssue[]>,
+  ): { io: GateIo; closed: Array<{ number: number; message: string }> } {
+    const closed: Array<{ number: number; message: string }> = [];
+    const io: GateIo = {
+      listOpenPrs: () => Promise.resolve(openPrs),
+      fetchLinkedIssues: (prNumber) =>
+        Promise.resolve(linkedByPr[prNumber] ?? []),
+      closePr: (prNumber, message) => {
+        closed.push({ number: prNumber, message });
+        return Promise.resolve();
+      },
+    };
+    return { io, closed };
+  }
+
+  test("closes only non-conforming external PRs and leaves the rest", async () => {
+    const { io, closed } = makeIo(
+      [
+        { number: 1, authorAssociation: "NONE", isBot: false }, // no issue -> close
+        { number: 2, authorAssociation: "MEMBER", isBot: false }, // internal -> skip
+        { number: 3, authorAssociation: "NONE", isBot: true }, // bot -> skip
+        { number: 4, authorAssociation: "CONTRIBUTOR", isBot: false }, // conforming -> keep
+        { number: 5, authorAssociation: "NONE", isBot: false }, // missing label -> close
+      ],
+      {
+        4: [
+          { repository: REPO, number: 40, state: "OPEN", labels: [GATE_LABEL] },
+        ],
+        5: [
+          { repository: REPO, number: 50, state: "OPEN", labels: ["🐛 Bug"] },
+        ],
+      },
+    );
+
+    const entries = await evaluateAllOpenPrs(io, REPO);
+
+    expect(closed.map((c) => c.number).sort((a, b) => a - b)).toEqual([1, 5]);
+    const byNumber = Object.fromEntries(
+      entries.map((entry) => [entry.number, entry.result]),
+    );
+    expect(byNumber[1]?.reason).toBe("no-linked-issue");
+    expect(byNumber[2]?.pass).toBe(true);
+    expect(byNumber[2]?.reason).toBe("internal");
+    expect(byNumber[3]?.reason).toBe("bot");
+    expect(byNumber[4]?.pass).toBe(true);
+    expect(byNumber[5]?.reason).toBe("missing-label");
+    expect(closed.find((c) => c.number === 1)?.message).toContain(GATE_LABEL);
+  });
+
+  test("returns an entry per PR and closes none when all conform", async () => {
+    const { io, closed } = makeIo(
+      [{ number: 9, authorAssociation: "NONE", isBot: false }],
+      {
+        9: [
+          { repository: REPO, number: 90, state: "OPEN", labels: [GATE_LABEL] },
+        ],
+      },
+    );
+
+    const entries = await evaluateAllOpenPrs(io, REPO);
+
+    expect(entries).toHaveLength(1);
+    expect(closed).toHaveLength(0);
+    expect(entries[0]?.result.pass).toBe(true);
   });
 });

--- a/.github/scripts/contribution-gate.ts
+++ b/.github/scripts/contribution-gate.ts
@@ -7,13 +7,17 @@
  * exempt (they work from Linear tickets or automation). PRs that do not follow
  * the process are commented on and closed.
  *
- * This runs as a periodic sweep (`schedule`) and on demand (`workflow_dispatch`)
- * over every open PR — deliberately NOT on `pull_request_target`, so it only
- * ever executes trusted base-branch code with the repository token and never
- * checks out or runs a fork's code.
+ * Two modes, both driven from `main()`:
+ *   - single-PR (default): reacts to one PR on `pull_request_target`
+ *     (`opened`/`reopened`/`edited`), using the PR_* env vars from the event.
+ *   - all-PRs sweep (`GATE_MODE=all`, or the `--all` flag): evaluates every
+ *     open PR, for on-demand `workflow_dispatch` runs. Set `DRY_RUN=true` to
+ *     log decisions without commenting/closing.
  *
- * Run in CI as: `bun .github/scripts/contribution-gate.ts`
- * (set `DRY_RUN=true` to log decisions without commenting/closing).
+ * In both modes the workflow checks out the base branch, so this only ever
+ * executes trusted repository code — it never runs a fork's code.
+ *
+ * Run in CI as: `bun .github/scripts/contribution-gate.ts`.
  * The pure `evaluateGate` decision and the `evaluateAllOpenPrs` orchestrator
  * (I/O injected) are unit-tested in `contribution-gate.test.ts`; `main()` wires
  * up the real GitHub I/O.
@@ -304,31 +308,78 @@ async function fetchOpenPullRequests(
   return prs;
 }
 
-async function main(): Promise<void> {
-  const token = requireEnv("GITHUB_TOKEN");
-  const repository = requireEnv("GITHUB_REPOSITORY");
-  const [owner, repo] = repository.split("/");
-  const dryRun = /^(1|true)$/i.test(process.env.DRY_RUN ?? "");
+/**
+ * Build the "comment then close" action for a repo. In dry-run mode it logs the
+ * intended action instead of mutating the PR.
+ */
+function makeCloser(
+  token: string,
+  base: string,
+  dryRun: boolean,
+): (prNumber: number, message: string) => Promise<void> {
+  return async (prNumber, message) => {
+    if (dryRun) {
+      console.log(`[dry-run] would comment on and close PR #${prNumber}`);
+      return;
+    }
+    await githubFetch(`${base}/issues/${prNumber}/comments`, token, {
+      method: "POST",
+      body: JSON.stringify({ body: message }),
+    });
+    await githubFetch(`${base}/issues/${prNumber}`, token, {
+      method: "PATCH",
+      body: JSON.stringify({ state: "closed", state_reason: "not_planned" }),
+    });
+  };
+}
+
+/** Single-PR mode: react to the PR carried by a `pull_request_target` event. */
+async function runSinglePr(
+  token: string,
+  owner: string,
+  repo: string,
+  repository: string,
+): Promise<void> {
+  const prNumber = Number(requireEnv("PR_NUMBER"));
+  const authorAssociation = process.env.PR_AUTHOR_ASSOCIATION ?? "NONE";
+  const isBot = (process.env.PR_AUTHOR_TYPE ?? "User") === "Bot";
+
+  const linkedIssues = await fetchLinkedIssues(token, owner, repo, prNumber);
+  const result = evaluateGate({
+    repository,
+    authorAssociation,
+    isBot,
+    linkedIssues,
+  });
+
+  console.log(
+    `Contribution gate for PR #${prNumber}: pass=${result.pass} reason=${result.reason} ` +
+      `(author_association=${authorAssociation}, bot=${isBot}, linked_issues=${linkedIssues.length})`,
+  );
+
+  if (result.pass || !result.message) {
+    return;
+  }
 
   const base = `https://api.github.com/repos/${owner}/${repo}`;
+  await makeCloser(token, base, false)(prNumber, result.message);
+  console.log(`Closed PR #${prNumber} (reason=${result.reason}).`);
+}
+
+/** All-PRs mode: sweep every open PR, for on-demand `workflow_dispatch` runs. */
+async function runSweep(
+  token: string,
+  owner: string,
+  repo: string,
+  repository: string,
+  dryRun: boolean,
+): Promise<void> {
+  const base = `https://api.github.com/repos/${owner}/${repo}`;
   const io: GateIo = {
-    listOpenPrs: () => fetchOpenPullRequests(token, owner!, repo!),
+    listOpenPrs: () => fetchOpenPullRequests(token, owner, repo),
     fetchLinkedIssues: (prNumber) =>
-      fetchLinkedIssues(token, owner!, repo!, prNumber),
-    closePr: async (prNumber, message) => {
-      if (dryRun) {
-        console.log(`[dry-run] would comment on and close PR #${prNumber}`);
-        return;
-      }
-      await githubFetch(`${base}/issues/${prNumber}/comments`, token, {
-        method: "POST",
-        body: JSON.stringify({ body: message }),
-      });
-      await githubFetch(`${base}/issues/${prNumber}`, token, {
-        method: "PATCH",
-        body: JSON.stringify({ state: "closed", state_reason: "not_planned" }),
-      });
-    },
+      fetchLinkedIssues(token, owner, repo, prNumber),
+    closePr: makeCloser(token, base, dryRun),
   };
 
   const entries = await evaluateAllOpenPrs(io, repository);
@@ -341,6 +392,21 @@ async function main(): Promise<void> {
     console.log(
       `  PR #${entry.number}: pass=${entry.result.pass} reason=${entry.result.reason}`,
     );
+  }
+}
+
+async function main(): Promise<void> {
+  const token = requireEnv("GITHUB_TOKEN");
+  const repository = requireEnv("GITHUB_REPOSITORY");
+  const [owner, repo] = repository.split("/");
+
+  const allMode =
+    process.env.GATE_MODE === "all" || process.argv.includes("--all");
+  if (allMode) {
+    const dryRun = /^(1|true)$/i.test(process.env.DRY_RUN ?? "");
+    await runSweep(token, owner!, repo!, repository, dryRun);
+  } else {
+    await runSinglePr(token, owner!, repo!, repository);
   }
 }
 

--- a/.github/scripts/contribution-gate.ts
+++ b/.github/scripts/contribution-gate.ts
@@ -1,15 +1,22 @@
 /**
- * Contribution gate: enforces the pg-toolbelt contribution workflow on pull
- * requests opened by external contributors.
+ * Contribution gate: enforces the pg-toolbelt contribution workflow across all
+ * OPEN pull requests opened by external contributors.
  *
  * A PR passes only when it links to an OPEN GitHub issue that carries the
  * `open-for-contribution` label. Members/collaborators/owners and bots are
  * exempt (they work from Linear tickets or automation). PRs that do not follow
  * the process are commented on and closed.
  *
+ * This runs as a periodic sweep (`schedule`) and on demand (`workflow_dispatch`)
+ * over every open PR — deliberately NOT on `pull_request_target`, so it only
+ * ever executes trusted base-branch code with the repository token and never
+ * checks out or runs a fork's code.
+ *
  * Run in CI as: `bun .github/scripts/contribution-gate.ts`
- * The pure `evaluateGate` decision function is unit-tested in
- * `contribution-gate.test.ts`; `main()` performs the GitHub I/O.
+ * (set `DRY_RUN=true` to log decisions without commenting/closing).
+ * The pure `evaluateGate` decision and the `evaluateAllOpenPrs` orchestrator
+ * (I/O injected) are unit-tested in `contribution-gate.test.ts`; `main()` wires
+ * up the real GitHub I/O.
  */
 
 export const GATE_LABEL = "open-for-contribution";
@@ -123,6 +130,55 @@ export function evaluateGate(input: GateInput): GateResult {
   return { pass: false, reason, message: buildMessage(reason) };
 }
 
+/** Minimal open-PR shape the gate needs to decide exemption. */
+export interface OpenPr {
+  number: number;
+  authorAssociation: string;
+  isBot: boolean;
+}
+
+/** Injected GitHub I/O so the sweep can be unit-tested without the network. */
+export interface GateIo {
+  /** List every open pull request in the repository. */
+  listOpenPrs: () => Promise<OpenPr[]>;
+  /** Fetch the issues a PR closes (via `closingIssuesReferences`). */
+  fetchLinkedIssues: (prNumber: number) => Promise<LinkedIssue[]>;
+  /** Comment with `message` then close the PR. Called only for failing PRs. */
+  closePr: (prNumber: number, message: string) => Promise<void>;
+}
+
+export interface SweepEntry {
+  number: number;
+  result: GateResult;
+}
+
+/**
+ * Evaluate the gate against every open PR, closing the ones that fail. Pure
+ * orchestration over the injected `io`; returns each PR's decision so the
+ * caller can log a summary.
+ */
+export async function evaluateAllOpenPrs(
+  io: GateIo,
+  repository: string,
+): Promise<SweepEntry[]> {
+  const openPrs = await io.listOpenPrs();
+  const entries: SweepEntry[] = [];
+  for (const pr of openPrs) {
+    const linkedIssues = await io.fetchLinkedIssues(pr.number);
+    const result = evaluateGate({
+      repository,
+      authorAssociation: pr.authorAssociation,
+      isBot: pr.isBot,
+      linkedIssues,
+    });
+    if (!result.pass && result.message) {
+      await io.closePr(pr.number, result.message);
+    }
+    entries.push({ number: pr.number, result });
+  }
+  return entries;
+}
+
 // --- GitHub I/O (only runs when executed directly) ---
 
 interface GraphQLIssueNode {
@@ -216,41 +272,76 @@ async function fetchLinkedIssues(
   }));
 }
 
+interface RestPullRequest {
+  number: number;
+  author_association: string;
+  user: { type: string } | null;
+}
+
+async function fetchOpenPullRequests(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<OpenPr[]> {
+  const prs: OpenPr[] = [];
+  for (let page = 1; ; page++) {
+    const url =
+      `https://api.github.com/repos/${owner}/${repo}/pulls` +
+      `?state=open&per_page=100&page=${page}`;
+    const response = await githubFetch(url, token);
+    const batch = (await response.json()) as RestPullRequest[];
+    for (const pr of batch) {
+      prs.push({
+        number: pr.number,
+        authorAssociation: pr.author_association,
+        isBot: pr.user?.type === "Bot",
+      });
+    }
+    if (batch.length < 100) {
+      break;
+    }
+  }
+  return prs;
+}
+
 async function main(): Promise<void> {
   const token = requireEnv("GITHUB_TOKEN");
   const repository = requireEnv("GITHUB_REPOSITORY");
   const [owner, repo] = repository.split("/");
-  const prNumber = Number(requireEnv("PR_NUMBER"));
-  const authorAssociation = process.env.PR_AUTHOR_ASSOCIATION ?? "NONE";
-  const isBot = (process.env.PR_AUTHOR_TYPE ?? "User") === "Bot";
-
-  const linkedIssues = await fetchLinkedIssues(token, owner!, repo!, prNumber);
-  const result = evaluateGate({
-    repository,
-    authorAssociation,
-    isBot,
-    linkedIssues,
-  });
-
-  console.log(
-    `Contribution gate for PR #${prNumber}: pass=${result.pass} reason=${result.reason} ` +
-      `(author_association=${authorAssociation}, bot=${isBot}, linked_issues=${linkedIssues.length})`,
-  );
-
-  if (result.pass) {
-    return;
-  }
+  const dryRun = /^(1|true)$/i.test(process.env.DRY_RUN ?? "");
 
   const base = `https://api.github.com/repos/${owner}/${repo}`;
-  await githubFetch(`${base}/issues/${prNumber}/comments`, token, {
-    method: "POST",
-    body: JSON.stringify({ body: result.message }),
-  });
-  await githubFetch(`${base}/issues/${prNumber}`, token, {
-    method: "PATCH",
-    body: JSON.stringify({ state: "closed", state_reason: "not_planned" }),
-  });
-  console.log(`Closed PR #${prNumber} (reason=${result.reason}).`);
+  const io: GateIo = {
+    listOpenPrs: () => fetchOpenPullRequests(token, owner!, repo!),
+    fetchLinkedIssues: (prNumber) =>
+      fetchLinkedIssues(token, owner!, repo!, prNumber),
+    closePr: async (prNumber, message) => {
+      if (dryRun) {
+        console.log(`[dry-run] would comment on and close PR #${prNumber}`);
+        return;
+      }
+      await githubFetch(`${base}/issues/${prNumber}/comments`, token, {
+        method: "POST",
+        body: JSON.stringify({ body: message }),
+      });
+      await githubFetch(`${base}/issues/${prNumber}`, token, {
+        method: "PATCH",
+        body: JSON.stringify({ state: "closed", state_reason: "not_planned" }),
+      });
+    },
+  };
+
+  const entries = await evaluateAllOpenPrs(io, repository);
+  const failing = entries.filter((entry) => !entry.result.pass);
+  console.log(
+    `Contribution gate sweep: ${entries.length} open PR(s) evaluated, ` +
+      `${failing.length} ${dryRun ? "would be " : ""}closed.`,
+  );
+  for (const entry of entries) {
+    console.log(
+      `  PR #${entry.number}: pass=${entry.result.pass} reason=${entry.result.reason}`,
+    );
+  }
 }
 
 if (import.meta.main) {

--- a/.github/workflows/contribution-gate.yml
+++ b/.github/workflows/contribution-gate.yml
@@ -1,11 +1,18 @@
 name: Contribution Gate
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - reopened
-      - edited
+  schedule:
+    # Sweep every 15 minutes. A non-conforming external PR is closed within one
+    # tick. This replaces a `pull_request_target` trigger so the gate only ever
+    # runs trusted base-branch code with the repository token — it never checks
+    # out or executes a fork's code.
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Evaluate and log decisions only; do not comment or close"
+        type: boolean
+        default: false
 
 permissions:
   pull-requests: write
@@ -13,31 +20,23 @@ permissions:
   contents: read
 
 concurrency:
-  group: contribution-gate-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: contribution-gate
+  # Never interrupt an in-flight sweep mid comment/close; queue instead.
+  cancel-in-progress: false
 
 jobs:
   gate:
     name: Contribution Gate
     runs-on: ubuntu-latest
-    # Exempt maintainers/collaborators and bots. External contributors are gated.
-    if: >
-      github.event.pull_request.author_association != 'OWNER' &&
-      github.event.pull_request.author_association != 'MEMBER' &&
-      github.event.pull_request.author_association != 'COLLABORATOR' &&
-      github.event.pull_request.user.type != 'Bot'
     steps:
-      # Checks out the base repo (default for pull_request_target), so the gate
-      # runs trusted code from main, never the untrusted PR head.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.13"
-      - name: Evaluate contribution gate
+      - name: Evaluate contribution gate across all open PRs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          # `inputs` is empty on the schedule event, so this is 'false' there.
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bun .github/scripts/contribution-gate.ts

--- a/.github/workflows/contribution-gate.yml
+++ b/.github/workflows/contribution-gate.yml
@@ -1,12 +1,14 @@
 name: Contribution Gate
 
 on:
-  schedule:
-    # Sweep every 15 minutes. A non-conforming external PR is closed within one
-    # tick. This replaces a `pull_request_target` trigger so the gate only ever
-    # runs trusted base-branch code with the repository token — it never checks
-    # out or executes a fork's code.
-    - cron: "*/15 * * * *"
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+  # Manual sweep over every open PR — e.g. after bulk-applying the
+  # `open-for-contribution` label. Set `dry_run` to log decisions without
+  # commenting or closing.
   workflow_dispatch:
     inputs:
       dry_run:
@@ -20,15 +22,45 @@ permissions:
   contents: read
 
 concurrency:
-  group: contribution-gate
-  # Never interrupt an in-flight sweep mid comment/close; queue instead.
-  cancel-in-progress: false
+  # Per-PR for pull_request_target; unique per run for manual sweeps (which
+  # carry no pull_request payload) so two sweeps never cancel each other.
+  group: contribution-gate-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   gate:
     name: Contribution Gate
     runs-on: ubuntu-latest
+    # Exempt maintainers/collaborators and bots. External contributors are gated.
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR' &&
+      github.event.pull_request.user.type != 'Bot'
     steps:
+      # Checks out the base repo (default for pull_request_target), so the gate
+      # runs trusted code from main, never the untrusted PR head.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.13"
+      - name: Evaluate contribution gate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+        run: bun .github/scripts/contribution-gate.ts
+
+  gate-all:
+    name: Contribution Gate (all open PRs)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      # Base-branch checkout only — the sweep makes API calls and never runs
+      # any PR's code.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -37,6 +69,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          # `inputs` is empty on the schedule event, so this is 'false' there.
+          GATE_MODE: all
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: bun .github/scripts/contribution-gate.ts


### PR DESCRIPTION
## Summary

Extends the contribution gate to support two modes of operation:

1. **Single-PR mode** (existing, reactive): Triggered by `pull_request_target` events (`opened`/`reopened`/`edited`), evaluates one PR immediately using environment variables from the event.

2. **All-PRs sweep mode** (new, on-demand): Triggered by `workflow_dispatch`, evaluates every open PR in the repository. Useful for bulk re-evaluation after applying `open-for-contribution` labels to multiple issues. Includes a `dry_run` input to log decisions without mutating PRs.

Both modes run only trusted base-branch code (never fork code) and use injected I/O interfaces for testability.

### Changes

**Script (`contribution-gate.ts`)**:
- Extracted pure orchestration logic into `evaluateAllOpenPrs()` with injected `GateIo` interface for GitHub API calls
- Added `fetchOpenPullRequests()` to paginate the REST API for all open PRs
- Added `makeCloser()` factory to build the "comment and close" action, with dry-run support
- Split `main()` into `runSinglePr()` (reactive) and `runSweep()` (on-demand) modes
- Mode selection via `GATE_MODE=all` env var or `--all` CLI flag; dry-run via `DRY_RUN=true`

**Tests (`contribution-gate.test.ts`)**:
- Added `evaluateAllOpenPrs` test suite covering mixed PR scenarios (external/internal, bots, conforming/non-conforming)
- Verifies only failing external PRs are closed and correct decisions are logged

**Workflow (`contribution-gate.yml`)**:
- Added `workflow_dispatch` trigger with `dry_run` boolean input
- New `gate-all` job that runs the sweep mode
- Updated concurrency group to handle both per-PR (pull_request_target) and per-run (workflow_dispatch) scenarios
- Added conditional to skip `gate-single` job when triggered manually

**Documentation (`MAINTAINERS.md`)**:
- Documented both reactive and on-demand modes
- Added security note: both paths run only trusted base-branch code
- Added instructions for manual sweep workflow with dry-run guidance

## Linked issue

This is an infrastructure improvement to the contribution workflow; no external issue.

## Checklist

- [x] Tests added for the new `evaluateAllOpenPrs` orchestrator and sweep mode
- [x] No user-facing package changes; workflow/script infrastructure only
- [x] Documentation updated in MAINTAINERS.md

https://claude.ai/code/session_01PT1aT8B2J3B6rjAyzGeEER