### PR TITLE
refactor(pg-delta): centralize managed view reconstruction

### DIFF
--- a/docs/architecture/managed-view-architecture.md
+++ b/docs/architecture/managed-view-architecture.md
@@ -222,6 +222,12 @@ function plan(rawSource, rawDesired, options) {
   edges). The Supabase scope rules are more cases. One code path.
 - The proof loop’s `reextract` is wrapped in the same `resolveView` so
   `plan == prove == run` holds with no special-casing.
+- **Reconstruction under management scope** (plan / prove / apply / schema
+  export) goes through one internal helper —
+  `policy/reconstruct.ts` → `reconstructManagedView` — which seals the order
+  `resolveView` then `projectManagementScope`. Diff and seed paths may still
+  call bare `resolveView` (no scope projection). The helper is not on the
+  package index; `ResolvedProfile` remains the public composition surface.
 
 ## Costs (kept honest)
 

--- a/packages/pg-delta/src/apply/apply.ts
+++ b/packages/pg-delta/src/apply/apply.ts
@@ -15,8 +15,7 @@ import type { Pool } from "pg";
 import type { FactBase } from "../core/fact.ts";
 import { extract } from "../extract/extract.ts";
 import { ENGINE_VERSION, type Plan } from "../plan/plan.ts";
-import { resolveView } from "../policy/policy.ts";
-import { projectManagementScope } from "../policy/view.ts";
+import { reconstructManagedView } from "../policy/reconstruct.ts";
 
 export type ActionStatus = "applied" | "unapplied" | "inDoubt";
 
@@ -151,22 +150,15 @@ export async function apply(
     const current = await (options?.reextract
       ? options.reextract(target)
       : extract(target, { redactSecrets: thePlan.redactSecrets ?? true }));
-    // reconstruct the SAME managed-view-under-scope the plan fingerprinted:
-    // resolveView FIRST, then the scope projection (change-set.ts) — the reverse
-    // order would strip owner edges a policy rule reads. `scope` defaults to the
-    // identity "cluster" projection, so unscoped plans are unchanged.
-    const view = projectManagementScope(
-      resolveView(
-        current.factBase,
-        thePlan.policy,
-        thePlan.capability,
-        options?.baseline,
-      ),
-      thePlan.scope ?? "cluster",
-      thePlan.defaultOwner !== undefined
-        ? { defaultOwner: thePlan.defaultOwner }
-        : {},
-    );
+    // reconstruct the SAME managed-view-under-scope the plan fingerprinted
+    // (`reconstructManagedView` seals resolveView → scope; defaults cluster).
+    const view = reconstructManagedView(current.factBase, {
+      policy: thePlan.policy,
+      capability: thePlan.capability,
+      baseline: options?.baseline,
+      scope: thePlan.scope,
+      defaultOwner: thePlan.defaultOwner,
+    });
     // KNOWN PITFALL (acknowledged, by design): the fingerprint folds the WHOLE
     // resolved view, INCLUDING `referenceOnly` assumed-schema facts (e.g.
     // `auth.users` kept so a managed dependent resolves its parent). Those facts

--- a/packages/pg-delta/src/frontends/schema-export.ts
+++ b/packages/pg-delta/src/frontends/schema-export.ts
@@ -97,20 +97,11 @@ export async function buildSchemaExport(
         resolvedDefaultOwner = r.rows[0]?.owner ?? null;
       }
     }
-    if (resolvedDefaultOwner !== null) {
-      const cu = (await pool.query<{ u: string }>(`SELECT current_user AS u`))
-        .rows[0]?.u;
-      if (cu !== undefined && cu !== resolvedDefaultOwner) {
-        options.onWarning?.(
-          `the resolved default owner "${resolvedDefaultOwner}" differs from the export ` +
-            `connection role "${cu}"; ownership of its objects will be left implicit (no OWNER TO). ` +
-            `Apply this directory connecting as "${resolvedDefaultOwner}", or re-export with ` +
-            `defaultOwner "${cu}" / defaultOwner null (verbose).`,
-        );
-      }
-    }
   }
 
+  // reconstruct BEFORE onWarning: resolveProfile keeps the caller-owned policy
+  // by reference, so a warning callback that mutates filters must not run until
+  // the managed view is already sealed (pre-V1 order: resolveView then warn).
   const scopedView = reconstructManagedView(factBase, {
     policy: ctx.planOptions.policy,
     capability: ctx.planOptions.capability,
@@ -120,6 +111,18 @@ export async function buildSchemaExport(
       ? { defaultOwner: resolvedDefaultOwner }
       : {}),
   });
