### PR TITLE
fix(pg-delta): add pgdelta --version and schema --help

### DIFF
--- a/.changeset/pgdelta-cli-version-and-schema-help.md
+++ b/.changeset/pgdelta-cli-version-and-schema-help.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): `pgdelta --version` (and `-v`/`version`) now prints the package version instead of "Unknown command", and `pgdelta schema --help` (and `-h`/`help`) prints the schema subcommand usage to stdout and exits 0 instead of erroring with "Unknown schema subcommand".

--- a/packages/pg-delta/src/cli/main.ts
+++ b/packages/pg-delta/src/cli/main.ts
@@ -40,6 +40,7 @@
  *   Repeatable; each occurrence confirms one rename.  Available on: plan, schema apply.
  */
 
+import { readFileSync } from "node:fs";
 import { cmdPlan } from "./commands/plan.ts";
 import { cmdApply } from "./commands/apply.ts";
 import { cmdRender } from "./commands/render.ts";
@@ -131,6 +132,36 @@ Old → New mapping:
   declarative-export-> schema export
 `.trimStart();
 
+const SCHEMA_USAGE = `
+pgdelta schema <subcommand> [options]
+
+Subcommands:
+  schema export  --source <pg-url> --out-dir <dir> [--layout by-object|ordered|grouped]
+                 [--format-options <json>]   (pretty-print SQL; any layout)
+                 grouped adds: [--grouping-mode single-file|subdirectory]
+                 [--group-patterns <json>] [--flat-schemas <csv>] [--no-group-partitions]
+  schema apply   --dir <dir> --shadow <pg-url> --target <pg-url>
+                 [--renames auto|prompt|off] [--force]
+                 [--accept-rename <from>=<to>] ... [--no-reorder]
+  schema lint    --dir <dir>
+                 Statically check the SQL files (pg-topo) for shadow-load
+                 cycles and other issues, without touching a database.
+
+Run 'pgdelta --help' for the full command reference and shared flags.
+`.trimStart();
+
+/** Package version, read from the bundled package.json at runtime. */
+function readVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { version?: string };
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
 async function main(): Promise<void> {
   // Bun populates process.argv as: ["bun", "main.ts", ...userArgs]
   const args = process.argv.slice(2);
@@ -169,6 +200,8 @@ async function main(): Promise<void> {
           await cmdSchemaApply(subArgs);
         } else if (sub === "lint") {
           await cmdSchemaLint(subArgs);
+        } else if (sub === "--help" || sub === "-h" || sub === "help") {
+          process.stdout.write(SCHEMA_USAGE);
         } else {
           process.stderr.write(
             `Unknown schema subcommand: ${sub ?? "(none)"}\n` +
@@ -178,6 +211,11 @@ async function main(): Promise<void> {
         }
         break;
       }
+      case "--version":
+      case "-v":
+      case "version":
+        process.stdout.write(`${readVersion()}\n`);
+        break;
       case "--help":
       case "-h":
       case "help":

--- a/packages/pg-delta/tests/cli.test.ts
+++ b/packages/pg-delta/tests/cli.test.ts
@@ -54,6 +54,60 @@ describe("CLI: --help", () => {
   }, 30_000);
 });
 
+describe("CLI: --version", () => {
+  // No container needed — argv-only path.
+  const PKG_VERSION = (
+    JSON.parse(readFileSync(join(PKG_DIR, "package.json"), "utf8")) as {
+      version: string;
+    }
+  ).version;
+
+  test("--version prints the package version and exits 0", async () => {
+    const res = await runCli(["--version"]);
+    // RED before the fix: no version flag, so this fell through to the default
+    // branch — "Unknown command: --version" on stderr, exit 2.
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout.trim()).toBe(PKG_VERSION);
+    expect(res.stderr).not.toContain("Unknown command");
+  }, 30_000);
+
+  test("-v and version are aliases for --version", async () => {
+    for (const arg of ["-v", "version"]) {
+      const res = await runCli([arg]);
+      expect({ arg, code: res.exitCode }).toMatchObject({ code: 0 });
+      expect(res.stdout.trim()).toBe(PKG_VERSION);
+    }
+  }, 30_000);
+});
+
+describe("CLI: schema --help", () => {
+  // No container needed — argv-only path.
+  test("schema --help prints schema usage to stdout and exits 0", async () => {
+    const res = await runCli(["schema", "--help"]);
+    // RED before the fix: `schema --help` hit the unknown-subcommand branch,
+    // printing "Unknown schema subcommand: --help" on stderr and exiting 2.
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("schema export");
+    expect(res.stdout).toContain("schema apply");
+    expect(res.stdout).toContain("schema lint");
+    expect(res.stderr).not.toContain("Unknown schema subcommand");
+  }, 30_000);
+
+  test("schema -h and schema help are aliases", async () => {
+    for (const arg of ["-h", "help"]) {
+      const res = await runCli(["schema", arg]);
+      expect({ arg, code: res.exitCode }).toMatchObject({ code: 0 });
+      expect(res.stdout).toContain("schema export");
+    }
+  }, 30_000);
+
+  test("an unknown schema subcommand still errors (exit 2)", async () => {
+    const res = await runCli(["schema", "bogus"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("Unknown schema subcommand");
+  }, 30_000);
+});
+
 describe("CLI: prove redaction guard", () => {
   test("rejects a snapshot whose redaction mode differs from the plan (before touching the clone)", async () => {
     const cluster = await sharedCluster();


### PR DESCRIPTION
## Summary

Fixes two CLI UX nits in `pgdelta` (argv parsing only — no engine/diff/planner changes):

- **`pgdelta --version`** (and `-v` / `version`) previously fell through to the default branch and printed `Unknown command`. It now reads the package version from `package.json` at runtime (via `new URL("../../package.json", import.meta.url)`, which resolves from both `src/cli/main.ts` under Bun and the built `dist/cli/main.js`) and prints it, exit 0. Falls back to `"unknown"` if the read fails, so it never throws.
- **`pgdelta schema --help`** (and `-h` / `help`) previously hit the unknown-subcommand branch, printing `Unknown schema subcommand` on stderr and exiting 2. It now prints a focused schema-subcommand usage block to **stdout** and exits **0**. An unknown schema subcommand (e.g. `schema bogus`) still errors with exit 2, unchanged.

### RED → GREEN

Followed the repo's test-driven-fix discipline (`test:` commit is checkoutable and fails; `fix:` commit greens it).

RED (before the fix), from `tests/cli.test.ts`:

```
(fail) CLI: --version > --version prints the package version and exits 0
  expect(received).toBe(expected)  Expected: 0  Received: 2
(fail) CLI: schema --help > schema --help prints schema usage ... exits 0
  expect(received).toBe(expected)  Expected: 0  Received: 2
```

GREEN (after the fix): `6 pass  0 fail` across the `CLI: --version`, `CLI: schema --help`, and pre-existing `CLI: --help` describes. Also verified manually: `pgdelta --version` → `1.0.0-alpha.32`; `pgdelta schema --help` → schema usage.

## Linked issue

<!-- No tracked issue for these nits; found during CLI review. -->

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change (`tests/cli.test.ts`, argv-only — no container)
- [x] Changeset added (`patch` bump for `@supabase/pg-delta`)
- [x] `bun run format-and-lint` and `bun run check-types` pass (knip clean too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjBazcP5erxzjj6EStUe9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjBazcP5erxzjj6EStUe9g)_