### PR TITLE
fix(pg-delta): avoid role rename policy dependency cycle

### DIFF
--- a/.changeset/famous-eagles-fry.md
+++ b/.changeset/famous-eagles-fry.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+Fix dependency-cycle planning when an accepted role rename is referenced by an RLS policy.

--- a/packages/pg-delta/src/plan/internal.ts
+++ b/packages/pg-delta/src/plan/internal.ts
@@ -123,10 +123,40 @@ export function buildActionGraph(
     alterersOf.set(key, list);
   });
 
+  // B1 temporary carve-out: an accepted ROLE rename destroys the old role id
+  // and produces the new one in the SAME action. A payload mutation such as
+  // ALTER POLICY … TO releases the old id and consumes that exact new id. Its
+  // consume edge correctly orders rename -> mutation; adding the generic
+  // release-before-destroy edge in the opposite direction would make a cycle.
+  // Keep this deliberately narrower than "release targets a rename": require
+  // one accepted role old->new pair represented by the destroyer action AND
+  // require this action to consume that pair's new id. I1's pre-diff payload
+  // normalization makes the redundant policy mutation disappear and removes
+  // this carve-out.
+  const releasesAcceptedRoleRename = (
+    action: Action,
+    released: StableId,
+    destroyer: number,
+  ): boolean => {
+    if (released.kind !== "role" || !renameActionIndices.has(destroyer)) {
+      return false;
+    }
+    const renameAction = actions[destroyer] as Action;
+    const releasedKey = encodeId(released);
+    if (!renameAction.destroys.some((id) => encodeId(id) === releasedKey)) {
+      return false;
+    }
+    const consumedKeys = new Set(action.consumes.map((id) => encodeId(id)));
+    return renameAction.produces.some(
+      (id) => id.kind === "role" && consumedKeys.has(encodeId(id)),
+    );
+  };
+
   actions.forEach((action, index) => {
     for (const id of action.releases) {
       const destroyer = destroyerOf.get(remember(id));
       if (destroyer !== undefined && destroyer !== index) {
+        if (releasesAcceptedRoleRename(action, id, destroyer)) continue;
         edges.push([index, destroyer]);
       }
     }

--- a/packages/pg-delta/src/plan/role-rename-carry.test.ts
+++ b/packages/pg-delta/src/plan/role-rename-carry.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import type { Delta } from "../core/diff.ts";
+import { buildFactBase, type Fact } from "../core/fact.ts";
 import {
   ALL_FACT_KINDS,
   encodeId,
@@ -18,8 +19,97 @@ import {
   ROLE_NAME_BEARING_KINDS,
   roleNamesIn,
 } from "./role-rename-carry.ts";
+import { plan } from "./plan.ts";
 
 const rename = new Map([["r1", "r2"]]);
+
+const rolePayload = () => ({
+  superuser: false,
+  inherit: true,
+  createRole: false,
+  createDb: false,
+  login: false,
+  replication: false,
+  bypassRls: false,
+  config: ["statement_timeout=42424ms"],
+});
+
+const schema: StableId = { kind: "schema", name: "app" };
+const table: StableId = { kind: "table", schema: "app", name: "docs" };
+const policy: StableId = {
+  kind: "policy",
+  schema: "app",
+  table: "docs",
+  name: "docs_read",
+};
+
+const policyFact = (role: string): Fact => ({
+  id: policy,
+  parent: table,
+  payload: {
+    cmd: "r",
+    permissive: true,
+    roles: [role],
+    usingExpr: "true",
+    checkExpr: null,
+  },
+});
+
+const rolePolicyBase = (role: string, includeRole = true) =>
+  buildFactBase(
+    [
+      ...(includeRole
+        ? [
+            {
+              id: { kind: "role", name: role } as StableId,
+              payload: rolePayload(),
+            },
+          ]
+        : []),
+      { id: schema, payload: {} },
+      { id: table, parent: schema, payload: { persistence: "p" } },
+      policyFact(role),
+    ],
+    [],
+  );
+
+describe("accepted role rename + policy role payload (B1)", () => {
+  test("orders the rename before ALTER POLICY without a dependency cycle", () => {
+    let thePlan!: ReturnType<typeof plan>;
+    expect(() => {
+      thePlan = plan(rolePolicyBase("role_a"), rolePolicyBase("role_b"), {
+        renames: "auto",
+        compact: false,
+      });
+    }).not.toThrow();
+
+    expect(thePlan.actions.map((action) => action.sql)).toMatchInlineSnapshot(`
+      [
+        "ALTER ROLE \"role_a\" RENAME TO \"role_b\"",
+        "ALTER POLICY \"docs_read\" ON \"app\".\"docs\" TO \"role_b\"",
+      ]
+    `);
+  });
+
+  test("still releases a genuinely dropped role before DROP ROLE", () => {
+    const source = rolePolicyBase("role_a");
+    const desired = rolePolicyBase("PUBLIC", false);
+    const thePlan = plan(source, desired, {
+      renames: "auto",
+      compact: false,
+    });
+
+    const alterPolicy = thePlan.actions.findIndex((action) =>
+      action.sql.startsWith('ALTER POLICY "docs_read"'),
+    );
+    const dropRole = thePlan.actions.findIndex((action) =>
+      action.sql.includes('DROP ROLE "role_a"'),
+    );
+    expect(alterPolicy).toBeGreaterThanOrEqual(0);
+    expect(dropRole).toBeGreaterThanOrEqual(0);
+    expect(alterPolicy).toBeLessThan(dropRole);
+  });
+});
 
 describe("relabelRoleNames", () => {
   test("remaps a bare role id", () => {

--- a/packages/pg-delta/src/plan/role-rename-carry.test.ts
+++ b/packages/pg-delta/src/plan/role-rename-carry.test.ts
@@ -85,8 +85,8 @@ describe("accepted role rename + policy role payload (B1)", () => {
 
     expect(thePlan.actions.map((action) => action.sql)).toMatchInlineSnapshot(`
       [
-        "ALTER ROLE \"role_a\" RENAME TO \"role_b\"",
-        "ALTER POLICY \"docs_read\" ON \"app\".\"docs\" TO \"role_b\"",
+        "ALTER ROLE "role_a" RENAME TO "role_b"",
+        "ALTER POLICY "docs_read" ON "app"."docs" TO "role_b"",
       ]
     `);
   });

--- a/packages/pg-delta/tests/renames.test.ts
+++ b/packages/pg-delta/tests/renames.test.ts
@@ -76,8 +76,8 @@ describe("stage 9: renames", () => {
       expect(thePlan.actions.map((action) => action.sql))
         .toMatchInlineSnapshot(`
         [
-          "ALTER ROLE \"renpolicy_old\" RENAME TO \"renpolicy_new\"",
-          "ALTER POLICY \"docs_read\" ON \"app\".\"docs\" TO \"renpolicy_new\"",
+          "ALTER ROLE "renpolicy_old" RENAME TO "renpolicy_new"",
+          "ALTER POLICY "docs_read" ON "app"."docs" TO "renpolicy_new"",
         ]
       `);
       const verdict = await provePlan(

--- a/packages/pg-delta/tests/renames.test.ts
+++ b/packages/pg-delta/tests/renames.test.ts
@@ -9,7 +9,11 @@ import { apply } from "../src/apply/apply.ts";
 import { extract } from "../src/extract/extract.ts";
 import { plan } from "../src/plan/plan.ts";
 import { provePlan } from "../src/proof/prove.ts";
-import { sharedCluster, type TestDb } from "./containers.ts";
+import {
+  isolatedClusterPair,
+  sharedCluster,
+  type TestDb,
+} from "./containers.ts";
 
 async function pair(
   prefix: string,
@@ -31,6 +35,67 @@ async function pair(
 }
 
 describe("stage 9: renames", () => {
+  test("role rename referenced by an RLS policy plans and proves without a cycle", async () => {
+    const [sourceCluster, desiredCluster] = await isolatedClusterPair();
+    const source = await sourceCluster.createDb("ren_policy_src");
+    const desired = await desiredCluster.createDb("ren_policy_dst");
+    try {
+      await sourceCluster.adminPool.query(`CREATE ROLE renpolicy_old NOLOGIN`);
+      await sourceCluster.adminPool.query(
+        `ALTER ROLE renpolicy_old SET statement_timeout = '42424ms'`,
+      );
+      await source.pool.query(`
+        CREATE SCHEMA app;
+        CREATE TABLE app.docs (id integer PRIMARY KEY);
+        ALTER TABLE app.docs ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY docs_read ON app.docs
+          FOR SELECT TO renpolicy_old USING (true);
+      `);
+
+      await desiredCluster.adminPool.query(`CREATE ROLE renpolicy_new NOLOGIN`);
+      await desiredCluster.adminPool.query(
+        `ALTER ROLE renpolicy_new SET statement_timeout = '42424ms'`,
+      );
+      await desired.pool.query(`
+        CREATE SCHEMA app;
+        CREATE TABLE app.docs (id integer PRIMARY KEY);
+        ALTER TABLE app.docs ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY docs_read ON app.docs
+          FOR SELECT TO renpolicy_new USING (true);
+      `);
+
+      const [sourceState, desiredState] = await Promise.all([
+        extract(source.pool),
+        extract(desired.pool),
+      ]);
+      const thePlan = plan(sourceState.factBase, desiredState.factBase, {
+        renames: "auto",
+        compact: false,
+      });
+
+      expect(thePlan.actions.map((action) => action.sql))
+        .toMatchInlineSnapshot(`
+        [
+          "ALTER ROLE \"renpolicy_old\" RENAME TO \"renpolicy_new\"",
+          "ALTER POLICY \"docs_read\" ON \"app\".\"docs\" TO \"renpolicy_new\"",
+        ]
+      `);
+      const verdict = await provePlan(
+        thePlan,
+        source.pool,
+        desiredState.factBase,
+      );
+      expect(verdict.applyError).toBeUndefined();
+      expect(verdict.driftDeltas).toEqual([]);
+      expect(verdict.ok).toBe(true);
+    } finally {
+      await Promise.all([
+        source.drop().catch(() => {}),
+        desired.drop().catch(() => {}),
+      ]);
+    }
+  }, 120_000);
+
   test("column leaf rename: emitted as RENAME COLUMN, values survive", async () => {
     const dbs = await pair(
       "ren_col",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for the B1 crash-class planner issue: an accepted role rename combined with an RLS policy referencing that role produced a dependency cycle. Includes a patch changeset for `@supabase/pg-delta`.

## What is the current behavior?

With `renames: "auto"`, changing `role_a` to `role_b` while an RLS policy changes its `TO` payload from `role_a` to `role_b` creates contradictory graph edges:

- consuming `role_b` orders `ALTER ROLE ... RENAME` before `ALTER POLICY ... TO role_b`;
- releasing `role_a` orders the policy alteration before the same rename.

Planning then throws:

```text
dependency cycle among 2 actions:
  ALTER ROLE "role_a" RENAME TO "role_b"
  ALTER POLICY "docs_read" ON "app"."docs" TO "role_b"
```

Refs #333

## What is the new behavior?

The action graph skips the conflicting release-before-destroy edge only when the destroyer is an accepted role rename that destroys the released old role and produces the new role consumed by the releasing action. Genuine role drops retain their existing release ordering.

Coverage includes the in-memory RED regression, a negative over-skip test, and an isolated-cluster extract → plan → prove integration test.

## Testing

- RED confirmed in both unit and integration tests with the cycle above.
- `bun run test:pg-delta` — 790 passed.
- `PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/renames.test.ts` — 12 passed.
- `PGDELTA_NEXT_PROGRESS=1 PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts` — 632 passed.
- `bun run format-and-lint`, `bun run check-types`, and `bun run knip` — passed.
- CI: unit, integration, and corpus matrices across PostgreSQL 14–18 are green.

## Additional context

This is intentionally a narrow ordering carve-out. The planned I1 pre-diff role-reference normalization will make the policy mutation redundant and remove this temporary exception.