+  if (exportScope === "database" && resolvedDefaultOwner !== null) {
+    const cu = (await pool.query<{ u: string }>(`SELECT current_user AS u`))
+      .rows[0]?.u;
+    if (cu !== undefined && cu !== resolvedDefaultOwner) {
+      options.onWarning?.(
+        `the resolved default owner "${resolvedDefaultOwner}" differs from the export ` +
+          `connection role "${cu}"; ownership of its objects will be left implicit (no OWNER TO). ` +
+          `Apply this directory connecting as "${resolvedDefaultOwner}", or re-export with ` +
+          `defaultOwner "${cu}" / defaultOwner null (verbose).`,
+      );
+    }
+  }
   const scopeAssumedRoles =
     exportScope === "database"
       ? factBase

--- a/packages/pg-delta/src/frontends/schema-export.ts
+++ b/packages/pg-delta/src/frontends/schema-export.ts
@@ -10,11 +10,9 @@ import {
   resolveProfile,
   type ResolveProfileOptions,
 } from "../integrations/profile.ts";
-import { flattenPolicy, resolveView } from "../policy/policy.ts";
-import {
-  type ManagementScope,
-  projectManagementScope,
-} from "../policy/view.ts";
+import { flattenPolicy } from "../policy/policy.ts";
+import { reconstructManagedView } from "../policy/reconstruct.ts";
+import type { ManagementScope } from "../policy/view.ts";
 import { exportSqlFiles, type ExportGrouping } from "./export-sql-files.ts";
 import type { ExportManifest } from "./export-manifest.ts";
 import type { SqlFile } from "./load-sql-files.ts";
@@ -75,12 +73,6 @@ export async function buildSchemaExport(
 
   const { factBase, diagnostics } = await ctx.extract(pool, { redactSecrets });
 
-  const view = resolveView(
-    factBase,
-    ctx.planOptions.policy,
-    ctx.planOptions.capability,
-    ctx.planOptions.baseline,
-  );
   const assumed = ctx.planOptions.policy
     ? flattenPolicy(ctx.planOptions.policy)
     : undefined;
@@ -119,11 +111,15 @@ export async function buildSchemaExport(
     }
   }
 
-  const scopedView = projectManagementScope(
-    view,
-    exportScope,
-    resolvedDefaultOwner !== null ? { defaultOwner: resolvedDefaultOwner } : {},
-  );
+  const scopedView = reconstructManagedView(factBase, {
+    policy: ctx.planOptions.policy,
+    capability: ctx.planOptions.capability,
+    baseline: ctx.planOptions.baseline,
+    scope: exportScope,
+    ...(resolvedDefaultOwner !== null
+      ? { defaultOwner: resolvedDefaultOwner }
+      : {}),
+  });
   const scopeAssumedRoles =
     exportScope === "database"
       ? factBase

--- a/packages/pg-delta/src/plan/phases/change-set.ts
+++ b/packages/pg-delta/src/plan/phases/change-set.ts
@@ -13,12 +13,8 @@ import { diff, type Delta } from "../../core/diff.ts";
 import type { Fact, FactBase } from "../../core/fact.ts";
 import type { Payload } from "../../core/hash.ts";
 import { encodeId, type StableId } from "../../core/stable-id.ts";
-import {
-  filterDeltas,
-  resolveView,
-  validatePolicy,
-} from "../../policy/policy.ts";
-import { projectManagementScope } from "../../policy/view.ts";
+import { filterDeltas, validatePolicy } from "../../policy/policy.ts";
+import { reconstructManagedView } from "../../policy/reconstruct.ts";
 import type { PlanOptions } from "../plan.ts";
 import type { RulesForId } from "../rules.ts";
 import { projectTarget } from "../project.ts";
