### PR TITLE
test(pg-delta): prove compact and uncompact corpus plans

### DIFF
--- a/packages/pg-delta/README.md
+++ b/packages/pg-delta/README.md
@@ -53,9 +53,12 @@ pre-sorting them (via `@supabase/pg-topo`) before the loader runs. See
   surface cycles and other diagnostics for proactive authoring — deliberately
   out of the apply path so apply stays Postgres-truth.
 
-- **Corpus proof loop**: every scenario in `corpus/` proven in BOTH
-  directions (build and teardown) — state proof = zero drift deltas after
-  applying the plan to a clone; data proof = seeded rows survive. The proof
+- **Corpus proof loop**: every scenario in `corpus/` is proven in BOTH
+  directions (build and teardown), with independently built compact and
+  uncompacted plan artifacts applied end-to-end. Compaction is therefore
+  enforced as cosmetic rather than required for convergence. State proof =
+  zero drift deltas after applying the plan to a clone; data proof = seeded
+  rows survive. The proof
   reports honest per-table **coverage** (`tablesChecked`, `tablesSkipped`,
   and a `contentMode` of `fingerprint` / `count` / `none`) rather than a bare
   boolean: a non-empty table whose schema is unchanged is content-fingerprinted
@@ -185,8 +188,9 @@ bun scripts/benchmark.ts                                # timing numbers
 ```
 
 Compaction (cosmetic clause folding + redundant-drop / default-ACL elision) is
-**on by default** and proof-stable — the plan converges to the same state either
-way. The passes, in order:
+**on by default** and proof-stable — the corpus independently builds, applies,
+and proves compact and uncompacted artifacts for every scenario and direction.
+The passes, in order:
 
 - **column folds** — `ADD COLUMN` clauses fold into their bare `CREATE TABLE`
   when no graph edge crosses the merge.

--- a/packages/pg-delta/tests/containers.ts
+++ b/packages/pg-delta/tests/containers.ts
@@ -7,13 +7,14 @@
  * `isolatedClusterPair()` is a SINGLETON pair shared by every cluster-level
  * test, and roles are cluster-global, so roles ACCUMULATE across scenarios.
  * There is NO automatic role cleanup — `dropRolesExcept` is exposed but each
- * caller must call it (and even then it is best-effort: a role owning objects
- * in another still-live test database cannot be dropped until that database is
- * gone). The established pattern for role-heavy tests instead avoids pollution
- * by construction: use distinctive role names/configs so rename detection stays
- * unambiguous, and prove plans that drop/rename roles against the SACRIFICIAL
- * source database directly (never a clone — a clone leaves the original source
- * pinning the old role; see owner-edge.test.ts).
+ * caller must call it. Cleanup is best-effort by default because a role owning
+ * objects in another still-live test database cannot be dropped until that
+ * database is gone; callers that require isolation can enable strict
+ * postcondition verification. The established pattern for role-heavy tests
+ * otherwise avoids pollution by construction: use distinctive role names/configs
+ * so rename detection stays unambiguous, and prove plans that drop/rename roles
+ * against the SACRIFICIAL source database directly (never a clone — a clone
+ * leaves the original source pinning the old role; see owner-edge.test.ts).
  */
 import {
   GenericContainer,
@@ -160,18 +161,41 @@ export class Cluster {
     return new Set(res.rows.map((r) => (r as { rolname: string }).rolname));
   }
 
-  /** Drop roles created since `baseline` (scenario cleanup). */
-  async dropRolesExcept(baseline: Set<string>): Promise<void> {
+  /** Drop roles created since `baseline`; strict mode verifies the postcondition. */
+  async dropRolesExcept(
+    baseline: Set<string>,
+    options: { strict?: boolean } = {},
+  ): Promise<void> {
     const current = await this.listRoles();
+    const cleanupErrors: string[] = [];
     for (const role of current) {
       if (baseline.has(role)) continue;
       const quoted = `"${role.replaceAll('"', '""')}"`;
