### PR TITLE
fix: circular dependency on drop seq and alter column

### DIFF
--- a/.changeset/eager-vans-tap.md
+++ b/.changeset/eager-vans-tap.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix dependency sorting when an owned sequence is dropped while its surviving column is rewritten.

--- a/packages/pg-delta/src/core/sort/dependency-filter.ts
+++ b/packages/pg-delta/src/core/sort/dependency-filter.ts
@@ -1,5 +1,6 @@
 import type { Change } from "../change.types.ts";
 import { CreateSequence } from "../objects/sequence/changes/sequence.create.ts";
+import { DropSequence } from "../objects/sequence/changes/sequence.drop.ts";
 import { stableId } from "../objects/utils.ts";
 import { findConsumerIndexes } from "./graph-utils.ts";
 import type { Edge, GraphData } from "./types.ts";
@@ -87,19 +88,21 @@ function shouldFilterSequenceOwnershipDependency(
     graphData.changeIndexesByExplicitRequirementId,
   );
 
-  // Check if any CreateSequence change creates a sequence that is owned by
+  // Check if any CreateSequence/DropSequence change carries a sequence owned by
   // the referenced table/column. If so, filter this ownership dependency edge.
   for (const changeIndex of changesInvolvingSequence) {
     const change = phaseChanges[changeIndex];
 
-    // Only filter edges from CreateSequence changes, not AlterSequenceSetOwnedBy.
-    // AlterSequenceSetOwnedBy is a separate change that sets ownership after
-    // both the sequence and table exist, so it doesn't create the cycle.
-    if (!(change instanceof CreateSequence)) {
+    // Only filter edges from sequence lifecycle changes, not
+    // AlterSequenceSetOwnedBy. Ownership is set after both objects exist.
+    if (
+      !(change instanceof CreateSequence) &&
+      !(change instanceof DropSequence)
+    ) {
       continue;
     }
 
-    // Check if this CreateSequence creates a sequence owned by the referenced table/column
+    // Check if this change's sequence is owned by the referenced table/column.
     if (isSequenceOwnedBy(change.sequence, referencedStableId)) {
       return true; // Filter this edge to break the cycle
     }

--- a/packages/pg-delta/src/core/sort/sort-changes.test.ts
+++ b/packages/pg-delta/src/core/sort/sort-changes.test.ts
@@ -4,6 +4,8 @@ import type { Change } from "../change.types.ts";
 import type { PgDepend } from "../depend.ts";
 import { AlterPublicationDropTables } from "../objects/publication/changes/publication.alter.ts";
 import { Publication } from "../objects/publication/publication.model.ts";
+import { DropSequence } from "../objects/sequence/changes/sequence.drop.ts";
+import { Sequence } from "../objects/sequence/sequence.model.ts";
 import {
   AlterTableAlterColumnType,
   AlterTableDropConstraint,
@@ -228,6 +230,67 @@ describe("sortChanges", () => {
       "DropView",
       "AlterTableAlterColumnType",
       "CreateView",
+    ]);
+  });
+
+  test("breaks the cycle between dropping an owned sequence and rewriting its column", async () => {
+    const branchTable = table("items");
+    const mainColumn = {
+      ...integerColumn("id", 1),
+      not_null: true,
+      data_type: "bigint",
+      data_type_str: "bigint",
+    };
+    const branchColumn = {
+      ...mainColumn,
+      data_type: "numeric",
+      data_type_str: "numeric",
+    };
+    const sequence = new Sequence({
+      schema: "public",
+      name: "items_id_seq",
+      data_type: "bigint",
+      start_value: 1,
+      minimum_value: 1n,
+      maximum_value: 9223372036854775807n,
+      increment: 1,
+      cycle_option: false,
+      cache_size: 1,
+      persistence: "p",
+      owned_by_schema: "public",
+      owned_by_table: "items",
+      owned_by_column: "id",
+      comment: null,
+      privileges: [],
+      owner: "postgres",
+    });
+    const changes: Change[] = [
+      new DropSequence({ sequence }),
+      new AlterTableAlterColumnType({
+        table: branchTable,
+        column: branchColumn,
+        previousColumn: mainColumn,
+      }),
+    ];
+    const mainCatalog = await catalogWithDepends([
+      {
+        dependent_stable_id: "column:public.items.id",
+        referenced_stable_id: "sequence:public.items_id_seq",
+        deptype: "n",
+      },
+      {
+        dependent_stable_id: "sequence:public.items_id_seq",
+        referenced_stable_id: "column:public.items.id",
+        deptype: "a",
+      },
+    ]);
+    const branchCatalog = await catalogWithDepends([]);
+
+    const sorted = sortChanges({ mainCatalog, branchCatalog }, changes);
+
+    expect(sorted.map(changeLabel)).toEqual([
+      "AlterTableAlterColumnType",
+      "DropSequence",
     ]);
   });
 

--- a/packages/pg-delta/tests/integration/dependencies-cycles.test.ts
+++ b/packages/pg-delta/tests/integration/dependencies-cycles.test.ts
@@ -18,7 +18,7 @@ for (const pgVersion of POSTGRES_VERSIONS) {
       "sequence owned by column cycle with table default",
       withDb(pgVersion, async (db) => {
         /**
-         * This test identifies the ONLY current cycle we have when sorting statements:
+         * This test covers the create-phase sequence ownership cycle:
          *
          * CYCLE DESCRIPTION:
          * - A sequence is owned by a table column (via OWNED BY)
@@ -84,6 +84,48 @@ for (const pgVersion of POSTGRES_VERSIONS) {
               deptype: "a", // auto dependency for ownership
             },
           ] as PgDepend[],
+        });
+      }),
+    );
+
+    test(
+      "drop an owned sequence while rewriting its surviving column",
+      withDb(pgVersion, async (db) => {
+        /**
+         * CYCLE SCENARIO:
+         * The source sequence is owned by a column whose default references it.
+         * The target removes the sequence and default while changing the column
+         * type, so the main catalog contributes dependencies in both directions.
+         *
+         * HOW IT IS BROKEN:
+         * Filtering the ownership edge leaves the default dependency to order the
+         * column changes before the sequence drop.
+         */
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: `
+            CREATE SCHEMA test_schema;
+            CREATE SEQUENCE test_schema.items_id_seq;
+            CREATE TABLE test_schema.items (
+              id bigint NOT NULL DEFAULT nextval('test_schema.items_id_seq')
+            );
+            ALTER SEQUENCE test_schema.items_id_seq OWNED BY test_schema.items.id;
+          `,
+          testSql: `
+            ALTER TABLE test_schema.items ALTER COLUMN id DROP DEFAULT;
+            DROP SEQUENCE test_schema.items_id_seq;
+            ALTER TABLE test_schema.items ALTER COLUMN id TYPE numeric USING id::numeric;
+          `,
+          assertSqlStatements: (sqlStatements) => {
+            expect(sqlStatements).toMatchInlineSnapshot(`
+              [
+                "ALTER TABLE test_schema.items ALTER COLUMN id DROP DEFAULT",
+                "ALTER TABLE test_schema.items ALTER COLUMN id TYPE numeric USING id::numeric",
+                "DROP SEQUENCE test_schema.items_id_seq CASCADE",
+              ]
+            `);
+          },
         });
       }),
     );


