### PR TITLE
docs(pg-delta): document identity and ACL invariants

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -109,9 +109,19 @@ run if the target drifted from what the plan was built against (the
 
 ---
 
-## The two cross-cutting ideas
+## The three cross-cutting ideas
 
-Two concerns don't belong to any single step — they shape the whole pipeline:
+Three concerns don't belong to any single step — they shape the whole pipeline:
+
+### Identity and ACLs — names are not OIDs
+
+`StableId` is a declarative, name-based address; PostgreSQL carries runtime
+references by OID. Role renames, ownership, memberships, grants, and
+non-semantic extraction hints all sit on that boundary. The identity/ACL
+invariants document separates today's post-diff carry from the planned
+canonical-normalization model and records what ACL equality actually means.
+
+→ [identity-and-acl.md](identity-and-acl.md)
 
 ### The managed view — "what do we even manage?"
 
@@ -142,6 +152,7 @@ per-extension special-casing in the core.
 | Document | What it covers |
 |---|---|
 | [target-architecture.md](target-architecture.md) | The north star: the five sub-problems, the two principles, the fact model, the rule table, the one graph, the proof loop — the full design and its guardrails. |
+| [identity-and-acl.md](identity-and-acl.md) | StableId addressability vs PostgreSQL OIDs, current and target rename flow, effective ACL equality, underscore metadata, and proof implications. |
 | [managed-view-architecture.md](managed-view-architecture.md) | How scope, ownership, and applier capability enter the engine through one `resolveView`, closed under the proof loop. |
 | [extension-intent.md](extension-intent.md) | How stateful extensions are diffed without destroying their data. |
 | [onboarding.md](onboarding.md) | The contributor map: which file holds each stage, and how to add a new object kind. |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -152,7 +152,7 @@ per-extension special-casing in the core.
 | Document | What it covers |
 |---|---|
 | [target-architecture.md](target-architecture.md) | The north star: the five sub-problems, the two principles, the fact model, the rule table, the one graph, the proof loop — the full design and its guardrails. |
-| [identity-and-acl.md](identity-and-acl.md) | StableId addressability vs PostgreSQL OIDs, current and target rename flow, effective ACL equality, underscore metadata, and proof implications. |
+| [identity-and-acl.md](identity-and-acl.md) | StableId addressability vs PostgreSQL OIDs, current and target rename flow, explicit per-grantee ACL equality, underscore metadata, and proof implications. |
 | [managed-view-architecture.md](managed-view-architecture.md) | How scope, ownership, and applier capability enter the engine through one `resolveView`, closed under the proof loop. |
 | [extension-intent.md](extension-intent.md) | How stateful extensions are diffed without destroying their data. |
 | [onboarding.md](onboarding.md) | The contributor map: which file holds each stage, and how to add a new object kind. |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -93,8 +93,8 @@ This is the safety net the old engine never had. `provePlan()` applies the plan
 to a **throwaway clone**, re-extracts it, and checks two things:
 
 - **State proof** — the result's fact hashes equal the desired state (zero drift).
-- **Data preservation** — rows in kept tables survive (and a table rewritten
-  without declaring it fails the proof).
+- **Data preservation** — rows in kept ordinary heap tables survive (and a table
+  rewritten without declaring it fails the proof).
 
 Because re-extraction yields the same kind of facts, "did the migration work?"
 becomes a hash comparison, run automatically in CI — not a production incident.

--- a/docs/architecture/identity-and-acl.md
+++ b/docs/architecture/identity-and-acl.md
@@ -19,7 +19,8 @@ carry and a narrow role-rename ordering carve-out.
 4. PostgreSQL carries OID references through a rename, but name-keyed facts do
    not follow automatically inside pg-delta.
 5. ACL identity is target + grantee + optional column. ACL payload is the
-   effective privilege set; grantor provenance is deliberately not modeled.
+   explicit per-grantee privilege set; grantor provenance is deliberately not
+   modeled.
 6. Payload keys beginning with `_` are operational hints. They may guide
    rendering, ordering, or safety, but never participate in equality.
 7. State proof compares post-apply declarative identities. Data proof remaps
@@ -147,16 +148,18 @@ the column fact. Keeping the optional column in the codec and every identity
 rewrite is essential—dropping it aliases a column grant with an object grant.
 
 The semantic payload contains sorted `privileges` and `grantable` sets.
-Extraction models the grantee's **effective privileges**, not which grantor
+Extraction models the grantee's **explicit ACL privileges**, not which grantor
 supplied them. `aclexplode()` can return the same privilege once per grantor;
 the extractor groups by grantee and de-duplicates privilege and grant-option
-values. Consequently:
+values. It does not resolve role memberships, owner-implied privileges, or
+access inherited through another role. Consequently:
 
-- two databases with the same effective grantee privileges compare equal even
-  if grantor provenance differs;
+- two databases with the same explicit ACL privileges for a grantee compare
+  equal even if grantor provenance differs;
 - removing one of several equivalent grantors is intentionally invisible while
-  the effective set remains;
-- export and replay preserve effective access, not exact GRANT provenance.
+  the explicit ACL set remains;
+- export and replay preserve explicit grantee ACL state, not exact GRANT
+  provenance or the complete authorization closure.
 
 Ordinary object ACL extraction normalizes a null ACL through `acldefault()` and
 synthesizes empty owner/PUBLIC entries when a built-in default was revoked. An
@@ -170,7 +173,7 @@ every object key beginning with `_`. Those fields therefore cannot change fact
 hashes, diff deltas, fingerprints, or state-proof equality.
 
 They are not dead data. They can guide a plan whose semantic need is already
-established by hashed state:
+established by hashed state. The current inventory is:
 
 | Field | Purpose and consumer |
 |---|---|

--- a/docs/architecture/identity-and-acl.md
+++ b/docs/architecture/identity-and-acl.md
@@ -1,0 +1,223 @@
+# Identity and ACL invariants
+
+Read this before changing a `StableId`, adding a role-bearing field, touching
+ACL extraction, or changing rename behavior. PostgreSQL catalogs use OIDs to
+connect objects at runtime; pg-delta uses declarative, name-based addresses to
+describe the state that DDL can reproduce. Confusing those two identities is
+the source of most rename and ACL edge cases.
+
+This document distinguishes the **current implementation** from the **I1
+target**. I1 has not landed yet: current planning still uses post-diff role
+carry and a narrow role-rename ordering carve-out.
+
+## The invariants at a glance
+
+1. A `StableId` is a structured declarative address, not a PostgreSQL OID.
+2. A fact's address belongs in `id`; semantic state belongs in `payload`.
+3. `encodeId()` is the only string codec. Do not recover structured fields by
+   parsing or regex outside that codec.
+4. PostgreSQL carries OID references through a rename, but name-keyed facts do
+   not follow automatically inside pg-delta.
+5. ACL identity is target + grantee + optional column. ACL payload is the
+   effective privilege set; grantor provenance is deliberately not modeled.
+6. Payload keys beginning with `_` are operational hints. They may guide
+   rendering, ordering, or safety, but never participate in equality.
+7. State proof compares post-apply declarative identities. Data proof remaps
+   accepted table/materialized-view renames only.
+
+## StableId means declarative addressability
+
+[`StableId`](../../packages/pg-delta/src/core/stable-id.ts) is a discriminated
+union of the fields PostgreSQL DDL needs to address an object:
+
+- a table is `{ kind: "table", schema, name }`;
+- a routine also includes its argument-type list;
+- a policy includes schema, table, and policy name;
+- a membership includes the granted role and member;
+- an ACL includes its target, grantee, and optional column.
+
+These are durable *names within a captured state*, not durable database
+identities. PostgreSQL may preserve one OID while `ALTER ... RENAME` changes the
+name. pg-delta will then extract a different `StableId` for the same physical
+object.
+
+Keep identity structured end-to-end. Extraction returns identity parts and
+TypeScript constructs the union. `encodeId()` and `parseId()` are the only
+canonical string boundary. Encoded ids currently serve as in-memory map and
+graph keys as well as persisted artifact fields and logs; callers must still
+inspect the structured union rather than reverse-engineering the string.
+Snapshot and plan formats have versions, but the StableId codec itself has no
+independent version tag today.
+
+Identity parts are not duplicated as structured payload attributes. Canonical
+`pg_get_*def()` text can still embed an object's own or referenced names; that
+known limitation can turn a would-be rename into a reported near-miss. Where
+payload content remains identity-free, its hash can remain equal across a leaf
+rename. Named Merkle rollups still fold encoded child ids and dependency
+endpoints, so identity changes propagate to normal state equality. Rename
+proposal uses a separate structural rollup that omits fact/edge identities to
+compare whole subtrees.
+
+## Names carried by PostgreSQL OIDs
+
+`ALTER ROLE old RENAME TO new` changes the catalog name while preserving the
+role OID. Ownership, grants, memberships, user mappings, and policy role lists
+continue to reference that OID. Re-extraction reports `new` everywhere even
+though pg-delta's pre-rename facts were keyed by `old`.
+
+The current StableId role-name registry is
+[`ROLE_NAME_BEARING_KINDS`](../../packages/pg-delta/src/plan/role-rename-carry.ts):
+
+| Kind | Role-bearing identity fields |
+|---|---|
+| `role` | `name` |
+| `membership` | `role`, `member` |
+| `userMapping` | `role` |
+| `defaultPrivilege` | `role`, `grantee` |
+| `acl` | `grantee`; recursively, a role-bearing `target` |
+| `comment` | recursively, a role-bearing `target` |
+| `securityLabel` | recursively, a role-bearing `target` |
+
+Two important role references are outside that table:
+
+- an `owner` is a dependency edge whose `to` endpoint is a role, not a
+  StableId kind;
+- `policy.roles` is a structured payload field, not identity.
+
+The registry guard test forces every new StableId kind to be classified, but it
+cannot protect payload fields. Whenever a new catalog field contains a role
+name, decide explicitly whether it belongs in identity, an edge, or structured
+payload. Do not derive or repair the reference by parsing SQL text.
+
+## Rename flow: current and target
+
+### Current implementation
+
+Current planning performs these steps:
+
+1. Reconstruct the managed source and desired views.
+2. Run generic diff and policy filtering; build remove/add worklists from kept
+   deltas.
+3. Propose rename-capable roots whose identity-free structural rollups match.
+   Ambiguous and near-miss candidates are reported, never guessed.
+4. Accept candidates according to `auto`, `prompt`, and explicit confirmation;
+   cancel their old and new subtrees from create/drop worklists.
+5. For accepted role renames, relabel role-bearing StableIds after the diff.
+   Cancel unchanged remove/add pairs and matching owner unlink/link pairs;
+   convert payload-changed pairs into mutations against the new identity.
+6. Emit the rename separately, with the old subtree in `destroys` and the new
+   subtree in `produces`, so dependent actions order against both names.
+
+This post-diff carry lives in
+[`role-rename-carry.ts`](../../packages/pg-delta/src/plan/role-rename-carry.ts).
+It cannot relabel `policy.roles`, because that reference is payload-carried.
+The current planner therefore retains the narrow B1 ordering carve-out for a
+policy mutation spanning an accepted role rename.
+
+### I1 target (not current)
+
+[I1](../roadmap/agent-tracks/I1-prediff-rename-identity.md) replaces carry with
+identity normalization:
+
+1. A discovery diff, with policy filtering, proposes and accepts role renames.
+2. Copy-on-write normalization rewrites both fact bases into the **desired-name
+   space**: ids, parents, edges, `referenceOnly` encoded ids, and known
+   structured payload references such as `policy.roles`.
+3. A second canonical diff and policy filter produce the ordinary plan.
+4. The existing rename-emission seam still renders SQL from the original
+   physical old/new facts.
+
+Only the source fingerprint remains tied to the physical pre-rename source.
+Everything else consumes the canonical pair. When I1 lands, the role carry
+module and B1 carve-out should disappear; until then, documentation and tests
+must describe them as current behavior.
+
+## ACL identity and equality
+
+An ACL is a satellite fact. Its identity is:
+
+```ts
+{ kind: "acl", target: StableId, grantee: string, column?: string }
+```
+
+For an object-level grant, `target` is the object and `column` is absent. For a
+column-level grant such as `GRANT SELECT (email) ON users TO reporter`, `target`
+remains the owning relation and `column` contains `email`; the fact's parent is
+the column fact. Keeping the optional column in the codec and every identity
+rewrite is essential—dropping it aliases a column grant with an object grant.
+
+The semantic payload contains sorted `privileges` and `grantable` sets.
+Extraction models the grantee's **effective privileges**, not which grantor
+supplied them. `aclexplode()` can return the same privilege once per grantor;
+the extractor groups by grantee and de-duplicates privilege and grant-option
+values. Consequently:
+
+- two databases with the same effective grantee privileges compare equal even
+  if grantor provenance differs;
+- removing one of several equivalent grantors is intentionally invisible while
+  the effective set remains;
+- export and replay preserve effective access, not exact GRANT provenance.
+
+Ordinary object ACL extraction normalizes a null ACL through `acldefault()` and
+synthesizes empty owner/PUBLIC entries when a built-in default was revoked. An
+extension member instead records only differences from `pg_init_privs` (or the
+object default), because recreating the extension restores the installed ACL.
+
+## Non-semantic underscore payload fields
+
+[`canonicalize()`](../../packages/pg-delta/src/core/hash.ts) recursively omits
+every object key beginning with `_`. Those fields therefore cannot change fact
+hashes, diff deltas, fingerprints, or state-proof equality.
+
+They are not dead data. They can guide a plan whose semantic need is already
+established by hashed state:
+
+| Field | Purpose and consumer |
+|---|---|
+| `_ownerDefault` | Version-correct owner defaults from `acldefault()`; lets default-ACL compaction remove only grants PostgreSQL supplies on create. |
+| `_initPrivs` | Extension member's installed ACL; lets ACL removal restore install state instead of blindly revoking everything. |
+| `_revokedDefault` | Records a removed built-in default privilege so default-privilege rendering can restore it. |
+| `_position` | Preserves declared column/composite-attribute creation order without making order-only drift semantic. |
+| `_serverMajor` | Selects only subscription mutations supported by the captured PostgreSQL version. |
+| `_configGucs` | Keeps assumed-schema seeding from replaying routines that require unsafe configuration. |
+
+The rule for adding one is strict: changing an underscore field alone must not
+represent desired-state drift, because generic diff will never see it. Use an
+underscore field only for extraction provenance, rendering context, ordering,
+or safety. If changing the value must produce DDL by itself, it is semantic and
+must not begin with `_`.
+
+## Proof implications
+
+State proof applies the finished plan, re-extracts the clone, reconstructs the
+same managed view, and compares it with the projected desired view. The
+post-apply catalog must therefore use the desired declarative ids and names;
+underscore hints cannot rescue a state mismatch because proof does not include
+them in equality.
+
+Data proof has a narrower rename rule. Accepted table and materialized-view
+renames map the old relation key used for pre-apply row statistics to the new
+relation key used after apply. That prevents a data-preserving rename from being
+misclassified as drop/recreate. Role and other object renames do not use this
+row-key map.
+
+Under the I1 target, the proof algorithm remains unchanged, but fingerprint
+routing matters: apply must compare the physical pre-rename source with the
+physical source fingerprint, while canonical ids feed diff, planning, and the
+desired state proof.
+
+## Checklist for contributors
+
+Before adding or changing identity, ACL, or role-bearing state:
+
+- Is the value part of the DDL address (`id`), semantic state (`payload`), or a
+  dependency/provenance relationship (`edge`)?
+- If a StableId embeds a role name, is its kind classified and relabeled in the
+  role-name-bearing registry and guard test?
+- If a payload embeds a role name, is the current carry limitation documented
+  and the I1 normalizer inventory updated?
+- Does an ACL change preserve `target`, `grantee`, and optional `column`?
+- Are privilege arrays sorted and grantor duplicates removed intentionally?
+- If a field begins with `_`, is it safe for equality and proof to ignore it?
+- Does rename behavior have both plan-ordering coverage and, for relations,
+  data-proof coverage?

--- a/docs/architecture/identity-and-acl.md
+++ b/docs/architecture/identity-and-acl.md
@@ -24,7 +24,7 @@ carry and a narrow role-rename ordering carve-out.
 6. Payload keys beginning with `_` are operational hints. They may guide
    rendering, ordering, or safety, but never participate in equality.
 7. State proof compares post-apply declarative identities. Data proof remaps
-   accepted table/materialized-view renames only.
+   accepted ordinary heap-table renames only.
 
 ## StableId means declarative addressability
 
@@ -101,19 +101,22 @@ Current planning performs these steps:
    deltas.
 3. Propose rename-capable roots whose identity-free structural rollups match.
    Ambiguous and near-miss candidates are reported, never guessed.
-4. Accept candidates according to `auto`, `prompt`, and explicit confirmation;
-   cancel their old and new subtrees from create/drop worklists.
-5. For accepted role renames, relabel role-bearing StableIds after the diff.
-   Cancel unchanged remove/add pairs and matching owner unlink/link pairs;
-   convert payload-changed pairs into mutations against the new identity.
+4. Accept candidates according to the rename mode (`auto`/`prompt`/`off`) and
+   explicit confirmations; cancel their old and new subtrees from create/drop
+   worklists.
+5. For accepted role renames, match remove/add deltas by relabeling their
+   role-bearing StableIds without rewriting either fact base. Cancel unchanged
+   pairs and matching owner unlink/link pairs; convert payload-changed pairs
+   into mutations against the new identity.
 6. Emit the rename separately, with the old subtree in `destroys` and the new
    subtree in `produces`, so dependent actions order against both names.
 
 This post-diff carry lives in
 [`role-rename-carry.ts`](../../packages/pg-delta/src/plan/role-rename-carry.ts).
 It cannot relabel `policy.roles`, because that reference is payload-carried.
-The current planner therefore retains the narrow B1 ordering carve-out for a
-policy mutation spanning an accepted role rename.
+The current planner therefore retains the narrow
+[B1](../roadmap/agent-tracks/B1-role-rename-policy-cycle.md) ordering carve-out
+for a policy mutation spanning an accepted role rename.
 
 ### I1 target (not current)
 
@@ -198,11 +201,13 @@ post-apply catalog must therefore use the desired declarative ids and names;
 underscore hints cannot rescue a state mismatch because proof does not include
 them in equality.
 
-Data proof has a narrower rename rule. Accepted table and materialized-view
-renames map the old relation key used for pre-apply row statistics to the new
-relation key used after apply. That prevents a data-preserving rename from being
-misclassified as drop/recreate. Role and other object renames do not use this
-row-key map.
+Data proof has narrower coverage: row statistics include only ordinary heap
+tables (`pg_class.relkind = 'r'`). For an accepted heap-table rename, proof maps
+the old relation key used before apply to the new key used afterward. That
+prevents a data-preserving rename from being misclassified as drop/recreate.
+Materialized views and partitioned table roots receive state-proof coverage but
+do not enter these row statistics; role and other object renames do not use the
+row-key map either.
 
 Under the I1 target, the proof algorithm remains unchanged, but fingerprint
 routing matters: apply must compare the physical pre-rename source with the

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -156,6 +156,10 @@ interface FactBase {
 }
 ```
 
+For the operational invariants behind StableId addressability, PostgreSQL OID
+carry, ACL equality, underscore metadata, and current-vs-target rename behavior,
+see [identity-and-acl.md](identity-and-acl.md).
+
 Six properties define it:
 
 - **Typed identity, structured end-to-end.** IDs are a discriminated union

--- a/packages/pg-delta/src/core/stable-id.ts
+++ b/packages/pg-delta/src/core/stable-id.ts
@@ -4,6 +4,7 @@
  * The ONLY place the canonical string encoding exists (guardrail 1).
  * Extraction returns identity *parts*; this codec produces/parses strings,
  * which appear only in persisted artifacts, graph keys, and logs.
+ * Identity, rename, and ACL invariants: docs/architecture/identity-and-acl.md.
  */
 
 /** Kinds identified by a single name (cluster- or database-global). */

--- a/packages/pg-delta/src/extract/scope.ts
+++ b/packages/pg-delta/src/extract/scope.ts
@@ -4,6 +4,7 @@
  * builders compose. Splitting the family builders into their own modules keeps
  * each catalog family local; this module is the one place the shared pieces
  * live (target-architecture §3.1–3.2).
+ * ACL identity/equality invariants: docs/architecture/identity-and-acl.md.
  */
 import type { PoolClient } from "pg";
 import type { Diagnostic } from "../core/diagnostic.ts";


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update for the I2 identity/ACL architecture track. No package behavior changes and no changeset.

## What is the current behavior?

The invariants connecting name-keyed `StableId`s, PostgreSQL OID-carried references, role rename carry, ACL equality, underscore metadata, and proof behavior are scattered across code comments. Contributors can easily mistake the planned I1 normalization model for current behavior or accidentally omit a role-bearing/column-qualified identity field.

Roadmap track: [I2 — Document identity / ACL invariants](https://github.com/supabase/pg-toolbelt/blob/feat/pg-delta-next/docs/roadmap/agent-tracks/I2-identity-invariants-docs.md)

## What is the new behavior?

- Adds a contributor-facing identity and ACL invariants document.
- Separates today's post-diff carry and B1 carve-out from the future I1 canonical-normalization target.
- Inventories role-bearing StableId kinds plus owner-edge and `policy.roles` exceptions.
- Documents explicit per-grantee, grantor-blind ACL equality and column-qualified ACL identity.
- Defines the contract for non-hashed `_` payload fields and their current consumers.
- Clarifies state-proof behavior and the data proof's ordinary heap-table coverage.
- Cross-links the document from the architecture index, target architecture, and relevant source headers.

## Additional context

Verification:

- `bun run format-and-lint`
- `bun run check-types`
- `bun run knip`
- Independent source-backed review of every current-vs-target claim and relative link

Docs/comments only; no runtime tests required.
