### PR TITLE
docs(pg-delta): mark server replacement follow-up resolved

### DIFF
--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -467,11 +467,11 @@ CANONICAL, foreign-column `attfdwoptions` — with fresh comment_ids each pass).
 
 Replace / apply cascade:
 
-- **FDW server children rebuild on replace** — `src/plan/rules/foreign.ts:81` (comment
-  `3537910549`). When `type`/`fdw` changes on a server that still has foreign tables,
-  marking the server `replace` emits only the server drop/create; PostgreSQL rejects
-  `DROP SERVER` while dependent foreign tables/user mappings exist → apply fails.
-  Rebuild the dependents explicitly or use a cascade/recreate path.
+- **FDW server children rebuild on replace** — ✅ **resolved** by `da2d75c1`.
+  Replacement emission recursively drops children across non-cascading server
+  boundaries, recreates surviving descendants after the server, and is pinned in
+  both directions by `foreign-data-wrapper-operations--replace-server-with-children`.
+  The original finding was comment `3537910549`.
 
 Extract-completeness (invisible drift / wrong from-empty replay):
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation-only roadmap correction.

## What is the current behavior?

The follow-up roadmap still lists foreign-server child rebuilding during server replacement as an open apply failure, even though the implementation and exact corpus coverage landed in `da2d75c1`.

Refs #333

## What is the new behavior?

The roadmap marks the item resolved and records the implementation and two-direction corpus evidence, preventing future reviewers and agents from repeatedly reporting or picking up the stale finding.

## Additional context

Confirmed while triaging the automated review on #349. `bun run format-and-lint` passes.