-      await this.adminPool
-        .query(`DROP OWNED BY ${quoted} CASCADE`)
-        .catch(() => {});
-      await this.adminPool
-        .query(`DROP ROLE IF EXISTS ${quoted}`)
-        .catch(() => {});
+      try {
+        await this.adminPool.query(`DROP OWNED BY ${quoted} CASCADE`);
+      } catch (error) {
+        cleanupErrors.push(`${role} DROP OWNED: ${String(error)}`);
+      }
+      try {
+        await this.adminPool.query(`DROP ROLE IF EXISTS ${quoted}`);
+      } catch (error) {
+        cleanupErrors.push(`${role} DROP ROLE: ${String(error)}`);
+      }
+    }
+
+    if (options.strict) {
+      const remaining = [...(await this.listRoles())]
+        .filter((role) => !baseline.has(role))
+        .sort();
+      if (remaining.length > 0) {
+        const detail =
+          cleanupErrors.length > 0
+            ? `; cleanup errors: ${cleanupErrors.join("; ")}`
+            : "";
+        throw new Error(
+          `Role cleanup incomplete; non-baseline roles remain: ${remaining.join(", ")}${detail}`,
+        );
+      }
     }
   }
 

--- a/packages/pg-delta/tests/engine.test.ts
+++ b/packages/pg-delta/tests/engine.test.ts
@@ -25,10 +25,56 @@ import {
 } from "./containers.ts";
 import { EXPECTED_RED } from "./expected-red.ts";
 