### PR DESCRIPTION
## Summary

I found this error running pg-delta to fix the schema of some Realtime tenants:

```
pg-delta exited 1:
Command failed, UnorderableCycleError: CycleError: dependency graph contains a cycle involving 2 changes:
  1. [0] DropSequence
  2. [3] AlterTableAlterColumnType

Cycle path (edges forming the cycle):
  [0] → [3] (source: catalog)
    Dependency: sequence:realtime.messages_id_seq → column:realtime.messages.id
    Reason: Cycle-breaking filter did not match (edge preserved)
  [3] → [0] (source: catalog)
    Dependency: column:realtime.messages.id → sequence:realtime.messages_id_seq
    Reason: Cycle-breaking filter did not match (edge preserved)

This usually indicates a circular dependency in the schema changes that cannot be resolved.
The cycle-breaking filters were unable to break this cycle.
    at sortPhaseChanges (/$bunfs/root/pgdelta:130432:38)
    at sortChangesByPhasedGraph (/$bunfs/root/pgdelta:130364:43)
    at buildPlanForCatalogs (/$bunfs/root/pgdelta:133372:36)
    at createPlan (/$bunfs/root/pgdelta:133337:32)
    at async func (/$bunfs/root/pgdelta:153232:40)
    at async runCommand (/$bunfs/root/pgdelta:114166:46)
    at processTicksAndRejections (native:7:39)
```

This PR is a proposal to fix the order which would break the circular dependency.

## Linked issue

Closes #346 
Closes REAL-919

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass
