### PR TITLE
fix(pg-delta): allow catalog extraction as a non-superuser role

### DIFF
--- a/.changeset/non-superuser-extraction.md
+++ b/.changeset/non-superuser-extraction.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): allow catalog extraction as a non-superuser role
+
+Extraction previously SELECTed from `pg_catalog.pg_user_mapping` (superuser-only), so any non-superuser connection — e.g. the `postgres` role on Supabase hosted projects — failed with `permission denied for table pg_user_mapping` (42501). User mappings are now read from the world-readable `pg_user_mappings` view; option values hidden from unprivileged readers degrade to an empty option list instead of erroring. The subscription extractor similarly stops selecting the superuser-only `pg_subscription.subconninfo` column unless the reader has privilege, degrading to the existing redacted-conninfo placeholder. Fixes supabase/cli#5826.

--- a/packages/pg-delta/src/core/catalog.model.ts
+++ b/packages/pg-delta/src/core/catalog.model.ts
@@ -64,6 +64,7 @@ import {
 import {
   extractSubscriptions,
   Subscription,
+  SUBSCRIPTION_CONNINFO_PLACEHOLDER,
 } from "./objects/subscription/subscription.model.ts";
 import { extractTables, type Table } from "./objects/table/table.model.ts";
 import {
@@ -77,9 +78,6 @@ import {
 import { type Enum, extractEnums } from "./objects/type/enum/enum.model.ts";
 import { extractRanges, type Range } from "./objects/type/range/range.model.ts";
 import { extractViews, type View } from "./objects/view/view.model.ts";
-
-const SUBSCRIPTION_CONNINFO_PLACEHOLDER =
-  "host=__CONN_HOST__ port=__CONN_PORT__ dbname=__CONN_DBNAME__ user=__CONN_USER__ password=__CONN_PASSWORD__";
 
 interface CatalogProps {
   aggregates: Record<string, Aggregate>;

--- a/packages/pg-delta/src/core/depend.ts
+++ b/packages/pg-delta/src/core/depend.ts
@@ -802,13 +802,13 @@ export async function extractDepends(pool: Pool): Promise<PgDepend[]> {
 
     UNION ALL
     /* User Mappings */
-    SELECT 'pg_user_mapping'::regclass, um.oid, 0::int2,
+    SELECT 'pg_user_mapping'::regclass, um.umid, 0::int2,
           NULL::text,
           format('userMapping:%I:%s', srv.srvname, CASE WHEN um.umuser = 0 THEN 'PUBLIC' ELSE um.umuser::regrole::text END)
-    FROM pg_user_mapping um
-    JOIN pg_foreign_server srv ON srv.oid = um.umserver
+    FROM pg_user_mappings um
+    JOIN pg_foreign_server srv ON srv.oid = um.srvid
     JOIN pg_foreign_data_wrapper fdw ON fdw.oid = srv.srvfdw
-    JOIN ids i ON i.classid = 'pg_user_mapping'::regclass AND i.objid = um.oid AND COALESCE(i.objsubid,0) = 0
+    JOIN ids i ON i.classid = 'pg_user_mapping'::regclass AND i.objid = um.umid AND COALESCE(i.objsubid,0) = 0
     WHERE NOT fdw.fdwname LIKE ANY (ARRAY['pg\\_%'])
   ),
   base AS (
@@ -1800,8 +1800,8 @@ export async function extractDepends(pool: Pool): Promise<PgDepend[]> {
       'n'::"char" AS deptype,
       NULL::text AS dep_schema,
       NULL::text AS ref_schema
-    FROM pg_user_mapping um
-    JOIN pg_foreign_server srv ON srv.oid = um.umserver
+    FROM pg_user_mappings um
+    JOIN pg_foreign_server srv ON srv.oid = um.srvid
     JOIN pg_foreign_data_wrapper fdw ON fdw.oid = srv.srvfdw
     WHERE NOT fdw.fdwname LIKE ANY (ARRAY['pg\\_%'])
 

--- a/packages/pg-delta/src/core/objects/foreign-data-wrapper/user-mapping/user-mapping.model.ts
+++ b/packages/pg-delta/src/core/objects/foreign-data-wrapper/user-mapping/user-mapping.model.ts
@@ -64,13 +64,20 @@ export class UserMapping extends BasePgModel {
 }
 
 /**
- * Extract `pg_user_mapping` rows into `UserMapping` models.
+ * Extract user mappings into `UserMapping` models.
  *
- * The returned models carry option values **verbatim** from
- * `pg_user_mapping.umoptions`, which means cleartext secrets like
- * `password` are present in memory. Always route through
- * `extractCatalog` (which calls `normalizeCatalog`) before emitting
- * options to any output channel — see CLI-1467 and
+ * Reads from the world-readable `pg_catalog.pg_user_mappings` system view
+ * instead of the superuser-only `pg_catalog.pg_user_mapping` catalog, so
+ * non-superuser roles (e.g. the `postgres` role on Supabase hosted projects)
+ * can extract a catalog — see supabase/cli#5826 / CLI-1919. The view exposes
+ * `umoptions` only to privileged readers (superuser, the server owner, or the
+ * mapped user with USAGE on the server); for anyone else it returns NULL, which
+ * we deliberately degrade to an empty option list rather than erroring.
+ *
+ * When options **are** visible, the returned models carry them **verbatim**,
+ * which means cleartext secrets like `password` are present in memory. Always
+ * route through `extractCatalog` (which calls `normalizeCatalog`) before
+ * emitting options to any output channel — see CLI-1467 and
  * `packages/pg-delta/src/core/objects/foreign-data-wrapper/sensitive-options.ts`.
  */
 export async function extractUserMappings(pool: Pool): Promise<UserMapping[]> {
@@ -91,8 +98,8 @@ export async function extractUserMappings(pool: Pool): Promise<UserMapping[]> {
           else p_validator.pronamespace::regnamespace::text || '.' || quote_ident(p_validator.proname)
         end as wrapper_validator
       from
-        pg_catalog.pg_user_mapping um
-        inner join pg_catalog.pg_foreign_server srv on srv.oid = um.umserver
+        pg_catalog.pg_user_mappings um
+        inner join pg_catalog.pg_foreign_server srv on srv.oid = um.srvid
         inner join pg_catalog.pg_foreign_data_wrapper fdw on fdw.oid = srv.srvfdw
         left join pg_catalog.pg_proc p_handler on p_handler.oid = fdw.fdwhandler
         left join pg_catalog.pg_proc p_validator on p_validator.oid = fdw.fdwvalidator

--- a/packages/pg-delta/src/core/objects/subscription/subscription.model.ts
+++ b/packages/pg-delta/src/core/objects/subscription/subscription.model.ts
@@ -7,6 +7,22 @@ import {
   securityLabelPropsSchema,
 } from "../security-label.types.ts";
 
+/**
+ * Placeholder used in place of a subscription's real `subconninfo`.
+ *
+ * `normalizeCatalog` unconditionally replaces every subscription's conninfo
+ * with this value, so real connection strings (which carry credentials) never
+ * reach output. It is also substituted at extraction time when the connected
+ * role lacks SELECT on the superuser-only `pg_subscription.subconninfo`
+ * column, so non-superuser extraction does not fail — see supabase/cli#5826.
+ *
+ * Lives here (a leaf module) rather than in `catalog.model.ts` because
+ * `catalog.model.ts` imports from this file; importing the other direction
+ * would create a cycle.
+ */
+export const SUBSCRIPTION_CONNINFO_PLACEHOLDER =
+  "host=__CONN_HOST__ port=__CONN_PORT__ dbname=__CONN_DBNAME__ user=__CONN_USER__ password=__CONN_PASSWORD__";
+
 const subscriptionPropsSchema = z.object({
   name: z.string(),
   raw_name: z.string(),
@@ -135,6 +151,32 @@ export async function extractSubscriptions(
     ? "case s.suborigin when 'none' then 'none' else 'any' end"
     : "'any'";
 
+  // `subconninfo` has SELECT revoked from PUBLIC on every supported PG version,
+  // so a bare `select s.*` fails for non-superusers even with zero
+  // subscriptions. Select only the PUBLIC-granted columns explicitly.
+  const versionGatedColumns = [
+    isPostgres16OrGreater ? "s.subpasswordrequired" : null,
+    isPostgres17OrGreater ? "s.subrunasowner" : null,
+    isPostgres17_2OrGreater ? "s.subfailover" : null,
+    isPostgres17_3OrGreater ? "s.suborigin" : null,
+  ]
+    .filter((c): c is string => c !== null)
+    .map((c) => `        ${c},\n`)
+    .join("");
+
+  // Column privileges are checked at plan time for every column a query
+  // references, even inside a CASE branch that never executes — so we cannot
+  // guard `subconninfo` inline. Probe the privilege first and only reference
+  // the column when the reader can see it, otherwise substitute the redacted
+  // placeholder (which `normalizeCatalog` would apply anyway) so non-superuser
+  // extraction does not fail — see supabase/cli#5826.
+  const { rows: privRows } = await pool.query<{ has_conninfo: boolean }>(
+    "select has_column_privilege('pg_catalog.pg_subscription', 'subconninfo', 'SELECT') as has_conninfo",
+  );
+  const conninfoExpr = privRows[0]?.has_conninfo
+    ? "s.subconninfo"
+    : `'${SUBSCRIPTION_CONNINFO_PLACEHOLDER}'`;
+
   const queryText = `
       with extension_oids as (
         select objid
@@ -143,7 +185,20 @@ export async function extractSubscriptions(
           and d.classid = 'pg_subscription'::regclass
       ),
       scoped_subscriptions as (
-        select s.*
+        select
+          s.oid,
+          s.subdbid,
+          s.subname,
+          s.subowner,
+          s.subenabled,
+          s.subbinary,
+          s.substream,
+          s.subtwophasestate,
+          s.subdisableonerr,
+          s.subslotname,
+          s.subsynccommit,
+          s.subpublications,
+${versionGatedColumns}          ${conninfoExpr} as subconninfo
         from pg_subscription s
         where s.subdbid = (select oid from pg_database where datname = current_database())
       )

--- a/packages/pg-delta/tests/integration/non-superuser-extraction.test.ts
+++ b/packages/pg-delta/tests/integration/non-superuser-extraction.test.ts
@@ -24,120 +24,114 @@ import {
 
 for (const pgVersion of POSTGRES_VERSIONS) {
   describe(`non-superuser extraction (pg${pgVersion})`, () => {
-    test(
-      "non-superuser role can extract a catalog containing user mappings and subscriptions",
-      async () => {
-        const image = await buildPostgresTestImage(pgVersion);
-        const [containerMain, containerBranch] = await Promise.all([
-          new PostgresAlpineContainer(image).start(),
-          new PostgresAlpineContainer(image).start(),
-        ]);
-        const mainUri = containerMain.getConnectionUri();
-        const branchUri = containerBranch.getConnectionUri();
+    test("non-superuser role can extract a catalog containing user mappings and subscriptions", async () => {
+      const image = await buildPostgresTestImage(pgVersion);
+      const [containerMain, containerBranch] = await Promise.all([
+        new PostgresAlpineContainer(image).start(),
+        new PostgresAlpineContainer(image).start(),
+      ]);
+      const mainUri = containerMain.getConnectionUri();
+      const branchUri = containerBranch.getConnectionUri();
 
-        // Admin pools (default superuser) to set up the fixtures.
-        const mainAdmin = createPool(mainUri);
-        const branchAdmin = createPool(branchUri);
+      // Admin pools (default superuser) to set up the fixtures.
+      const mainAdmin = createPool(mainUri);
+      const branchAdmin = createPool(branchUri);
 
-        try {
-          // Isolated containers don't share roles: create on both sides.
-          await mainAdmin.query(
+      try {
+        // Isolated containers don't share roles: create on both sides.
+        await mainAdmin.query(
+          "CREATE ROLE pgdelta_nosuper WITH NOLOGIN NOSUPERUSER;",
+        );
+        await branchAdmin.query(
+          "CREATE ROLE pgdelta_nosuper WITH NOLOGIN NOSUPERUSER;",
+        );
+
+        // Branch has the objects the non-superuser reader must be able to see.
+        await branchAdmin.query("CREATE FOREIGN DATA WRAPPER test_fdw;");
+        await branchAdmin.query(
+          "CREATE SERVER test_server FOREIGN DATA WRAPPER test_fdw;",
+        );
+        await branchAdmin.query(
+          "CREATE USER MAPPING FOR PUBLIC SERVER test_server OPTIONS (user 'remote_user', password 'secret');",
+        );
+        await branchAdmin.query(
+          "CREATE SUBSCRIPTION test_sub CONNECTION 'host=example.invalid dbname=x' PUBLICATION test_pub WITH (connect = false, slot_name = NONE, enabled = false, create_slot = false);",
+        );
+
+        const result = await createPlan(mainUri, branchUri, {
+          role: "pgdelta_nosuper",
+        });
+
+        expect(result).not.toBeNull();
+        const statements = flattenPlanStatements(result!.plan);
+
+        // User mapping is created with NO options (unprivileged reader cannot
+        // see umoptions, so they degrade to an empty option list).
+        const userMappingStatement = statements.find((s) =>
+          s.includes("CREATE USER MAPPING FOR PUBLIC SERVER test_server"),
+        );
+        expect(userMappingStatement).toBeDefined();
+        expect(userMappingStatement).not.toContain("OPTIONS");
+        expect(userMappingStatement).not.toContain("remote_user");
+        expect(userMappingStatement).not.toContain("secret");
+
+        // Subscription is created, but conninfo is the redacted placeholder.
+        const subscriptionStatement = statements.find((s) =>
+          s.includes("CREATE SUBSCRIPTION"),
+        );
+        expect(subscriptionStatement).toBeDefined();
+        expect(subscriptionStatement).not.toContain("example.invalid");
+      } finally {
+        await Promise.all([mainAdmin.end(), branchAdmin.end()]);
+        await Promise.all([containerMain.stop(), containerBranch.stop()]);
+      }
+    });
+
+    test("identical FDW state on both sides diffs clean as non-superuser", async () => {
+      const image = await buildPostgresTestImage(pgVersion);
+      const [containerMain, containerBranch] = await Promise.all([
+        new PostgresAlpineContainer(image).start(),
+        new PostgresAlpineContainer(image).start(),
+      ]);
+      const mainUri = containerMain.getConnectionUri();
+      const branchUri = containerBranch.getConnectionUri();
+
+      const mainAdmin = createPool(mainUri);
+      const branchAdmin = createPool(branchUri);
+
+      try {
+        for (const pool of [mainAdmin, branchAdmin]) {
+          await pool.query(
             "CREATE ROLE pgdelta_nosuper WITH NOLOGIN NOSUPERUSER;",
           );
-          await branchAdmin.query(
-            "CREATE ROLE pgdelta_nosuper WITH NOLOGIN NOSUPERUSER;",
-          );
-
-          // Branch has the objects the non-superuser reader must be able to see.
-          await branchAdmin.query("CREATE FOREIGN DATA WRAPPER test_fdw;");
-          await branchAdmin.query(
+          await pool.query("CREATE FOREIGN DATA WRAPPER test_fdw;");
+          await pool.query(
             "CREATE SERVER test_server FOREIGN DATA WRAPPER test_fdw;",
           );
-          await branchAdmin.query(
+          await pool.query(
             "CREATE USER MAPPING FOR PUBLIC SERVER test_server OPTIONS (user 'remote_user', password 'secret');",
           );
-          await branchAdmin.query(
-            "CREATE SUBSCRIPTION test_sub CONNECTION 'host=example.invalid dbname=x' PUBLICATION test_pub WITH (connect = false, slot_name = NONE, enabled = false, create_slot = false);",
-          );
-
-          const result = await createPlan(mainUri, branchUri, {
-            role: "pgdelta_nosuper",
-          });
-
-          expect(result).not.toBeNull();
-          const statements = flattenPlanStatements(result!.plan);
-
-          // User mapping is created with NO options (unprivileged reader cannot
-          // see umoptions, so they degrade to an empty option list).
-          const userMappingStatement = statements.find((s) =>
-            s.includes("CREATE USER MAPPING FOR PUBLIC SERVER test_server"),
-          );
-          expect(userMappingStatement).toBeDefined();
-          expect(userMappingStatement).not.toContain("OPTIONS");
-          expect(userMappingStatement).not.toContain("remote_user");
-          expect(userMappingStatement).not.toContain("secret");
-
-          // Subscription is created, but conninfo is the redacted placeholder.
-          const subscriptionStatement = statements.find((s) =>
-            s.includes("CREATE SUBSCRIPTION"),
-          );
-          expect(subscriptionStatement).toBeDefined();
-          expect(subscriptionStatement).not.toContain("example.invalid");
-        } finally {
-          await Promise.all([mainAdmin.end(), branchAdmin.end()]);
-          await Promise.all([containerMain.stop(), containerBranch.stop()]);
         }
-      },
-    );
 
-    test(
-      "identical FDW state on both sides diffs clean as non-superuser",
-      async () => {
-        const image = await buildPostgresTestImage(pgVersion);
-        const [containerMain, containerBranch] = await Promise.all([
-          new PostgresAlpineContainer(image).start(),
-          new PostgresAlpineContainer(image).start(),
-        ]);
-        const mainUri = containerMain.getConnectionUri();
-        const branchUri = containerBranch.getConnectionUri();
+        const result = await createPlan(mainUri, branchUri, {
+          role: "pgdelta_nosuper",
+        });
 
-        const mainAdmin = createPool(mainUri);
-        const branchAdmin = createPool(branchUri);
-
-        try {
-          for (const pool of [mainAdmin, branchAdmin]) {
-            await pool.query(
-              "CREATE ROLE pgdelta_nosuper WITH NOLOGIN NOSUPERUSER;",
-            );
-            await pool.query("CREATE FOREIGN DATA WRAPPER test_fdw;");
-            await pool.query(
-              "CREATE SERVER test_server FOREIGN DATA WRAPPER test_fdw;",
-            );
-            await pool.query(
-              "CREATE USER MAPPING FOR PUBLIC SERVER test_server OPTIONS (user 'remote_user', password 'secret');",
-            );
-          }
-
-          const result = await createPlan(mainUri, branchUri, {
-            role: "pgdelta_nosuper",
-          });
-
-          // Options are hidden symmetrically on both sides, so there is no
-          // spurious user-mapping/server/fdw diff.
-          const relevant = result
-            ? flattenPlanStatements(result.plan).filter(
-                (s) =>
-                  s.includes("USER MAPPING") ||
-                  s.includes("SERVER") ||
-                  s.includes("FOREIGN DATA WRAPPER"),
-              )
-            : [];
-          expect(relevant).toEqual([]);
-        } finally {
-          await Promise.all([mainAdmin.end(), branchAdmin.end()]);
-          await Promise.all([containerMain.stop(), containerBranch.stop()]);
-        }
-      },
-    );
+        // Options are hidden symmetrically on both sides, so there is no
+        // spurious user-mapping/server/fdw diff.
+        const relevant = result
+          ? flattenPlanStatements(result.plan).filter(
+              (s) =>
+                s.includes("USER MAPPING") ||
+                s.includes("SERVER") ||
+                s.includes("FOREIGN DATA WRAPPER"),
+            )
+          : [];
+        expect(relevant).toEqual([]);
+      } finally {
+        await Promise.all([mainAdmin.end(), branchAdmin.end()]);
+        await Promise.all([containerMain.stop(), containerBranch.stop()]);
+      }
+    });
   });
 }

--- a/packages/pg-delta/tests/integration/non-superuser-extraction.test.ts
+++ b/packages/pg-delta/tests/integration/non-superuser-extraction.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for non-superuser catalog extraction (supabase/cli#5826, CLI-1919).
+ *
+ * When connected as a non-superuser role (e.g. the `postgres` role on Supabase
+ * hosted projects), extraction must not SELECT from superuser-only catalogs such
+ * as `pg_user_mapping` or the `pg_subscription.subconninfo` column.
+ *
+ * The `role` option only performs `SET ROLE` on every pooled connection when
+ * `createPlan` is given connection URL strings (via `createManagedPool`) — this
+ * is exactly the Supabase CLI production path. `withDbIsolated` hands back Pool
+ * objects (which bypass `SET ROLE` during extraction), so these tests start
+ * containers directly to obtain connection URIs and drive the string path.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createPlan } from "../../src/core/plan/create.ts";
+import { flattenPlanStatements } from "../../src/core/plan/render.ts";
+import { createPool } from "../../src/core/postgres-config.ts";
+import { POSTGRES_VERSIONS } from "../constants.ts";
+import {
+  buildPostgresTestImage,
+  PostgresAlpineContainer,
+} from "../postgres-alpine.ts";
+
+for (const pgVersion of POSTGRES_VERSIONS) {
+  describe(`non-superuser extraction (pg${pgVersion})`, () => {
+    test(
+      "non-superuser role can extract a catalog containing user mappings and subscriptions",
+      async () => {
+        const image = await buildPostgresTestImage(pgVersion);
+        const [containerMain, containerBranch] = await Promise.all([
+          new PostgresAlpineContainer(image).start(),
+          new PostgresAlpineContainer(image).start(),
+        ]);
+        const mainUri = containerMain.getConnectionUri();
+        const branchUri = containerBranch.getConnectionUri();
+
+        // Admin pools (default superuser) to set up the fixtures.
+        const mainAdmin = createPool(mainUri);
+        const branchAdmin = createPool(branchUri);
+
+        try {
+          // Isolated containers don't share roles: create on both sides.
+          await mainAdmin.query(
+            "CREATE ROLE pgdelta_nosuper WITH NOLOGIN NOSUPERUSER;",
+          );
+          await branchAdmin.query(
+            "CREATE ROLE pgdelta_nosuper WITH NOLOGIN NOSUPERUSER;",
+          );
+
+          // Branch has the objects the non-superuser reader must be able to see.
+          await branchAdmin.query("CREATE FOREIGN DATA WRAPPER test_fdw;");
+          await branchAdmin.query(
+            "CREATE SERVER test_server FOREIGN DATA WRAPPER test_fdw;",
+          );
+          await branchAdmin.query(
+            "CREATE USER MAPPING FOR PUBLIC SERVER test_server OPTIONS (user 'remote_user', password 'secret');",
+          );
+          await branchAdmin.query(
+            "CREATE SUBSCRIPTION test_sub CONNECTION 'host=example.invalid dbname=x' PUBLICATION test_pub WITH (connect = false, slot_name = NONE, enabled = false, create_slot = false);",
+          );
+
+          const result = await createPlan(mainUri, branchUri, {
+            role: "pgdelta_nosuper",
+          });
+
+          expect(result).not.toBeNull();
+          const statements = flattenPlanStatements(result!.plan);
+
+          // User mapping is created with NO options (unprivileged reader cannot
+          // see umoptions, so they degrade to an empty option list).
+          const userMappingStatement = statements.find((s) =>
+            s.includes("CREATE USER MAPPING FOR PUBLIC SERVER test_server"),
+          );
+          expect(userMappingStatement).toBeDefined();
+          expect(userMappingStatement).not.toContain("OPTIONS");
+          expect(userMappingStatement).not.toContain("remote_user");
+          expect(userMappingStatement).not.toContain("secret");
+
+          // Subscription is created, but conninfo is the redacted placeholder.
+          const subscriptionStatement = statements.find((s) =>
+            s.includes("CREATE SUBSCRIPTION"),
+          );
+          expect(subscriptionStatement).toBeDefined();
+          expect(subscriptionStatement).not.toContain("example.invalid");
+        } finally {
+          await Promise.all([mainAdmin.end(), branchAdmin.end()]);
+          await Promise.all([containerMain.stop(), containerBranch.stop()]);
+        }
+      },
+    );
+
+    test(
+      "identical FDW state on both sides diffs clean as non-superuser",
+      async () => {
+        const image = await buildPostgresTestImage(pgVersion);
+        const [containerMain, containerBranch] = await Promise.all([
+          new PostgresAlpineContainer(image).start(),
+          new PostgresAlpineContainer(image).start(),
+        ]);
+        const mainUri = containerMain.getConnectionUri();
+        const branchUri = containerBranch.getConnectionUri();
+
+        const mainAdmin = createPool(mainUri);
+        const branchAdmin = createPool(branchUri);
+
+        try {
+          for (const pool of [mainAdmin, branchAdmin]) {
+            await pool.query(
+              "CREATE ROLE pgdelta_nosuper WITH NOLOGIN NOSUPERUSER;",
+            );
+            await pool.query("CREATE FOREIGN DATA WRAPPER test_fdw;");
+            await pool.query(
+              "CREATE SERVER test_server FOREIGN DATA WRAPPER test_fdw;",
+            );
+            await pool.query(
+              "CREATE USER MAPPING FOR PUBLIC SERVER test_server OPTIONS (user 'remote_user', password 'secret');",
+            );
+          }
+
+          const result = await createPlan(mainUri, branchUri, {
+            role: "pgdelta_nosuper",
+          });
+
+          // Options are hidden symmetrically on both sides, so there is no
+          // spurious user-mapping/server/fdw diff.
+          const relevant = result
+            ? flattenPlanStatements(result.plan).filter(
+                (s) =>
+                  s.includes("USER MAPPING") ||
+                  s.includes("SERVER") ||
+                  s.includes("FOREIGN DATA WRAPPER"),
+              )
+            : [];
+          expect(relevant).toEqual([]);
+        } finally {
+          await Promise.all([mainAdmin.end(), branchAdmin.end()]);
+          await Promise.all([containerMain.stop(), containerBranch.stop()]);
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Problem

pg-delta's catalog extraction SELECTs from `pg_catalog.pg_user_mapping`, which is superuser-only (SELECT revoked from PUBLIC). On Supabase hosted projects the CLI connects as `postgres` (not a superuser), so extraction fails with `permission denied for table pg_user_mapping` (SQLSTATE 42501), breaking `supabase db pull --linked` with the pg_delta engine on every hosted project. It only ever worked locally because the local CLI connects as `supabase_admin` (superuser).

Fixing that surfaced a second, latent instance of the same bug class: the subscription extractor did `select s.*` from `pg_subscription`, and the `subconninfo` column has SELECT revoked from PUBLIC on every supported PG version — `select *` requires privilege on **all** columns, so it fails unconditionally for non-superusers (even with zero subscriptions), and PostgreSQL checks column ACLs at plan time, so it can't be dodged with a `CASE` around the column reference.

Refs supabase/cli#5826 (Linear supabase/cli#5826).

## Fix

* **User mappings** are now read from the world-readable `pg_user_mappings` system view (`umid`/`srvid`/`umuser`/`umoptions`) in the extractor (`user-mapping.model.ts`) and in both `pg_depend` CTEs (`depend.ts`). The `'pg_user_mapping'::regclass` classid literals stay — regclass casts need no table privilege. Option values the view hides from unprivileged readers (`umoptions IS NULL`) degrade to an empty option list instead of erroring.
* **Subscriptions**: the extractor selects an explicit PUBLIC-granted column list instead of `s.*`, and probes `has_column_privilege('pg_catalog.pg_subscription', 'subconninfo', 'SELECT')` first — only referencing the column when readable, otherwise substituting the redacted-conninfo placeholder that `normalizeCatalog` applies unconditionally anyway (so the degrade is invisible downstream).

## RED → GREEN

Regression test (`tests/integration/non-superuser-extraction.test.ts`) runs `createPlan` over connection **URIs** with `role: pgdelta_nosuper` (a `NOSUPERUSER` role) — the same code path the Supabase CLI uses. Checked out at the test-only commit it fails with:

```
error: permission denied for table pg_user_mapping
  code: "42501"
```

and, once the user-mapping fix alone is applied, with `permission denied for table pg_subscription`. With the fix both tests pass on PG 15/17/18.

Also verified: `foreign-data-wrapper-operations` (privileged readers still extract options verbatim), `subscription-operations` (PG 15 + 17, version-gated column list), `role-option`, and the full unit suite (1149 pass).

## Follow-up (separate repo)

After this ships in a published version, the Supabase CLI must bump its pinned `npm:@supabase/pg-delta@…` version (diff/pgdelta templates + `pkg/config/pgdelta_version.go`).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)