+const COMPACT_MODES = [true, false] as const;
+type ModeRunner = (key: string, run: () => Promise<void>) => Promise<void>;
+
+function compactLabel(compact: boolean): string {
+  return compact ? "compact" : "uncompact";
+}
+
+function failureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function withModeContext(
+  key: string,
+  run: () => Promise<void>,
+): Promise<void> {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof Error) {
+      if (!error.message.includes(`[${key}]`)) {
+        error.message = `[${key}] ${error.message}`;
+      }
+      throw error;
+    }
+    throw new Error(`[${key}] ${String(error)}`);
+  }
+}
+
+async function runCompactModes(
+  run: (compact: boolean) => Promise<void>,
+): Promise<void> {
+  const failures: unknown[] = [];
+  for (const compact of COMPACT_MODES) {
+    try {
+      await run(compact);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length === 1) throw failures[0];
+  if (failures.length > 1) {
+    throw new AggregateError(failures, failures.map(failureMessage).join("\n"));
+  }
+}
+
 async function proveOn(
   name: string,
   scenarioName: string,
   direction: "forward" | "reverse",
+  compact: boolean,
   clusterA: Cluster,
   clusterB: Cluster,
   fromSql: string,
@@ -53,6 +99,7 @@ async function proveOn(
     const capability = await probeApplierCapability(source.pool);
     const thePlan = plan(sourceState.factBase, desiredState.factBase, {
       capability,
+      compact,
     });
 
     const clone = await source.clone();
@@ -132,13 +179,72 @@ async function proveOn(
 async function runDirection(
   scenario: Scenario,
   direction: "forward" | "reverse",
+  modeRunner: ModeRunner = async (_key, run) => run(),
 ): Promise<void> {
   const [fromSql, toSql, seed] =
     direction === "forward"
       ? [scenario.a, scenario.b, scenario.seed]
       : [scenario.b, scenario.a, scenario.seedB];
-  const label =
-    direction === "forward" ? scenario.name : `${scenario.name}:reverse`;
+  const label = `${scenario.name}:${direction}`;
+
+  const proveMode = async (
+    compact: boolean,
+    clusterA: Cluster,
+    clusterB: Cluster,
+    cleanup: () => Promise<unknown> = async () => {},
+  ): Promise<void> => {
+    const key = `${label} [${compactLabel(compact)}]`;
+    let modeFailed = false;
+    let modeError: unknown;
+    try {
+      await modeRunner(key, () =>
+        withModeContext(key, () =>
+          proveOn(
+            key,
+            scenario.name,
+            direction,
+            compact,
+            clusterA,
+            clusterB,
+            fromSql,
+            toSql,
+            seed,
+          ),
+        ),
+      );
+    } catch (error) {
+      modeFailed = true;
+      modeError = error;
+    }
+
+    // Cleanup is intentionally outside modeRunner: EXPECTED_RED classifies
+    // planner/proof failures only and must never swallow a broken teardown.
+    let cleanupFailed = false;
+    let cleanupError: unknown;
+    try {
+      await withModeContext(key, async () => {
+        await cleanup();
+      });
+    } catch (error) {
+      cleanupFailed = true;
+      cleanupError = error;
+    }
+
+    if (modeFailed && cleanupFailed) {
+      // Preserve the mode error's concrete type: SeedCoverageError must remain
+      // distinguishable so EXPECTED_RED can never swallow it.
+      if (modeError instanceof Error) {
+        modeError.message += `\ncleanup also failed: ${failureMessage(cleanupError)}`;
+        throw modeError;
+      }
+      throw new AggregateError(
+        [modeError, cleanupError],
+        `proof failed: ${failureMessage(modeError)}\ncleanup also failed: ${failureMessage(cleanupError)}`,
+      );
+    }
+    if (modeFailed) throw modeError;
+    if (cleanupFailed) throw cleanupError;
+  };
 
   if (scenario.meta.isolatedCluster) {
     const [clusterA, clusterB] = await isolatedClusterPair();
@@ -149,23 +255,16 @@ async function runDirection(
       clusterA.listRoles(),
       clusterB.listRoles(),
     ]);
-    try {
-      await proveOn(
-        label,
-        scenario.name,
-        direction,
-        clusterA,
-        clusterB,
-        fromSql,
-        toSql,
-        seed,
-      );
-    } finally {
-      await Promise.all([
-        clusterA.dropRolesExcept(baseA),
-        clusterB.dropRolesExcept(baseB),
-      ]);
-    }
+    await runCompactModes((compact) =>
+      proveMode(compact, clusterA, clusterB, async () => {
+        // proveOn drops every scenario database before returning. Only then is
+        // it safe to reset cluster-global roles for the next mode's replay.
+        await Promise.all([
+          clusterA.dropRolesExcept(baseA),
+          clusterB.dropRolesExcept(baseB),
+        ]);
+      }),
+    );
     return;
   }
 
@@ -173,16 +272,20 @@ async function runDirection(
   if (scenario.meta.minVersion !== undefined) {
     if ((await cluster.pgMajor()) < scenario.meta.minVersion) return;
   }
-  await proveOn(
-    label,
-    scenario.name,
-    direction,
-    cluster,
-    cluster,
-    fromSql,
-    toSql,
-    seed,
-  );
+
+  if (mustRunSerially(scenario)) {
+    const baselineRoles = await cluster.listRoles();
+    await runCompactModes((compact) =>
+      proveMode(compact, cluster, cluster, async () => {
+        // Database teardown lives inside proveOn and therefore completes before
+        // role cleanup. This ordering avoids DROP ROLE ownership/grant errors.
+        await cluster.dropRolesExcept(baselineRoles);
+      }),
+    );
+    return;
+  }
+
+  await runCompactModes((compact) => proveMode(compact, cluster, cluster));
 }
 
 async function runPinnedOrProve(
@@ -203,13 +306,14 @@ async function runPinnedOrProve(
     const cluster = await sharedCluster();
     if ((await cluster.pgMajor()) < pin.minMajor) pinned = false;
   }
-  if (!pinned) {
-    await runDirection(scenario, direction);
-    return;
-  }
-  // runPinnedDirection owns the pinned semantics (incl. the seed-coverage
-  // rethrow), so the guard is bound by seed-coverage.test.ts.
-  await runPinnedDirection(key, () => runDirection(scenario, direction));
+  const modeRunner = pinned
+    ? (modeKey: string, run: () => Promise<void>) =>
+        // runPinnedDirection owns the pinned semantics (incl. the seed-coverage
+        // rethrow), so the guard is bound by seed-coverage.test.ts. Applying it
+        // per mode ensures both artifacts run and each stale pin is detected.
+        runPinnedDirection(modeKey, run)
+    : undefined;
+  await runDirection(scenario, direction, modeRunner);
 }
 
 // Live progress (opt-in via PGDELTA_NEXT_PROGRESS=1). `bun test` buffers its
@@ -334,7 +438,7 @@ if (CONCURRENCY > 1) {
             corpusProgress(c.label, ok);
           }
         },
-        180_000,
+        360_000,
       );
     }
   });