@@ -98,44 +94,24 @@ export function buildChangeSet(
   // `verb` rules remain for the delta-level filter below. With no policy/baseline
   // and no member edges this is the identity projection, so the corpus is unchanged.
   //
-  // The management-scope projection runs AFTER resolveView, never before: a
-  // policy owner-exclusion rule (Supabase Rule 6) reads the `owner` edge, and
-  // `projectManagementScope("database")` prunes role facts together with those
-  // owner edges — so projecting scope first would strip the edge the policy
-  // needs and wrongly plan a DROP of a platform object owned by a system role
-  // (e.g. an event trigger). This is the SAME order `schema export` uses, and it
-  // is done HERE (the single managed-view-under-scope definition) so plan, the
-  // apply fingerprint gate, and the proof loop all reconstruct the identical
-  // view — `plan == prove == run`. `scope` defaults to "cluster", which is the
-  // identity projection, so direct library callers / the corpus are unchanged.
-  const scope = options?.scope ?? "cluster";
-  // the default owner whose ownership stays implicit under database scope (its
-  // owner edges pruned → no ALTER … OWNER TO). Symmetric on both sides so the
-  // fingerprint/proof reconstruct the same view; ignored at cluster scope.
-  const scopeOpts =
-    options?.defaultOwner !== undefined
-      ? { defaultOwner: options.defaultOwner }
-      : {};
-  const source = projectManagementScope(
-    resolveView(
-      rawSource,
-      options?.policy,
-      options?.capability,
-      options?.baseline,
-    ),
-    scope,
-    scopeOpts,
-  );
-  const desired = projectManagementScope(
-    resolveView(
-      rawDesired,
-      options?.policy,
-      options?.capability,
-      options?.baseline,
-    ),
-    scope,
-    scopeOpts,
-  );
+  // Managed view under scope: `reconstructManagedView` seals resolveView THEN
+  // projectManagementScope (owner edges must survive for policy exclusion before
+  // database-scope role prune). Plan / apply / prove / export share that helper
+  // so `plan == prove == run`. `scope` defaults to "cluster" (identity).
+  const source = reconstructManagedView(rawSource, {
+    policy: options?.policy,
+    capability: options?.capability,
+    baseline: options?.baseline,
+    scope: options?.scope,
+    defaultOwner: options?.defaultOwner,
+  });
+  const desired = reconstructManagedView(rawDesired, {
+    policy: options?.policy,
+    capability: options?.capability,
+    baseline: options?.baseline,
+    scope: options?.scope,
+    defaultOwner: options?.defaultOwner,
+  });
 
   const allDeltas = diff(source, desired);
   const { kept: deltas, filtered: filteredDeltas } = options?.policy

--- a/packages/pg-delta/src/policy/reconstruct.test.ts
+++ b/packages/pg-delta/src/policy/reconstruct.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Guard + pin (V1): the full managed-view composition
+ * (`resolveView` → `projectManagementScope`) must live in exactly one module.
+ * Call sites that need both steps go through `reconstructManagedView`; bare
+ * `resolveView` alone remains allowed (diff / seed paths).
+ *
+ * Import/call-based per module — not a nested-call grep. schema-export used to
+ * compose via an intermediate variable, which a
+ * `projectManagementScope(resolveView(` search would miss.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+import {
+  buildFactBase,
+  type DependencyEdge,
+  type Fact,
+  type FactBase,
+} from "../core/fact.ts";
+import { encodeId } from "../core/stable-id.ts";
+import { resolveView, type Policy } from "./policy.ts";
+import { reconstructManagedView } from "./reconstruct.ts";
+import { projectManagementScope } from "./view.ts";
+
+const SRC_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const HELPER_REL = "policy/reconstruct.ts";
+
+function listProductionTs(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) {
+      out.push(...listProductionTs(path));
+      continue;
+    }
+    if (!name.endsWith(".ts") || name.endsWith(".test.ts")) continue;
+    out.push(path);
+  }
+  return out;
+}
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+function mentionsBoth(code: string): boolean {
+  return (
+    /\bresolveView\b/.test(code) && /\bprojectManagementScope\b/.test(code)
+  );
+}
+
+/** Full shape pin — rootHash alone omits diagnostics / referenceOnly / source. */
+function expectSameFactBase(a: FactBase, b: FactBase): void {
+  expect(a.source).toBe(b.source);
+  expect(a.rootHash).toBe(b.rootHash);
+  expect(a.diagnostics).toEqual(b.diagnostics);
+  expect([...a.referenceOnly].sort()).toEqual([...b.referenceOnly].sort());
+  const factKey = (f: Fact) => encodeId(f.id);
+  const factsA = a
+    .facts()
+    .slice()
+    .sort((x, y) => (factKey(x) < factKey(y) ? -1 : 1));
+  const factsB = b
+    .facts()
+    .slice()
+    .sort((x, y) => (factKey(x) < factKey(y) ? -1 : 1));
+  expect(factsA).toEqual(factsB);
+  const edgeKey = (e: DependencyEdge) =>
+    `${encodeId(e.from)}-${e.kind}->${encodeId(e.to)}`;
+  expect(
+    a.edges.slice().sort((x, y) => (edgeKey(x) < edgeKey(y) ? -1 : 1)),
+  ).toEqual(b.edges.slice().sort((x, y) => (edgeKey(x) < edgeKey(y) ? -1 : 1)));
+}
+
+describe("reconstructManagedView is the sole full composition site", () => {
+  test("no production module outside the helper imports/calls both steps", () => {
+    const offenders: string[] = [];
+    for (const path of listProductionTs(SRC_ROOT)) {
+      const rel = relative(SRC_ROOT, path).replaceAll("\\", "/");
+      if (rel === HELPER_REL) continue;
+      const code = stripComments(readFileSync(path, "utf8"));
+      if (mentionsBoth(code)) offenders.push(rel);
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("reconstructManagedView — composition pin", () => {
+  const tableId = { kind: "table" as const, schema: "app", name: "t" };
+  const facts: Fact[] = [
+    { id: { kind: "schema", name: "app" }, payload: {} },
+    { id: tableId, parent: { kind: "schema", name: "app" }, payload: {} },
+    { id: { kind: "role", name: "supabase_admin" }, payload: {} },
+    { id: { kind: "role", name: "app_owner" }, payload: {} },
+  ];
+  const edges: DependencyEdge[] = [
+    {
+      from: tableId,
+      to: { kind: "role", name: "supabase_admin" },
+      kind: "owner",
+    },
+  ];
+  // owner-exclusion (Supabase Rule 6 shape). `defaultOwner: "supabase_admin"`
+  // is load-bearing for the ORDER pin: database scope prunes that owner edge,
+  // so resolveView-after-scope can no longer match `{ owner }` and the table
+  // wrongly survives. With `defaultOwner: "app_owner"` the dangling edge is
+  // retained and reverse order still excludes — a false green.
+  const policy: Policy = {
+    id: "owner-exclude",
+    filter: [{ match: { owner: "supabase_admin" }, action: "exclude" }],
+  };
+  const databaseOpts = {
+    policy,
+    scope: "database" as const,
+    defaultOwner: "supabase_admin",
+  };
+
+  test("matches resolveView then projectManagementScope (full FactBase shape)", () => {
+    const fb = buildFactBase(facts, edges);
+    const viaHelper = reconstructManagedView(fb, databaseOpts);
+    const viaOpen = projectManagementScope(
+      resolveView(fb, databaseOpts.policy),
+      databaseOpts.scope,
+      { defaultOwner: databaseOpts.defaultOwner },
+    );
+    expectSameFactBase(viaHelper, viaOpen);
+    expect(viaHelper.get(tableId)).toBeUndefined();
+  });
+
+  test("reversed scope→resolveView leaves the owner-excluded table (order pin)", () => {
+    const fb = buildFactBase(facts, edges);
+    const viaHelper = reconstructManagedView(fb, databaseOpts);
+    const viaReversed = resolveView(
+      projectManagementScope(fb, databaseOpts.scope, {
+        defaultOwner: databaseOpts.defaultOwner,
+      }),
+      databaseOpts.policy,
+    );
+    // Correct order excludes the system-owned table; reverse order cannot.
+    expect(viaHelper.get(tableId)).toBeUndefined();
+    expect(viaReversed.get(tableId)).toBeDefined();
+    expect(viaHelper.rootHash).not.toBe(viaReversed.rootHash);
+  });
+
+  test("default scope is cluster (identity after resolveView)", () => {
+    const fb = buildFactBase(facts, edges);
+    const viaHelper = reconstructManagedView(fb, { policy });
+    const viaResolve = resolveView(fb, policy);
+    expectSameFactBase(viaHelper, viaResolve);
+    expect(viaHelper.get({ kind: "role", name: "app_owner" })).toBeDefined();
+  });
+});

--- a/packages/pg-delta/src/policy/reconstruct.ts
+++ b/packages/pg-delta/src/policy/reconstruct.ts
@@ -1,0 +1,48 @@
+/**
+ * Single reconstruction entry point for the managed view under management scope
+ * (docs/architecture/managed-view-architecture.md; agent track V1).
+ *
+ * Order is fixed: `resolveView` THEN `projectManagementScope`. A policy
+ * owner-exclusion rule reads the `owner` edge, and database-scope role pruning
+ * removes those edges with the role facts — projecting scope first would strip
+ * the edge the policy needs and wrongly plan a DROP of a platform object owned
+ * by a system role. Plan, prove, apply, and schema export all call this helper
+ * so `plan == prove == run` cannot drift by open-coding the composition.
+ *
+ * Internal only — not re-exported from the package index or the `./policy`
+ * public subpath. `ResolvedProfile` remains the public safe-composition surface.
+ * Bare `resolveView` (without scope) stays legitimate for diff/seed paths.
+ */
+import type { FactBase } from "../core/fact.ts";
+import type { ApplierCapability } from "./capability.ts";
+import { resolveView, type Policy } from "./policy.ts";
+import { projectManagementScope, type ManagementScope } from "./view.ts";
+
+interface ReconstructManagedViewOptions {
+  // `| undefined` so call sites can forward optional plan/profile fields under
+  // exactOptionalPropertyTypes without conditional spreads at every site.
+  policy?: Policy | undefined;
+  capability?: ApplierCapability | undefined;
+  baseline?: FactBase | undefined;
+  /** Default `"cluster"` (identity scope projection). */
+  scope?: ManagementScope | undefined;
+  /** Under database scope: owner edges to this role stay implicit (no OWNER TO). */
+  defaultOwner?: string | undefined;
+}
+
+/**
+ * Rebuild the managed-view-under-scope: policy/capability/baseline projection,
+ * then management-scope role pruning.
+ */
+export function reconstructManagedView(
+  fb: FactBase,
+  opts: ReconstructManagedViewOptions = {},
+): FactBase {
+  const scope = opts.scope ?? "cluster";
+  const view = resolveView(fb, opts.policy, opts.capability, opts.baseline);
+  return projectManagementScope(
+    view,
+    scope,
+    opts.defaultOwner !== undefined ? { defaultOwner: opts.defaultOwner } : {},
+  );
+}

--- a/packages/pg-delta/src/proof/prove.ts
+++ b/packages/pg-delta/src/proof/prove.ts
@@ -17,8 +17,8 @@ import type { StableId } from "../core/stable-id.ts";
 import { extract } from "../extract/extract.ts";
 import type { Action, Plan } from "../plan/plan.ts";
 import { projectTarget } from "../plan/project.ts";
-import { resolveView, type Policy } from "../policy/policy.ts";
-import { projectManagementScope } from "../policy/view.ts";
+import type { Policy } from "../policy/policy.ts";
+import { reconstructManagedView } from "../policy/reconstruct.ts";
 import type { ApplierCapability } from "../policy/capability.ts";
 
 /** Structured table identity on the verdict: a collision-free { schema, name }
@@ -470,35 +470,21 @@ export async function provePlan(
         `as options.baseline so the proof compares the same view the plan diffed.`,
     );
   }
-  // reconstruct the SAME managed-view-under-scope the plan diffed: resolveView
-  // FIRST, then the scope projection (change-set.ts), on BOTH the proven clone
-  // and the target — otherwise cluster-global roles (or an owner-excluded
-  // platform object whose owner edge the scope projection would strip before
-  // the policy runs) reappear as drift. `scope` defaults to the identity
-  // "cluster" projection, so the corpus proof is unchanged.
-  const scope = thePlan.scope ?? "cluster";
-  // same default owner the plan projected with (owner edges to it stay implicit),
-  // so the proven clone and the target reconstruct the identical view.
-  const scopeOpts =
-    thePlan.defaultOwner !== undefined
-      ? { defaultOwner: thePlan.defaultOwner }
-      : {};
-  const provenFb = projectManagementScope(
-    resolveView(proven.factBase, policy, capability, options.baseline),
-    scope,
-    scopeOpts,
-  );
+  // reconstruct the SAME managed-view-under-scope the plan diffed on BOTH the
+  // proven clone and the target (`reconstructManagedView` seals order).
+  const viewOpts = {
+    policy,
+    capability,
+    baseline: options.baseline,
+    scope: thePlan.scope,
+    defaultOwner: thePlan.defaultOwner,
+  };
+  const provenFb = reconstructManagedView(proven.factBase, viewOpts);
   // target the PROJECTED desired: the plan only applies kept deltas, so it
   // converges to `desired` minus the policy-filtered changes (review #2).
-  const target = projectManagementScope(
-    resolveView(
-      projectTarget(desired, thePlan.filteredDeltas),
-      policy,
-      capability,
-      options.baseline,
-    ),
-    scope,
-    scopeOpts,
+  const target = reconstructManagedView(
+    projectTarget(desired, thePlan.filteredDeltas),
+    viewOpts,
   );
   const driftDeltas = diff(provenFb, target);
   const after = await tableStats(clonePool);


### PR DESCRIPTION
## Summary
- add an internal `reconstructManagedView` helper that fixes the `resolveView` → `projectManagementScope` order
- migrate plan, prove, apply, and schema export to the shared reconstruction path
- add source guards and behavioral pins, including a reverse-order regression case and full FactBase comparison
- document the internal reconstruction seam; no changeset because behavior and public API are unchanged

## Test plan
- [x] `bun test src/policy/reconstruct.test.ts`
- [x] `bun test src/policy/ src/plan/phases/ src/proof/prove.test.ts`
- [x] `bun test tests/schema-frontends.test.ts`
- [x] `bun run format-and-lint`
- [x] `bun run check-types`