### PR TITLE
fix(pg-delta): plan/apply failure fixes — domains, enums, partitions, FDW, aggregates

### DIFF
--- a/.changeset/foreign-server-extension-subpartition-fixes.md
+++ b/.changeset/foreign-server-extension-subpartition-fixes.md
@@ -1,0 +1,11 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix five round-trip fidelity gaps in the planner:
+
+- Multi-level partitions keep their own `PARTITION BY` clause, so a partition that is itself partitioned can have sub-partitions attached.
+- Removing a foreign server `VERSION` (which has no `ALTER SERVER` grammar) now routes to a drop + recreate instead of crashing planning.
+- `ALTER EXTENSION … SET SCHEMA` is no longer emitted for non-relocatable extensions; relocation is planned as a drop + recreate in the new schema.
+- Zero-argument aggregate `COMMENT` / `SECURITY LABEL` targets render `name(*)` instead of the invalid `name()`.
+- Replacing a foreign server that has dependent foreign tables / user mappings now drops and recreates those children around the replace (the parent `DROP SERVER` does not cascade), instead of failing on the surviving dependents.

--- a/.changeset/issue-333-domain-enum-array-notvalid.md
+++ b/.changeset/issue-333-domain-enum-array-notvalid.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Three planning fixes from issue #333: (1) a domain whose `baseType`/`collation` change is a drop+recreate — the planner now fails loud at plan time (instead of emitting a plan Postgres rejects at apply) when a surviving table column still depends on the domain, mirroring the existing in-use range-type guard. (2) An enum value-set rebuild (removal/reorder) migrated every dependent column with a scalar `col::text::<enum>` cast regardless of the column's own declared type; an `enum[]` column now casts correctly (`TYPE <enum>[] USING col::text[]::<enum>[]`) instead of erroring or silently narrowing to scalar. (3) A constraint's `validated` attribute going from `true` to `false` (VALIDATED → NOT VALID) threw `constraint cannot be de-validated in place` instead of planning a fix; it now replaces the constraint (`DROP CONSTRAINT` + `ADD CONSTRAINT … NOT VALID`), matching how `create()` already renders a fresh NOT VALID constraint.

--- a/packages/pg-delta/corpus/aggregate-operations--comment-zero-arg/a.sql
+++ b/packages/pg-delta/corpus/aggregate-operations--comment-zero-arg/a.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA test_schema;
+
+CREATE AGGREGATE test_schema.count_all(*)
+(
+  SFUNC = pg_catalog.int8inc,
+  STYPE = int8,
+  INITCOND = '0'
+);

--- a/packages/pg-delta/corpus/aggregate-operations--comment-zero-arg/b.sql
+++ b/packages/pg-delta/corpus/aggregate-operations--comment-zero-arg/b.sql
@@ -1,0 +1,12 @@
+-- A zero-argument aggregate's COMMENT / SECURITY LABEL target must render the
+-- signature as (*), not (): PostgreSQL requires COMMENT ON AGGREGATE name(*).
+CREATE SCHEMA test_schema;
+
+CREATE AGGREGATE test_schema.count_all(*)
+(
+  SFUNC = pg_catalog.int8inc,
+  STYPE = int8,
+  INITCOND = '0'
+);
+
+COMMENT ON AGGREGATE test_schema.count_all(*) IS 'counts all rows';

--- a/packages/pg-delta/corpus/alter-extension--set-schema-non-relocatable/a.sql
+++ b/packages/pg-delta/corpus/alter-extension--set-schema-non-relocatable/a.sql
@@ -1,0 +1,6 @@
+-- xml2 is a NON-relocatable extension: PostgreSQL rejects
+-- ALTER EXTENSION xml2 SET SCHEMA. Relocating it between states must therefore
+-- be planned as drop + recreate in the new schema, not an in-place ALTER.
+CREATE SCHEMA schema_a;
+
+CREATE EXTENSION xml2 SCHEMA schema_a;

--- a/packages/pg-delta/corpus/alter-extension--set-schema-non-relocatable/b.sql
+++ b/packages/pg-delta/corpus/alter-extension--set-schema-non-relocatable/b.sql
@@ -1,0 +1,3 @@
+CREATE SCHEMA schema_b;
+
+CREATE EXTENSION xml2 SCHEMA schema_b;

--- a/packages/pg-delta/corpus/foreign-data-wrapper-operations--remove-server-version/a.sql
+++ b/packages/pg-delta/corpus/foreign-data-wrapper-operations--remove-server-version/a.sql
@@ -1,0 +1,2 @@
+CREATE FOREIGN DATA WRAPPER corpus_test_fdw;
+CREATE SERVER corpus_test_server VERSION '1.0' FOREIGN DATA WRAPPER corpus_test_fdw;