--- a/packages/pg-delta/tests/engine.test.ts
+++ b/packages/pg-delta/tests/engine.test.ts
@@ -260,8 +260,8 @@ async function runDirection(
         // proveOn drops every scenario database before returning. Only then is
         // it safe to reset cluster-global roles for the next mode's replay.
         await Promise.all([
-          clusterA.dropRolesExcept(baseA),
-          clusterB.dropRolesExcept(baseB),
+          clusterA.dropRolesExcept(baseA, { strict: true }),
+          clusterB.dropRolesExcept(baseB, { strict: true }),
         ]);
       }),
     );
@@ -279,7 +279,7 @@ async function runDirection(
       proveMode(compact, cluster, cluster, async () => {
         // Database teardown lives inside proveOn and therefore completes before
         // role cleanup. This ordering avoids DROP ROLE ownership/grant errors.
-        await cluster.dropRolesExcept(baselineRoles);
+        await cluster.dropRolesExcept(baselineRoles, { strict: true });
       }),
     );
     return;

--- a/packages/pg-delta/tests/role-cleanup.test.ts
+++ b/packages/pg-delta/tests/role-cleanup.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { Cluster } from "./containers.ts";
+
+function clusterWithRoleCleanupFailure(): Cluster {
+  const adminPool = {
+    async query(sql: string) {
+      if (sql.startsWith("SELECT rolname")) {
+        return { rows: [{ rolname: "test" }, { rolname: "leftover" }] };
+      }
+      if (sql.startsWith("DROP ")) {
+        throw new Error("role is still referenced");
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    },
+  };
+
+  return new Cluster(undefined as never, adminPool as never, () => "");
+}
+
+describe("Cluster.dropRolesExcept", () => {
+  test("strict cleanup rejects when a non-baseline role remains", async () => {
+    const cluster = clusterWithRoleCleanupFailure();
+
+    expect(
+      cluster.dropRolesExcept(new Set(["test"]), { strict: true }),
+    ).rejects.toThrow(/role cleanup incomplete.*leftover/i);
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test-harness and documentation update for roadmap track C1.

## What is the current behavior?

The corpus builds and proves one plan artifact per scenario and direction using  <br>the default compacted shape. An uncompacted plan can therefore regress without  <br>the corpus detecting it, even though users can request `--no-compact` output.

Refs supabase/pg-toolbelt#333

## What is the new behavior?

* Builds independent `compact: true` and `compact: false` plan artifacts for  <br>every corpus scenario and direction, then proves each artifact end-to-end.
* Replays each mode from clean databases and strictly verifies cluster-global  <br>roles return to their baseline after database teardown.
* Runs both modes even after a failure, applies EXPECTED_RED semantics per mode,  <br>and keeps cleanup failures outside expected-red classification.
* Adds scenario, direction, and compact-mode context to failures.
* Documents compaction as cosmetic rather than required for convergence.

## Additional context

No production planner/proof API or default behavior changes. No changeset is  <br>needed because this PR only changes tests and documentation.

Review-fix RED evidence:

```text
Expected promise that rejects
Received promise that resolved
```

After strict postcondition verification was enabled, the focused regression  <br>test and both shared/isolated role corpus paths pass.

Validation:

* `bun test tests/role-cleanup.test.ts` — 1 passed
* focused shared + isolated role corpus cases — 4 passed
* `bun run test:pg-delta` — 805 passed
* `PGDELTA_NEXT_CONCURRENCY=8 PGDELTA_TEST_IMAGE=postgres:17-alpine bun test tests/engine.test.ts` — 632/632 corpus directions passed
* `bun run format-and-lint`
* `bun run check-types`
* `bun run knip`