--- a/packages/pg-delta/corpus/foreign-data-wrapper-operations--remove-server-version/b.sql
+++ b/packages/pg-delta/corpus/foreign-data-wrapper-operations--remove-server-version/b.sql
@@ -1,0 +1,5 @@
+-- Same server without VERSION. PostgreSQL has no ALTER SERVER grammar to unset
+-- a version, so the forward diff (removal) must route to drop + recreate; the
+-- reverse (adding VERSION) is a plain ALTER SERVER … VERSION.
+CREATE FOREIGN DATA WRAPPER corpus_test_fdw;
+CREATE SERVER corpus_test_server FOREIGN DATA WRAPPER corpus_test_fdw;

--- a/packages/pg-delta/corpus/foreign-data-wrapper-operations--replace-server-with-children/a.sql
+++ b/packages/pg-delta/corpus/foreign-data-wrapper-operations--replace-server-with-children/a.sql
@@ -1,0 +1,14 @@
+-- The server's FOREIGN DATA WRAPPER differs between states (fdw1 → fdw2), which
+-- forces a server replace (there is no ALTER SERVER … FOREIGN DATA WRAPPER). A
+-- foreign table and a user mapping depend on the server in BOTH states, so the
+-- DROP SERVER (RESTRICT) fails unless those dependents are rebuilt around it.
+CREATE SCHEMA corpus_test_schema;
+
+CREATE FOREIGN DATA WRAPPER corpus_fdw1;
+CREATE FOREIGN DATA WRAPPER corpus_fdw2;
+
+CREATE SERVER corpus_server FOREIGN DATA WRAPPER corpus_fdw1;
+
+CREATE USER MAPPING FOR CURRENT_USER SERVER corpus_server;
+
+CREATE FOREIGN TABLE corpus_test_schema.remote_items (id integer) SERVER corpus_server;

--- a/packages/pg-delta/corpus/foreign-data-wrapper-operations--replace-server-with-children/b.sql
+++ b/packages/pg-delta/corpus/foreign-data-wrapper-operations--replace-server-with-children/b.sql
@@ -1,0 +1,10 @@
+CREATE SCHEMA corpus_test_schema;
+
+CREATE FOREIGN DATA WRAPPER corpus_fdw1;
+CREATE FOREIGN DATA WRAPPER corpus_fdw2;
+
+CREATE SERVER corpus_server FOREIGN DATA WRAPPER corpus_fdw2;
+
+CREATE USER MAPPING FOR CURRENT_USER SERVER corpus_server;
+
+CREATE FOREIGN TABLE corpus_test_schema.remote_items (id integer) SERVER corpus_server;

--- a/packages/pg-delta/corpus/not-valid--fk-validate-drift/a.sql
+++ b/packages/pg-delta/corpus/not-valid--fk-validate-drift/a.sql
@@ -1,0 +1,15 @@
+-- FK constraint exists as NOT VALID (not yet validated)
+CREATE SCHEMA test_schema;
+
+CREATE TABLE test_schema.orders (
+  id integer PRIMARY KEY
+);
+
+CREATE TABLE test_schema.items (
+  id integer PRIMARY KEY,
+  order_id integer
+);
+
+ALTER TABLE test_schema.items
+  ADD CONSTRAINT items_order_id_fkey
+  FOREIGN KEY (order_id) REFERENCES test_schema.orders (id) NOT VALID;

--- a/packages/pg-delta/corpus/not-valid--fk-validate-drift/b.sql
+++ b/packages/pg-delta/corpus/not-valid--fk-validate-drift/b.sql
@@ -1,0 +1,17 @@
+-- same FK constraint is now validated (convalidated = true); convergence
+-- should validate it (and the reverse direction, b -> a, exercises
+-- validated -> NOT VALID)
+CREATE SCHEMA test_schema;
+
+CREATE TABLE test_schema.orders (
+  id integer PRIMARY KEY
+);
+
+CREATE TABLE test_schema.items (
+  id integer PRIMARY KEY,
+  order_id integer
+);
+
+ALTER TABLE test_schema.items
+  ADD CONSTRAINT items_order_id_fkey
+  FOREIGN KEY (order_id) REFERENCES test_schema.orders (id);

--- a/packages/pg-delta/corpus/partitioned-table-operations--subpartitioned-multilevel/a.sql
+++ b/packages/pg-delta/corpus/partitioned-table-operations--subpartitioned-multilevel/a.sql
@@ -1,0 +1,10 @@
+-- 3-level partitioning: only the root exists here. The forward diff must
+-- create the middle layer (itself PARTITION BY RANGE) and the leaf under it,
+-- exercising the subpartitioned-partition create path.
+CREATE SCHEMA test_schema;
+
+CREATE TABLE test_schema.events (
+  id integer NOT NULL,
+  region text NOT NULL,
+  created_on date NOT NULL
+) PARTITION BY LIST (region);

--- a/packages/pg-delta/corpus/partitioned-table-operations--subpartitioned-multilevel/b.sql
+++ b/packages/pg-delta/corpus/partitioned-table-operations--subpartitioned-multilevel/b.sql
@@ -1,0 +1,17 @@
+-- root (PARTITION BY LIST) → events_us (a partition that is ITSELF
+-- PARTITION BY RANGE) → events_us_2024 (leaf). The middle partition must
+-- retain its PARTITION BY clause or the leaf cannot attach.
+CREATE SCHEMA test_schema;
+
+CREATE TABLE test_schema.events (
+  id integer NOT NULL,
+  region text NOT NULL,
+  created_on date NOT NULL
+) PARTITION BY LIST (region);
+
+CREATE TABLE test_schema.events_us PARTITION OF test_schema.events
+  FOR VALUES IN ('us')
+  PARTITION BY RANGE (created_on);
+
+CREATE TABLE test_schema.events_us_2024 PARTITION OF test_schema.events_us
+  FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');

--- a/packages/pg-delta/corpus/type-ops--enum-replace-array-column/a.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-replace-array-column/a.sql
@@ -1,0 +1,10 @@
+CREATE SCHEMA test_schema;
+
+-- Enum with 6 values
+CREATE TYPE test_schema.priority AS ENUM ('low', 'medium', 'high', 'critical', 'urgent', 'blocked');
+
+CREATE TABLE test_schema.tasks (
+  id integer PRIMARY KEY,
+  priority test_schema.priority,
+  tags test_schema.priority[]
+);

--- a/packages/pg-delta/corpus/type-ops--enum-replace-array-column/b.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-replace-array-column/b.sql
@@ -1,0 +1,10 @@
+CREATE SCHEMA test_schema;
+
+-- Enum with 4 values (urgent and blocked removed) — forces the rebuild path
+CREATE TYPE test_schema.priority AS ENUM ('low', 'medium', 'high', 'critical');
+
+CREATE TABLE test_schema.tasks (
+  id integer PRIMARY KEY,
+  priority test_schema.priority,
+  tags test_schema.priority[]
+);

--- a/packages/pg-delta/corpus/type-ops--enum-replace-array-column/seed.sql
+++ b/packages/pg-delta/corpus/type-ops--enum-replace-array-column/seed.sql
@@ -1,0 +1,2 @@
+INSERT INTO test_schema.tasks (id, priority, tags) VALUES
+  (1, 'high', ARRAY['high', 'critical']::test_schema.priority[]);

--- a/packages/pg-delta/src/plan/phases/action-emitter.ts
+++ b/packages/pg-delta/src/plan/phases/action-emitter.ts
@@ -22,7 +22,7 @@ import { lockClassFor } from "../locks.ts";
 import type { Action } from "../plan.ts";
 import { grantTarget, qid } from "../render.ts";
 import { subtreeIds } from "../renames.ts";
-import { ruleFlag } from "../rule-flags.ts";
+import { cascadesToChildren, ruleFlag } from "../rule-flags.ts";
 import { ownerEdgeKey } from "../role-rename-carry.ts";
 import { type ActionSpec, type PlanParams, type RulesForId } from "../rules.ts";
 import type { ChangedRoleFact } from "./change-set.ts";
@@ -206,20 +206,37 @@ export function emitActions(input: ActionEmitterInput): ActionEmitterOutput {
     // the replacement is rendered from the PROJECTED plan target, so a filtered
     // attribute change or child fact is not baked into the recreated SQL (P1 #1)
     const newFact = projectedDesired.getByEncoded(key) as Fact;
-    // old descendants die with the drop
-    const oldDescendants: StableId[] = [oldFact.id];
-    const walkOld = (id: StableId): void => {
-      for (const child of source.childrenOf(id)) {
-        oldDescendants.push(child.id);
-        walkOld(child.id);
-      }
+    // The old subtree dies with the replace. A child folds into its parent's
+    // DROP only when that parent's DROP CASCADES to it (DROP TABLE → its
+    // columns); a child across a NON-cascading boundary (a foreign table or user
+    // mapping under a server, whose DROP SERVER is RESTRICT) needs its OWN drop
+    // action, which the graph's child-teardown rule orders before the parent's
+    // drop. Without this the bare DROP SERVER fails on its surviving dependents.
+    const emitReplaceDrop = (rootFact: Fact): void => {
+      const destroys: StableId[] = [rootFact.id];
+      const walk = (fact: Fact): void => {
+        for (const child of source.childrenOf(fact.id)) {
+          if (cascadesToChildren(fact.id.kind)) {
+            destroys.push(child.id);
+            walk(child);
+          } else {
+            emitReplaceDrop(child);
+          }
+        }
+      };
+      walk(rootFact);
+      // A non-root (boundary) child drop must NOT consume its parent: the parent
+      // is re-created in this same plan, so consuming it would order the child
+      // drop AFTER the parent's re-create. Its ordering before the parent drop
+      // comes from the child-teardown rule (source parent → parentDestroyer).
+      const isRoot = encodeId(rootFact.id) === key;
+      pushAction("drop", rulesForId(rootFact.id).drop(rootFact), {
+        consumes:
+          isRoot && rootFact.parent !== undefined ? [rootFact.parent] : [],
+        destroys,
+      });
     };
-    walkOld(oldFact.id);
-    const dropSpec = rulesForId(oldFact.id).drop(oldFact);
-    pushAction("drop", dropSpec, {
-      consumes: oldFact.parent !== undefined ? [oldFact.parent] : [],
-      destroys: oldDescendants,
-    });
+    emitReplaceDrop(oldFact);
     emitCreate(newFact, projectedDesired);
     // recreate surviving descendants from the PROJECTED plan target (satellites,
     // sub-facts). Descendants with their own attribute deltas are covered: the

--- a/packages/pg-delta/src/plan/phases/replacement-expansion.ts
+++ b/packages/pg-delta/src/plan/phases/replacement-expansion.ts
@@ -64,6 +64,12 @@ export function expandReplacements(
         replaceIds.add(key);
         continue;
       }
+      // a transition with no in-place ALTER grammar routes the whole fact to
+      // replace (drop + recreate) — its `alter` is never rendered.
+      if (attrRule.replaceWhen?.(s.from, s.to, fact)) {
+        replaceIds.add(key);
+        continue;
+      }
       const rebuild = attrRule.rebuildsDependents?.(s.from, s.to);
       if (rebuild === true) rebuildSeeds.set(key, null);
       else if (Array.isArray(rebuild)) rebuildSeeds.set(key, new Set(rebuild));

--- a/packages/pg-delta/src/plan/render.ts
+++ b/packages/pg-delta/src/plan/render.ts
@@ -56,7 +56,10 @@ export function commentTarget(
     case "procedure":
       return `PROCEDURE ${routineSig(id)}`;
     case "aggregate":
-      return `AGGREGATE ${routineSig(id)}`;
+      // A zero-argument aggregate's signature is `(*)`, not `()` — PostgreSQL
+      // requires COMMENT ON / SECURITY LABEL ON AGGREGATE name(*). Ordered-set
+      // args (id.args non-empty) render as the plain list, like `aggSig`.
+      return `AGGREGATE ${rel(id.schema, id.name)}(${id.args.length > 0 ? id.args.join(", ") : "*"})`;
     case "extension":
       return `EXTENSION ${qid(id.name)}`;
     case "role":

--- a/packages/pg-delta/src/plan/rules.ts
+++ b/packages/pg-delta/src/plan/rules.ts
@@ -85,6 +85,16 @@ export type AttributeRule =
         from: PayloadValue,
         to: PayloadValue,
       ) => boolean | readonly string[];
+      /** When a specific transition has no in-place ALTER grammar, route the
+       *  WHOLE fact to replace (drop + recreate) instead of emitting `alter` —
+       *  e.g. unsetting a foreign server VERSION, or SET SCHEMA on a
+       *  non-relocatable extension. Evaluated during replacement classification;
+       *  the fact is then dropped + recreated (its `alter` never runs). */
+      replaceWhen?: (
+        from: PayloadValue,
+        to: PayloadValue,
+        fact: Fact,
+      ) => boolean;
     }
   | "replace";
 

--- a/packages/pg-delta/src/plan/rules/constraint-validated.test.ts
+++ b/packages/pg-delta/src/plan/rules/constraint-validated.test.ts
@@ -56,7 +56,9 @@ describe("constraint validated: true -> false", () => {
       throw new Error("validated must be an alter rule");
     const fact = conFact(false);
     const view = buildFactBase([schemaFact, tableFact, fact], []);
-    expect(() => validatedRule.alter(fact, true, false, view, view)).not.toThrow();
+    expect(() =>
+      validatedRule.alter(fact, true, false, view, view),
+    ).not.toThrow();
     const spec = validatedRule.alter(fact, true, false, view, view);
     const sql = Array.isArray(spec) ? spec.map((s) => s.sql) : [spec.sql];
     expect(sql).toEqual([

--- a/packages/pg-delta/src/plan/rules/constraint-validated.test.ts
+++ b/packages/pg-delta/src/plan/rules/constraint-validated.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Constraint `validated` true → false (VALIDATED → NOT VALID).
+ *
+ * On a real Postgres round-trip, `pg_get_constraintdef()` bakes the
+ * `NOT VALID` suffix into the `def` text itself for CHECK/FK constraints, so
+ * `def` (unconditionally "replace") always changes in lockstep with
+ * `validated` and the fact is replaced wholesale — this specific transition
+ * is unreachable via the corpus. This unit test isolates the `validated`
+ * attribute rule directly (same `def` text on both sides, only the boolean
+ * flips) to exercise the code path a hand-built FactBase — or a future
+ * constraint kind/PG version whose def doesn't encode NOT VALID — could
+ * still reach. Pure — no DB.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../../core/fact.ts";
+import type { StableId } from "../../core/stable-id.ts";
+import { constraintRules } from "./constraints.ts";
+
+const schemaFact: Fact = { id: { kind: "schema", name: "app" }, payload: {} };
+const tableFact: Fact = {
+  id: { kind: "table", schema: "app", name: "items" },
+  parent: { kind: "schema", name: "app" },
+  payload: { owner: "test", persistence: "p" },
+};
+const conId: StableId = {
+  kind: "constraint",
+  schema: "app",
+  table: "items",
+  name: "items_order_id_fkey",
+};
+const def = `FOREIGN KEY (order_id) REFERENCES app.orders(id)`;
+
+const conFact = (validated: boolean): Fact => ({
+  id: conId,
+  parent: { kind: "table", schema: "app", name: "items" },
+  payload: { def, type: "f", validated },
+});
+
+describe("constraint validated: true -> false", () => {
+  test("false -> true still renders VALIDATE CONSTRAINT", () => {
+    const validatedRule = constraintRules.constraint!.attributes["validated"];
+    if (typeof validatedRule !== "object")
+      throw new Error("validated must be an alter rule");
+    const fact = conFact(true);
+    const view = buildFactBase([schemaFact, tableFact, fact], []);
+    const spec = validatedRule.alter(fact, false, true, view, view);
+    const sql = Array.isArray(spec) ? spec.map((s) => s.sql) : [spec.sql];
+    expect(sql).toEqual([
+      `ALTER TABLE "app"."items" VALIDATE CONSTRAINT "items_order_id_fkey"`,
+    ]);
+  });
+
+  test("true -> false does not throw — replaces via DROP + ADD ... NOT VALID", () => {
+    const validatedRule = constraintRules.constraint!.attributes["validated"];
+    if (typeof validatedRule !== "object")
+      throw new Error("validated must be an alter rule");
+    const fact = conFact(false);
+    const view = buildFactBase([schemaFact, tableFact, fact], []);
+    expect(() => validatedRule.alter(fact, true, false, view, view)).not.toThrow();
+    const spec = validatedRule.alter(fact, true, false, view, view);
+    const sql = Array.isArray(spec) ? spec.map((s) => s.sql) : [spec.sql];
+    expect(sql).toEqual([
+      `ALTER TABLE "app"."items" DROP CONSTRAINT "items_order_id_fkey"`,
+      `ALTER TABLE "app"."items" ADD CONSTRAINT "items_order_id_fkey" FOREIGN KEY (order_id) REFERENCES app.orders(id) NOT VALID`,
+    ]);
+  });
+});

--- a/packages/pg-delta/src/plan/rules/constraints.ts
+++ b/packages/pg-delta/src/plan/rules/constraints.ts
@@ -62,10 +62,30 @@ export const constraintRules: Record<string, KindRules> = {
       validated: {
         alter: (fact, _from, to) => {
           const id = fact.id as { schema: string; table: string; name: string };
-          if (!to)
-            throw new Error("constraint cannot be de-validated in place");
+          const target = constraintTarget(fact);
+          if (!to) {
+            // VALIDATED → NOT VALID: PostgreSQL has no ALTER form to
+            // de-validate a constraint in place — only ADD CONSTRAINT …
+            // NOT VALID accepts it. Replace the constraint itself (drop +
+            // re-add), mirroring create()'s NOT VALID suffixing (defensive
+            // guard against a def that already carries the text).
+            const defText = str(p(fact, "def"));
+            const addSql =
+              !defText.includes("NOT VALID")
+                ? `${defText} NOT VALID`
+                : defText;
+            return [
+              { sql: `${target} DROP CONSTRAINT ${qid(id.name)}` },
+              {
+                sql: `${target} ADD CONSTRAINT ${qid(id.name)} ${addSql}`,
+                ...(p(fact, "type") === "f"
+                  ? { lockClass: "shareRowExclusive" as const }
+                  : {}),
+              },
+            ];
+          }
           return {
-            sql: `${constraintTarget(fact)} VALIDATE CONSTRAINT ${qid(id.name)}`,
+            sql: `${target} VALIDATE CONSTRAINT ${qid(id.name)}`,
             lockClass: "shareUpdateExclusive",
           };
         },

--- a/packages/pg-delta/src/plan/rules/constraints.ts
+++ b/packages/pg-delta/src/plan/rules/constraints.ts
@@ -70,10 +70,9 @@ export const constraintRules: Record<string, KindRules> = {
             // re-add), mirroring create()'s NOT VALID suffixing (defensive
             // guard against a def that already carries the text).
             const defText = str(p(fact, "def"));
-            const addSql =
-              !defText.includes("NOT VALID")
-                ? `${defText} NOT VALID`
-                : defText;
+            const addSql = !defText.includes("NOT VALID")
+              ? `${defText} NOT VALID`
+              : defText;
             return [
               { sql: `${target} DROP CONSTRAINT ${qid(id.name)}` },
               {

--- a/packages/pg-delta/src/plan/rules/foreign.ts
+++ b/packages/pg-delta/src/plan/rules/foreign.ts
@@ -68,6 +68,9 @@ export const foreignRules: Record<string, KindRules> = {
         alter: (fact, _from, to) => ({
           sql: `ALTER SERVER ${qid((fact.id as { name: string }).name)} VERSION ${lit(str(to))}`,
         }),
+        // PostgreSQL has no ALTER SERVER grammar to UNSET a version, so removing
+        // it (to == null) forces a drop + recreate of the server.
+        replaceWhen: (_from, to) => to == null,
       },
       options: {
         alter: (fact, from, to) => ({

--- a/packages/pg-delta/src/plan/rules/schemas.ts
+++ b/packages/pg-delta/src/plan/rules/schemas.ts
@@ -84,6 +84,10 @@ export const schemaRules: Record<string, KindRules> = {
           consumes: [{ kind: "schema", name: str(to) }],
           releases: [{ kind: "schema", name: str(from) }],
         }),
+        // A non-relocatable extension rejects SET SCHEMA, so relocating it must
+        // be a drop + recreate in the new schema (its create rule emits the
+        // `SCHEMA <s>` clause). The relocatable flag is extracted per extension.
+        replaceWhen: (_from, _to, fact) => p(fact, "relocatable") === false,
       },
     },
   },

--- a/packages/pg-delta/src/plan/rules/tables.ts
+++ b/packages/pg-delta/src/plan/rules/tables.ts
@@ -46,6 +46,10 @@ export const tableRules: Record<string, KindRules> = {
       if (bound != null && parentT != null) {
         // a partition: columns are inherited, the bound carries the shape
         createSql = `CREATE ${unlogged}TABLE ${relName} PARTITION OF ${rel(parentT.schema, parentT.name)} ${str(bound)}`;
+        // a partition may itself be partitioned (multi-level partitioning): keep
+        // its own PARTITION BY so sub-partitions can attach — otherwise the
+        // middle layer is created as a plain table and its leaves fail to attach.
+        if (partKey != null) createSql += ` PARTITION BY ${str(partKey)}`;
         consumes.push({
           kind: "table",
           schema: parentT.schema,

--- a/packages/pg-delta/src/plan/rules/types.ts
+++ b/packages/pg-delta/src/plan/rules/types.ts
@@ -291,8 +291,25 @@ export const typeRules: Record<string, KindRules> = {
                 : 1,
             );
           for (const col of dependentColumns) {
+            // The column's declared type (format_type() output, captured
+            // verbatim at extract time — structured catalog data, not parsed
+            // SQL) tells whether it is an ARRAY of this enum: format_type
+            // renders an array type with a trailing `[]`. A scalar column
+            // casts through `text`; an array column must cast through
+            // `text[]` (element-wise) — `col::text` on an array has no
+            // built-in cast to the scalar enum and either errors
+            // ("invalid input value for enum ... {a,b}") or, worse, silently
+            // narrows the column to scalar.
+            const colFact = view.get(col);
+            const colType =
+              colFact !== undefined ? str(p(colFact, "type")) : "";
+            const isArray = colType.endsWith("[]");
+            const targetType = isArray ? `${relName}[]` : relName;
+            const usingCast = isArray
+              ? `${qid(col.name)}::text[]::${relName}[]`
+              : `${qid(col.name)}::text::${relName}`;
             specs.push({
-              sql: `ALTER TABLE ${rel(col.schema, col.table)} ALTER COLUMN ${qid(col.name)} TYPE ${relName} USING ${qid(col.name)}::text::${relName}`,
+              sql: `ALTER TABLE ${rel(col.schema, col.table)} ALTER COLUMN ${qid(col.name)} TYPE ${targetType} USING ${usingCast}`,
               // reference the rewritten column so the proof's rewrite
               // attribution maps this action to its table (the action's
               // primary subject is the type, not the table it rewrites)

--- a/packages/pg-delta/src/plan/rules/types.ts
+++ b/packages/pg-delta/src/plan/rules/types.ts
@@ -21,9 +21,34 @@ export const typeRules: Record<string, KindRules> = {
       const id = fact.id as { schema: string; name: string };
       return `ALTER DOMAIN ${rel(id.schema, id.name)}`;
     }),
-    create: (fact, view) => {
+    create: (fact, view, _params, sourceView) => {
       const id = fact.id as { schema: string; name: string };
-      let sql = `CREATE DOMAIN ${rel(id.schema, id.name)} AS ${str(p(fact, "baseType"))}`;
+      const relName = rel(id.schema, id.name);
+      // GUARD (baseType/collation replace): both attributes are "replace", so
+      // any change drops and recreates the domain. A table column is NOT a
+      // rebuildable kind, so if a SURVIVING user column depends on this domain
+      // PostgreSQL rejects the DROP at apply ("cannot drop type … other
+      // objects depend on it"). Fail loud at plan time — mirrors the in-use
+      // range-type guard above (§ type rule) and the in-use composite ALTER
+      // ATTRIBUTE guard below. Only a REPLACE (the domain is present in the
+      // source) can hit this; a fresh create brings its columns with it.
+      if (sourceView?.get(fact.id) !== undefined) {
+        const inUse = compositeUserColumns(view, fact.id).filter(
+          (colId) => sourceView.get(colId) !== undefined,
+        );
+        if (inUse.length > 0) {
+          const cols = inUse
+            .map((c) => {
+              const col = c as { schema: string; table: string; name: string };
+              return `${rel(col.schema, col.table)}.${qid(col.name)}`;
+            })
+            .join(", ");
+          throw new Error(
+            `domain ${relName}: cannot replace an in-use domain — column(s) ${cols} depend on it, and PostgreSQL forbids dropping a type while a column uses it. Replacing an in-use domain is not supported yet; drop the using column(s), or recreate the domain, first.`,
+          );
+        }
+      }
+      let sql = `CREATE DOMAIN ${relName} AS ${str(p(fact, "baseType"))}`;
       const collation = p(fact, "collation");
       if (collation != null) sql += ` COLLATE ${str(collation)}`;
       const def = p(fact, "default");

--- a/packages/pg-delta/tests/domain-in-use-guard.test.ts
+++ b/packages/pg-delta/tests/domain-in-use-guard.test.ts
@@ -1,0 +1,47 @@
+/**
+ * A domain's `baseType`/`collation` attributes are "replace" (drop+create),
+ * so any change drops and recreates the domain. A table COLUMN is not a
+ * rebuildable kind, so if a surviving user column depends on the domain
+ * PostgreSQL rejects the DROP at apply time ("cannot drop type … other
+ * objects depend on it"). The planner must fail LOUD at plan time instead of
+ * emitting a plan that crashes at apply — mirroring the in-use range-type
+ * guard. Full in-place column migration for domains is tracked separately.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { extract } from "../src/extract/extract.ts";
+import { plan } from "../src/plan/plan.ts";
+import { createTestDb, type TestDb } from "./containers.ts";
+
+let dbA: TestDb;
+let dbB: TestDb;
+
+beforeAll(async () => {
+  dbA = await createTestDb("domain-a");
+  dbB = await createTestDb("domain-b");
+  // A: domain over integer, used by a surviving table column.
+  await dbA.pool.query(`
+    CREATE SCHEMA app;
+    CREATE DOMAIN app.d AS integer;
+    CREATE TABLE app.bookings (id integer PRIMARY KEY, span app.d);
+  `);
+  // B: same names, but the domain's base type changed to bigint — a
+  // "replace" of the domain while the app.bookings.span column still uses it.
+  await dbB.pool.query(`
+    CREATE SCHEMA app;
+    CREATE DOMAIN app.d AS bigint;
+    CREATE TABLE app.bookings (id integer PRIMARY KEY, span app.d);
+  `);
+}, 120_000);
+
+afterAll(async () => {
+  await Promise.all([dbA.drop(), dbB.drop()]);
+});
+
+describe("domain replace while in use", () => {
+  test("throws a clear plan-time error when a surviving column depends on the domain", async () => {
+    const [a, b] = [await extract(dbA.pool), await extract(dbB.pool)];
+    expect(() => plan(a.factBase, b.factBase)).toThrow(
+      /in-use domain|domain .* cannot .* replace|depend on it/i,
+    );
+  });
+});


### PR DESCRIPTION
Second of three PRs working through the plan/apply correctness backlog in #333 (apply/plan-failure cluster: items 3, 5, 6, 7, 8, 9, 10, 11). Refs #333. **Stacked on #334** — review only the commits above its base.

## What's fixed

- **Item 5 — domain replace with in-use columns:** `baseType`/`collation` changes now hit the same in-use guard range types already had — planning throws a clear error naming the domain and dependent columns instead of emitting a `DROP DOMAIN` Postgres rejects.
- **Item 6 — enum value-set rebuild vs `enum[]` columns:** the dependent-column migration reads the column's `format_type()` payload and casts arrays via `::text[]::<enum>[]` instead of the scalar `::text::<enum>`.
- **Item 7 — subpartitioned partitions:** the partition-create branch now appends the partition's own `PARTITION BY`, so multilevel partitioning converges.
- **Item 8 — `validated → NOT VALID`:** routes through replace (`DROP CONSTRAINT` + `ADD … NOT VALID`) instead of throwing. Honest caveat: unreachable via real round-trips on current PG (the `NOT VALID` suffix is baked into `pg_get_constraintdef()`, so the `def` replace intercepts first) — proven by a plan-level unit test on hand-built facts; kept as defense in depth plus a supplementary `not-valid--fk-validate-drift` corpus scenario.
- **Item 9 — removing foreign-server `VERSION`:** no ALTER grammar exists for unsetting it; the transition now routes to replace instead of crashing planning on `str(null)`.
- **Item 10 — `SET SCHEMA` on non-relocatable extensions:** the rule now respects the extracted `relocatable` flag and replaces (drop + recreate in the new schema) when Postgres would reject the ALTER.
- **Item 11 — zero-arg aggregate metadata targets:** `COMMENT ON AGGREGATE` / security labels render `name(*)` instead of the invalid `name()`.
- **Item 3 (was UNSURE — reproduced):** replacing a foreign server with children failed on RESTRICT `DROP SERVER`. The prescribed rebuildable-flag fix was demonstrably insufficient (parent links aren't dependency edges); the real fix makes the replace machinery respect cascade boundaries — children across a non-cascading boundary (foreign tables / user mappings under a server) get their own DROP ordered before the parent's.

Two small planner mechanisms were introduced: a `replaceWhen` predicate on alter attribute rules ("this transition has no ALTER grammar → replace the fact") used by items 9/10, and the cascade-boundary walk in the replace-drop path for item 3.

## Test evidence (RED → GREEN)

RED excerpts live in the fix commit bodies; highlights:
- item 5: plan emitted `DROP DOMAIN` with a dependent column → now throws `cannot replace an in-use domain — column(s) "app"."bookings"."span" depend on it`
- item 6: `invalid input value for enum test_schema.priority: "{high,critical}"`
- item 7: `"events_us" is not partitioned`
- item 9: `expected a scalar, got null`
- item 10: `extension "xml2" does not support SET SCHEMA`
- item 11: `syntax error at or near ")"`
- item 3: `cannot drop server … because other objects depend on it`

New corpus scenarios: `type-ops--enum-replace-array-column`, `not-valid--fk-validate-drift`, plus five FDW/extension/partition/aggregate scenarios from the RED commits.

## Validation

- Unit suite: 691 pass / 0 fail
- Full corpus (postgres:17-alpine): 624/624 pass
- `format-and-lint` + `check-types`: clean
- Changesets included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
