### PR TITLE
fix(pg-delta): stop dropping REVOKE ... FROM PUBLIC in privilege diffs

### DIFF
--- a/.changeset/pg-delta-public-default-privilege-diff.md
+++ b/.changeset/pg-delta-public-default-privilege-diff.md
@@ -1,0 +1,27 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): correctly diff PUBLIC's built-in default privilege so REVOKE ... FROM PUBLIC is no longer silently dropped for functions, procedures, aggregates, domains, enums, ranges, composite types, and languages
+
+`filterPublicBuiltInDefaults` stripped any `grantee === "PUBLIC"` entry
+matching an object type's implicit default privilege (EXECUTE for
+procedures/aggregates, USAGE for domains/enums/ranges/composite
+types/languages) from both sides of a privilege diff, unconditionally.
+
+For altered objects, both sides' privileges are already extracted via
+`COALESCE(<acl-column>, acldefault(...))`, so they correctly and
+symmetrically reflect PostgreSQL's implicit PUBLIC default (or its
+explicit revocation) with no filtering needed at all - stripping PUBLIC
+from both sides turned "existing object + a new PUBLIC revoke on one
+side" into an empty diff.
+
+For newly created objects, the "effective defaults" side (tracked via
+`ALTER DEFAULT PRIVILEGES` customizations) never encodes PostgreSQL's
+hardcoded PUBLIC fallback, while the desired object's real ACL does -
+filtering PUBLIC off the desired side to paper over that asymmetry
+erased the signal whenever the desired state revoked PUBLIC's default.
+A new `withPublicBuiltInDefault` helper now adds that built-in default
+back onto the defaults side instead, so both sides compare
+symmetrically and an explicit `REVOKE ... FROM PUBLIC` in the desired
+state is preserved.

--- a/packages/pg-delta/src/core/objects/aggregate/aggregate.diff.ts
+++ b/packages/pg-delta/src/core/objects/aggregate/aggregate.diff.ts
@@ -2,7 +2,7 @@ import { diffObjects } from "../base.diff.ts";
 import {
   diffPrivileges,
   emitObjectPrivilegeChanges,
-  filterPublicBuiltInDefaults,
+  withPublicBuiltInDefault,
 } from "../base.privilege-diff.ts";
 import type { ObjectDiffContext } from "../diff-context.ts";
 import { diffSecurityLabels } from "../security-label.types.ts";
@@ -79,17 +79,16 @@ export function diffAggregates(
       aggregate.owner !== ctx.currentUser
         ? effectiveDefaults.filter((p) => p.grantee !== ctx.currentUser)
         : effectiveDefaults;
-    // Filter out PUBLIC's built-in default EXECUTE privilege (PostgreSQL grants it automatically)
-    // Reference: https://www.postgresql.org/docs/17/ddl-priv.html Table 5.2
-    // This prevents generating unnecessary "GRANT EXECUTE TO PUBLIC" statements
-    const desiredPrivileges = filterPublicBuiltInDefaults(
-      "aggregate",
-      aggregate.privileges,
-    );
+    // aggregate.privileges is the desired object's real ACL, which already
+    // reflects PostgreSQL's implicit PUBLIC EXECUTE default (or its absence,
+    // if explicitly revoked). Compare it unfiltered against the defaults side
+    // with that same built-in default added back in, so both sides are
+    // symmetric.
+    const desiredPrivileges = aggregate.privileges;
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Use the aggregate owner as the reference.
     const privilegeResults = diffPrivileges(
-      filterPublicBuiltInDefaults("aggregate", creatorFilteredDefaults),
+      withPublicBuiltInDefault("aggregate", creatorFilteredDefaults),
       desiredPrivileges,
       aggregate.owner,
     );
@@ -216,22 +215,15 @@ export function diffAggregates(
     );
 
     // PRIVILEGES
-    // Filter out PUBLIC's built-in default EXECUTE privilege from main catalog
-    // (PostgreSQL grants it automatically, so we shouldn't compare it)
-    const mainPrivilegesFiltered = filterPublicBuiltInDefaults(
-      "aggregate",
-      mainAggregate.privileges,
-    );
-    // Filter out PUBLIC's built-in default EXECUTE privilege from branch catalog
-    const branchPrivilegesFiltered = filterPublicBuiltInDefaults(
-      "aggregate",
-      branchAggregate.privileges,
-    );
+    // Both mainAggregate.privileges and branchAggregate.privileges are
+    // extracted via COALESCE(<acl-column>, acldefault(...)), so PostgreSQL's
+    // implicit PUBLIC EXECUTE default is already correctly represented (or
+    // absent, if explicitly revoked) on both sides. Diff them unfiltered.
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Use branch owner as the reference.
     const privilegeResults = diffPrivileges(
-      mainPrivilegesFiltered,
-      branchPrivilegesFiltered,
+      mainAggregate.privileges,
+      branchAggregate.privileges,
       branchAggregate.owner,
     );
 

--- a/packages/pg-delta/src/core/objects/base.privilege-diff.ts
+++ b/packages/pg-delta/src/core/objects/base.privilege-diff.ts
@@ -169,9 +169,10 @@ function groupPrivilegesByColumns<T extends PrivilegeProps>(
 }
 
 /**
- * Filters out PUBLIC's built-in default privileges that PostgreSQL automatically grants
- * when creating certain object types. This prevents generating unnecessary GRANT statements
- * for privileges that PostgreSQL grants automatically.
+ * Returns the privilege name that PostgreSQL implicitly grants to PUBLIC by
+ * default for a given object type (e.g. EXECUTE for procedures/aggregates,
+ * USAGE for domains/enums/ranges/composite types/languages), or `null` if the
+ * object type has no PUBLIC built-in default.
  *
  * Reference: PostgreSQL 17 Documentation, Table 5.2 "Summary of Access Privileges"
  * https://www.postgresql.org/docs/17/ddl-priv.html
@@ -181,47 +182,91 @@ function groupPrivilegesByColumns<T extends PrivilegeProps>(
  * - Types/Domains/Enums/Ranges/Composite Types: USAGE
  * - Languages: USAGE
  *
- * Objects WITHOUT default PUBLIC privileges (so we should generate GRANT statements):
+ * Objects WITHOUT default PUBLIC privileges:
  * - Tables, Views, Materialized Views, Sequences, Schemas, etc.
+ */
+function getPublicBuiltInDefaultPrivilege(
+  objectType: Change["objectType"],
+): string | null {
+  switch (objectType) {
+    case "procedure":
+    case "aggregate":
+      return "EXECUTE";
+
+    case "domain":
+    case "enum":
+    case "range":
+    case "composite_type":
+    case "language":
+      return "USAGE";
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Filters out PUBLIC's built-in default privileges that PostgreSQL automatically grants
+ * when creating certain object types. This prevents generating unnecessary GRANT statements
+ * for privileges that PostgreSQL grants automatically.
+ *
+ * See {@link getPublicBuiltInDefaultPrivilege} for the object type -> privilege mapping.
  */
 export function filterPublicBuiltInDefaults<T extends PrivilegeProps>(
   objectType: Change["objectType"],
   privileges: T[],
 ): T[] {
-  // Only filter PUBLIC privileges
-  return privileges.filter((priv) => {
-    if (priv.grantee !== "PUBLIC") {
-      return true; // Keep all non-PUBLIC privileges
-    }
+  const builtInPrivilege = getPublicBuiltInDefaultPrivilege(objectType);
+  if (builtInPrivilege === null) {
+    // This object type has no PUBLIC built-in default, so keep all PUBLIC
+    // privileges and generate GRANT statements for them.
+    return privileges;
+  }
 
-    // Check if this is a built-in default privilege for this object type
-    switch (objectType) {
-      case "procedure":
-      case "aggregate":
-        // Functions/Procedures/Aggregates: EXECUTE is granted to PUBLIC by default
-        // Filter it out so we don't generate unnecessary GRANT EXECUTE TO PUBLIC
-        return priv.privilege !== "EXECUTE";
+  return privileges.filter(
+    (priv) => priv.grantee !== "PUBLIC" || priv.privilege !== builtInPrivilege,
+  );
+}
 
-      case "domain":
-      case "enum":
-      case "range":
-      case "composite_type":
-        // Types/Domains/Enums/Ranges/Composite Types: USAGE is granted to PUBLIC by default
-        // Filter it out so we don't generate unnecessary GRANT USAGE TO PUBLIC
-        return priv.privilege !== "USAGE";
+/**
+ * Adds PostgreSQL's implicit PUBLIC built-in default privilege (e.g. EXECUTE
+ * for procedures/aggregates, USAGE for domains/enums/ranges/composite
+ * types/languages) to a privilege list, unless an entry for that grantee and
+ * privilege is already present.
+ *
+ * `DefaultPrivilegeState.getEffectiveDefaults` only tracks explicit
+ * `ALTER DEFAULT PRIVILEGES` customizations, so it never encodes PostgreSQL's
+ * hardcoded PUBLIC fallback the way a real ACL does. This helper restores
+ * that fallback so the "effective defaults" side of a create-path privilege
+ * diff can be compared symmetrically against the desired object's actual
+ * (unfiltered) privileges.
+ *
+ * See {@link getPublicBuiltInDefaultPrivilege} for the object type -> privilege mapping.
+ */
+export function withPublicBuiltInDefault<T extends PrivilegeProps>(
+  objectType: Change["objectType"],
+  privileges: T[],
+): T[] {
+  const builtInPrivilege = getPublicBuiltInDefaultPrivilege(objectType);
+  if (builtInPrivilege === null) {
+    return privileges;
+  }
 
-      case "language":
-        // Languages: USAGE is granted to PUBLIC by default
-        // Filter it out so we don't generate unnecessary GRANT USAGE TO PUBLIC
-        return priv.privilege !== "USAGE";
+  const hasDefaultAlready = privileges.some(
+    (priv) => priv.grantee === "PUBLIC" && priv.privilege === builtInPrivilege,
+  );
+  if (hasDefaultAlready) {
+    return privileges;
+  }
 
-      default:
-        // For other object types (tables, views, sequences, schemas, etc.),
-        // PUBLIC has NO default privileges, so we should keep all PUBLIC privileges
-        // and generate GRANT statements for them
-        return true;
-    }
-  });
+  return [
+    ...privileges,
+    {
+      grantee: "PUBLIC",
+      privilege: builtInPrivilege,
+      grantable: false,
+    } as T,
+  ];
 }
 
 /**

--- a/packages/pg-delta/src/core/objects/domain/domain.diff.ts
+++ b/packages/pg-delta/src/core/objects/domain/domain.diff.ts
@@ -2,7 +2,7 @@ import { diffObjects } from "../base.diff.ts";
 import {
   diffPrivileges,
   emitObjectPrivilegeChanges,
-  filterPublicBuiltInDefaults,
+  withPublicBuiltInDefault,
 } from "../base.privilege-diff.ts";
 import type { ObjectDiffContext } from "../diff-context.ts";
 import { diffSecurityLabels } from "../security-label.types.ts";
@@ -113,17 +113,16 @@ export function diffDomains(
       newDomain.owner !== ctx.currentUser
         ? effectiveDefaults.filter((p) => p.grantee !== ctx.currentUser)
         : effectiveDefaults;
-    // Filter out PUBLIC's built-in default USAGE privilege (PostgreSQL grants it automatically)
-    // Reference: https://www.postgresql.org/docs/17/ddl-priv.html Table 5.2
-    // This prevents generating unnecessary "GRANT USAGE TO PUBLIC" statements
-    const desiredPrivileges = filterPublicBuiltInDefaults(
-      "domain",
-      newDomain.privileges,
-    );
+    // newDomain.privileges is the desired object's real ACL, which already
+    // reflects PostgreSQL's implicit PUBLIC USAGE default (or its absence, if
+    // explicitly revoked). Compare it unfiltered against the defaults side
+    // with that same built-in default added back in, so both sides are
+    // symmetric.
+    const desiredPrivileges = newDomain.privileges;
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Use the domain owner as the reference.
     const privilegeResults = diffPrivileges(
-      filterPublicBuiltInDefaults("domain", creatorFilteredDefaults),
+      withPublicBuiltInDefault("domain", creatorFilteredDefaults),
       desiredPrivileges,
       newDomain.owner,
     );
@@ -289,22 +288,15 @@ export function diffDomains(
     );
 
     // PRIVILEGES
-    // Filter out PUBLIC's built-in default USAGE privilege from main catalog
-    // (PostgreSQL grants it automatically, so we shouldn't compare it)
-    const mainPrivilegesFiltered = filterPublicBuiltInDefaults(
-      "domain",
-      mainDomain.privileges,
-    );
-    // Filter out PUBLIC's built-in default USAGE privilege from branch catalog
-    const branchPrivilegesFiltered = filterPublicBuiltInDefaults(
-      "domain",
-      branchDomain.privileges,
-    );
+    // Both mainDomain.privileges and branchDomain.privileges are extracted via
+    // COALESCE(<acl-column>, acldefault(...)), so PostgreSQL's implicit
+    // PUBLIC USAGE default is already correctly represented (or absent, if
+    // explicitly revoked) on both sides. Diff them unfiltered.
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Use branch owner as the reference.
     const privilegeResults = diffPrivileges(
-      mainPrivilegesFiltered,
-      branchPrivilegesFiltered,
+      mainDomain.privileges,
+      branchDomain.privileges,
       branchDomain.owner,
     );
 

--- a/packages/pg-delta/src/core/objects/language/language.diff.ts
+++ b/packages/pg-delta/src/core/objects/language/language.diff.ts
@@ -3,7 +3,6 @@ import { diffObjects } from "../base.diff.ts";
 import {
   diffPrivileges,
   emitObjectPrivilegeChanges,
-  filterPublicBuiltInDefaults,
 } from "../base.privilege-diff.ts";
 import type { ObjectDiffContext } from "../diff-context.ts";
 import { hasNonAlterableChanges } from "../utils.ts";
@@ -104,22 +103,16 @@ export function diffLanguages(
       // a name change would be handled as drop + create by diffObjects()
 
       // PRIVILEGES
-      // Filter out PUBLIC's built-in default USAGE privilege from main catalog
-      // (PostgreSQL grants it automatically, so we shouldn't compare it)
-      const mainPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "language",
-        mainLanguage.privileges,
-      );
-      // Filter out PUBLIC's built-in default USAGE privilege from branch catalog
-      const branchPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "language",
-        branchLanguage.privileges,
-      );
+      // Both mainLanguage.privileges and branchLanguage.privileges are
+      // extracted via COALESCE(<acl-column>, acldefault(...)), so
+      // PostgreSQL's implicit PUBLIC USAGE default is already correctly
+      // represented (or absent, if explicitly revoked) on both sides. Diff
+      // them unfiltered.
       // Filter out owner privileges - owner always has ALL privileges implicitly
       // and shouldn't be compared. Use branch owner as the reference.
       const privilegeResults = diffPrivileges(
-        mainPrivilegesFiltered,
-        branchPrivilegesFiltered,
+        mainLanguage.privileges,
+        branchLanguage.privileges,
         branchLanguage.owner,
       );
 

--- a/packages/pg-delta/src/core/objects/procedure/procedure.diff.ts
+++ b/packages/pg-delta/src/core/objects/procedure/procedure.diff.ts
@@ -2,7 +2,7 @@ import { diffObjects } from "../base.diff.ts";
 import {
   diffPrivileges,
   emitObjectPrivilegeChanges,
-  filterPublicBuiltInDefaults,
+  withPublicBuiltInDefault,
 } from "../base.privilege-diff.ts";
 import type { ObjectDiffContext } from "../diff-context.ts";
 import { diffSecurityLabels } from "../security-label.types.ts";
@@ -94,18 +94,17 @@ export function diffProcedures(
       proc.owner !== ctx.currentUser
         ? effectiveDefaults.filter((p) => p.grantee !== ctx.currentUser)
         : effectiveDefaults;
-    // Filter out PUBLIC's built-in default EXECUTE privilege (PostgreSQL grants it automatically)
-    // Reference: https://www.postgresql.org/docs/17/ddl-priv.html Table 5.2
-    // This prevents generating unnecessary "GRANT EXECUTE TO PUBLIC" statements
-    const desiredPrivileges = filterPublicBuiltInDefaults(
-      "procedure",
-      proc.privileges,
-    );
+    // proc.privileges is the desired object's real ACL, which already
+    // reflects PostgreSQL's implicit PUBLIC EXECUTE default (or its absence,
+    // if explicitly revoked). Compare it unfiltered against the defaults side
+    // with that same built-in default added back in, so both sides are
+    // symmetric.
+    const desiredPrivileges = proc.privileges;
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Note: we use the final owner (proc.owner), not the
     // current user, because ownership change happens before privilege diffing.
     const privilegeResults = diffPrivileges(
-      filterPublicBuiltInDefaults("procedure", creatorFilteredDefaults),
+      withPublicBuiltInDefault("procedure", creatorFilteredDefaults),
       desiredPrivileges,
       proc.owner,
     );
@@ -364,22 +363,15 @@ export function diffProcedures(
       // a name change would be handled as drop + create by diffObjects()
 
       // PRIVILEGES
-      // Filter out PUBLIC's built-in default EXECUTE privilege from main catalog
-      // (PostgreSQL grants it automatically, so we shouldn't compare it)
-      const mainPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "procedure",
-        mainProcedure.privileges,
-      );
-      // Filter out PUBLIC's built-in default EXECUTE privilege from branch catalog
-      const branchPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "procedure",
-        branchProcedure.privileges,
-      );
+      // Both mainProcedure.privileges and branchProcedure.privileges are
+      // extracted via COALESCE(<acl-column>, acldefault(...)), so PostgreSQL's
+      // implicit PUBLIC EXECUTE default is already correctly represented (or
+      // absent, if explicitly revoked) on both sides. Diff them unfiltered.
       // Filter out owner privileges - owner always has ALL privileges implicitly
       // and shouldn't be compared. Use branch owner as the reference.
       const privilegeResults = diffPrivileges(
-        mainPrivilegesFiltered,
-        branchPrivilegesFiltered,
+        mainProcedure.privileges,
+        branchProcedure.privileges,
         branchProcedure.owner,
       );
 

--- a/packages/pg-delta/src/core/objects/type/composite-type/composite-type.diff.ts
+++ b/packages/pg-delta/src/core/objects/type/composite-type/composite-type.diff.ts
@@ -2,7 +2,7 @@ import { diffObjects } from "../../base.diff.ts";
 import {
   diffPrivileges,
   emitObjectPrivilegeChanges,
-  filterPublicBuiltInDefaults,
+  withPublicBuiltInDefault,
 } from "../../base.privilege-diff.ts";
 import type { ObjectDiffContext } from "../../diff-context.ts";
 import { diffSecurityLabels } from "../../security-label.types.ts";
@@ -106,17 +106,16 @@ export function diffCompositeTypes(
       ct.owner !== ctx.currentUser
         ? effectiveDefaults.filter((p) => p.grantee !== ctx.currentUser)
         : effectiveDefaults;
-    // Filter out PUBLIC's built-in default USAGE privilege (PostgreSQL grants it automatically)
-    // Reference: https://www.postgresql.org/docs/17/ddl-priv.html Table 5.2
-    // This prevents generating unnecessary "GRANT USAGE TO PUBLIC" statements
-    const desiredPrivileges = filterPublicBuiltInDefaults(
-      "composite_type",
-      ct.privileges,
-    );
+    // ct.privileges is the desired object's real ACL, which already reflects
+    // PostgreSQL's implicit PUBLIC USAGE default (or its absence, if
+    // explicitly revoked). Compare it unfiltered against the defaults side
+    // with that same built-in default added back in, so both sides are
+    // symmetric.
+    const desiredPrivileges = ct.privileges;
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Use the composite type owner as the reference.
     const privilegeResults = diffPrivileges(
-      filterPublicBuiltInDefaults("composite_type", creatorFilteredDefaults),
+      withPublicBuiltInDefault("composite_type", creatorFilteredDefaults),
       desiredPrivileges,
       ct.owner,
     );
@@ -299,22 +298,16 @@ export function diffCompositeTypes(
       }
 
       // PRIVILEGES
-      // Filter out PUBLIC's built-in default USAGE privilege from main catalog
-      // (PostgreSQL grants it automatically, so we shouldn't compare it)
-      const mainPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "composite_type",
-        mainCompositeType.privileges,
-      );
-      // Filter out PUBLIC's built-in default USAGE privilege from branch catalog
-      const branchPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "composite_type",
-        branchCompositeType.privileges,
-      );
+      // Both mainCompositeType.privileges and branchCompositeType.privileges
+      // are extracted via COALESCE(<acl-column>, acldefault(...)), so
+      // PostgreSQL's implicit PUBLIC USAGE default is already correctly
+      // represented (or absent, if explicitly revoked) on both sides. Diff
+      // them unfiltered.
       // Filter out owner privileges - owner always has ALL privileges implicitly
       // and shouldn't be compared. Use branch owner as the reference.
       const privilegeResults = diffPrivileges(
-        mainPrivilegesFiltered,
-        branchPrivilegesFiltered,
+        mainCompositeType.privileges,
+        branchCompositeType.privileges,
         branchCompositeType.owner,
       );
 

--- a/packages/pg-delta/src/core/objects/type/enum/enum.diff.ts
+++ b/packages/pg-delta/src/core/objects/type/enum/enum.diff.ts
@@ -2,7 +2,7 @@ import { diffObjects } from "../../base.diff.ts";
 import {
   diffPrivileges,
   emitObjectPrivilegeChanges,
-  filterPublicBuiltInDefaults,
+  withPublicBuiltInDefault,
 } from "../../base.privilege-diff.ts";
 import type { ObjectDiffContext } from "../../diff-context.ts";
 import { diffSecurityLabels } from "../../security-label.types.ts";
@@ -89,17 +89,16 @@ export function diffEnums(
       createdEnum.owner !== ctx.currentUser
         ? effectiveDefaults.filter((p) => p.grantee !== ctx.currentUser)
         : effectiveDefaults;
-    // Filter out PUBLIC's built-in default USAGE privilege (PostgreSQL grants it automatically)
-    // Reference: https://www.postgresql.org/docs/17/ddl-priv.html Table 5.2
-    // This prevents generating unnecessary "GRANT USAGE TO PUBLIC" statements
-    const desiredPrivileges = filterPublicBuiltInDefaults(
-      "enum",
-      createdEnum.privileges,
-    );
+    // createdEnum.privileges is the desired object's real ACL, which already
+    // reflects PostgreSQL's implicit PUBLIC USAGE default (or its absence, if
+    // explicitly revoked). Compare it unfiltered against the defaults side
+    // with that same built-in default added back in, so both sides are
+    // symmetric.
+    const desiredPrivileges = createdEnum.privileges;
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Use the enum owner as the reference.
     const privilegeResults = diffPrivileges(
-      filterPublicBuiltInDefaults("enum", creatorFilteredDefaults),
+      withPublicBuiltInDefault("enum", creatorFilteredDefaults),
       desiredPrivileges,
       createdEnum.owner,
     );
@@ -159,12 +158,14 @@ export function diffEnums(
         branchEnum.owner !== ctx.currentUser
           ? effectiveDefaults.filter((p) => p.grantee !== ctx.currentUser)
           : effectiveDefaults;
-      const desiredPrivileges = filterPublicBuiltInDefaults(
-        "enum",
-        branchEnum.privileges,
-      );
+      // branchEnum.privileges is the desired object's real ACL, which already
+      // reflects PostgreSQL's implicit PUBLIC USAGE default (or its absence,
+      // if explicitly revoked). Compare it unfiltered against the defaults
+      // side with that same built-in default added back in, so both sides
+      // are symmetric.
+      const desiredPrivileges = branchEnum.privileges;
       const privilegeResults = diffPrivileges(
-        filterPublicBuiltInDefaults("enum", creatorFilteredDefaults),
+        withPublicBuiltInDefault("enum", creatorFilteredDefaults),
         desiredPrivileges,
         branchEnum.owner,
       );
@@ -230,22 +231,15 @@ export function diffEnums(
     );
 
     // PRIVILEGES
-    // Filter out PUBLIC's built-in default USAGE privilege from main catalog
-    // (PostgreSQL grants it automatically, so we shouldn't compare it)
-    const mainPrivilegesFiltered = filterPublicBuiltInDefaults(
-      "enum",
-      mainEnum.privileges,
-    );
-    // Filter out PUBLIC's built-in default USAGE privilege from branch catalog
-    const branchPrivilegesFiltered = filterPublicBuiltInDefaults(
-      "enum",
-      branchEnum.privileges,
-    );
+    // Both mainEnum.privileges and branchEnum.privileges are extracted via
+    // COALESCE(<acl-column>, acldefault(...)), so PostgreSQL's implicit
+    // PUBLIC USAGE default is already correctly represented (or absent, if
+    // explicitly revoked) on both sides. Diff them unfiltered.
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Use branch owner as the reference.
     const privilegeResults = diffPrivileges(
-      mainPrivilegesFiltered,
-      branchPrivilegesFiltered,
+      mainEnum.privileges,
+      branchEnum.privileges,
       branchEnum.owner,
     );
 

--- a/packages/pg-delta/src/core/objects/type/range/range.diff.ts
+++ b/packages/pg-delta/src/core/objects/type/range/range.diff.ts
@@ -2,7 +2,7 @@ import { diffObjects } from "../../base.diff.ts";
 import {
   diffPrivileges,
   emitObjectPrivilegeChanges,
-  filterPublicBuiltInDefaults,
+  withPublicBuiltInDefault,
 } from "../../base.privilege-diff.ts";
 import type { ObjectDiffContext } from "../../diff-context.ts";
 import { diffSecurityLabels } from "../../security-label.types.ts";
@@ -87,17 +87,16 @@ export function diffRanges(
       createdRange.owner !== ctx.currentUser
         ? effectiveDefaults.filter((p) => p.grantee !== ctx.currentUser)
         : effectiveDefaults;
-    // Filter out PUBLIC's built-in default USAGE privilege (PostgreSQL grants it automatically)
-    // Reference: https://www.postgresql.org/docs/17/ddl-priv.html Table 5.2
-    // This prevents generating unnecessary "GRANT USAGE TO PUBLIC" statements
-    const desiredPrivileges = filterPublicBuiltInDefaults(
-      "range",
-      createdRange.privileges,
-    );
+    // createdRange.privileges is the desired object's real ACL, which already
+    // reflects PostgreSQL's implicit PUBLIC USAGE default (or its absence, if
+    // explicitly revoked). Compare it unfiltered against the defaults side
+    // with that same built-in default added back in, so both sides are
+    // symmetric.
+    const desiredPrivileges = createdRange.privileges;
     // Filter out owner privileges - owner always has ALL privileges implicitly
     // and shouldn't be compared. Use the range owner as the reference.
     const privilegeResults = diffPrivileges(
-      filterPublicBuiltInDefaults("range", creatorFilteredDefaults),
+      withPublicBuiltInDefault("range", creatorFilteredDefaults),
       desiredPrivileges,
       createdRange.owner,
     );
@@ -190,22 +189,15 @@ export function diffRanges(
       );
 
       // PRIVILEGES
-      // Filter out PUBLIC's built-in default USAGE privilege from main catalog
-      // (PostgreSQL grants it automatically, so we shouldn't compare it)
-      const mainPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "range",
-        mainRange.privileges,
-      );
-      // Filter out PUBLIC's built-in default USAGE privilege from branch catalog
-      const branchPrivilegesFiltered = filterPublicBuiltInDefaults(
-        "range",
-        branchRange.privileges,
-      );
+      // Both mainRange.privileges and branchRange.privileges are extracted
+      // via COALESCE(<acl-column>, acldefault(...)), so PostgreSQL's implicit
+      // PUBLIC USAGE default is already correctly represented (or absent, if
+      // explicitly revoked) on both sides. Diff them unfiltered.
       // Filter out owner privileges - owner always has ALL privileges implicitly
       // and shouldn't be compared. Use branch owner as the reference.
       const privilegeResults = diffPrivileges(
-        mainPrivilegesFiltered,
-        branchPrivilegesFiltered,
+        mainRange.privileges,
+        branchRange.privileges,
         branchRange.owner,
       );
 

--- a/packages/pg-delta/tests/integration/revoke-execute-from-public.test.ts
+++ b/packages/pg-delta/tests/integration/revoke-execute-from-public.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import dedent from "dedent";
+import type { Pool } from "pg";
+import { createPlan } from "../../src/core/plan/create.ts";
+import { flattenPlanStatements } from "../../src/core/plan/render.ts";
+import { POSTGRES_VERSIONS } from "../constants.ts";
+import { withDbIsolated } from "../utils.ts";
+import { roundtripFidelityTest } from "./roundtrip.ts";
+
+const FN = "public.secret_fn()";
+
+async function generatedSql(main: Pool, branch: Pool): Promise<string[]> {
+  const planResult = await createPlan(main, branch, {});
+  return planResult ? flattenPlanStatements(planResult.plan) : [];
+}
+
+// probe_nopriv has no explicit grants, so it can EXECUTE only via PUBLIC.
+async function publicCanExecute(db: Pool): Promise<boolean> {
+  const { rows } = await db.query(
+    `SELECT has_function_privilege('probe_nopriv', '${FN}', 'EXECUTE') AS ok`,
+  );
+  return rows[0].ok === true;
+}
+
+for (const pgVersion of POSTGRES_VERSIONS) {
+  describe(`revoke execute from PUBLIC (pg${pgVersion})`, () => {
+    test(
+      "control: REVOKE EXECUTE ... FROM <named role> is emitted",
+      withDbIsolated(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: dedent`
+            CREATE ROLE app_user;
+            CREATE FUNCTION ${FN} RETURNS int LANGUAGE sql AS $$ SELECT 1 $$;
+            GRANT EXECUTE ON FUNCTION ${FN} TO app_user;
+          `,
+          testSql: dedent`REVOKE EXECUTE ON FUNCTION ${FN} FROM app_user;`,
+          expectedSqlTerms: [
+            "SET check_function_bodies = false",
+            "REVOKE ALL ON FUNCTION public.secret_fn() FROM app_user",
+          ],
+        });
+      }),
+    );
+
+    test(
+      "create: preserves REVOKE EXECUTE ... FROM PUBLIC",
+      withDbIsolated(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          testSql: dedent`
+            CREATE FUNCTION ${FN} RETURNS int LANGUAGE sql AS $$ SELECT 1 $$;
+            REVOKE EXECUTE ON FUNCTION ${FN} FROM PUBLIC;
+          `,
+          expectedSqlTerms: [
+            "SET check_function_bodies = false",
+            "CREATE FUNCTION public.secret_fn()\n RETURNS integer\n LANGUAGE sql\nAS $function$ SELECT 1 $function$",
+            "REVOKE ALL ON FUNCTION public.secret_fn() FROM PUBLIC",
+          ],
+        });
+      }),
+    );
+
+    test(
+      "applied migration matches the target PUBLIC EXECUTE privilege",
+      withDbIsolated(pgVersion, async (db) => {
+        const { main, branch } = db;
+        await main.query("CREATE ROLE probe_nopriv NOLOGIN");
+        await branch.query("CREATE ROLE probe_nopriv NOLOGIN");
+        await branch.query(dedent`
+          CREATE FUNCTION ${FN} RETURNS int LANGUAGE sql AS $$ SELECT 1 $$;
+          REVOKE EXECUTE ON FUNCTION ${FN} FROM PUBLIC;
+        `);
+
+        const sql = await generatedSql(main, branch);
+        for (const stmt of sql) await main.query(stmt);
+
+        expect(await publicCanExecute(branch)).toBe(false);
+        expect(await publicCanExecute(main)).toBe(false);
+      }),
+    );
+
+    test(
+      "alter: emits REVOKE EXECUTE ... FROM PUBLIC for an existing function",
+      withDbIsolated(pgVersion, async (db) => {
+        const { main, branch } = db;
+        const setup = dedent`CREATE FUNCTION ${FN} RETURNS int LANGUAGE sql AS $$ SELECT 1 $$;`;
+        await main.query(setup);
+        await branch.query(setup);
+        await branch.query(
+          dedent`REVOKE EXECUTE ON FUNCTION ${FN} FROM PUBLIC;`,
+        );
+
+        const sql = await generatedSql(main, branch);
+        expect(sql.join("\n")).toContain("FROM PUBLIC");
+      }),
+    );
+  });
+}

--- a/packages/pg-delta/tests/integration/revoke-usage-from-public-domain.test.ts
+++ b/packages/pg-delta/tests/integration/revoke-usage-from-public-domain.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import dedent from "dedent";
+import type { Pool } from "pg";
+import { createPlan } from "../../src/core/plan/create.ts";
+import { flattenPlanStatements } from "../../src/core/plan/render.ts";
+import { POSTGRES_VERSIONS } from "../constants.ts";
+import { withDbIsolated } from "../utils.ts";
+import { roundtripFidelityTest } from "./roundtrip.ts";
+
+const DOMAIN = "test_schema.secret_dom";
+
+async function generatedSql(main: Pool, branch: Pool): Promise<string[]> {
+  const planResult = await createPlan(main, branch, {});
+  return planResult ? flattenPlanStatements(planResult.plan) : [];
+}
+
+for (const pgVersion of POSTGRES_VERSIONS) {
+  describe(`revoke usage from PUBLIC on domain (pg${pgVersion})`, () => {
+    test(
+      "control: REVOKE USAGE ... FROM <named role> is emitted",
+      withDbIsolated(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: dedent`
+            CREATE SCHEMA test_schema;
+            CREATE ROLE app_user;
+            CREATE DOMAIN ${DOMAIN} AS int;
+            GRANT USAGE ON DOMAIN ${DOMAIN} TO app_user;
+          `,
+          testSql: dedent`REVOKE USAGE ON DOMAIN ${DOMAIN} FROM app_user;`,
+          expectedSqlTerms: [
+            "REVOKE ALL ON DOMAIN test_schema.secret_dom FROM app_user",
+          ],
+        });
+      }),
+    );
+
+    test(
+      "create: preserves REVOKE USAGE ... FROM PUBLIC for a new domain",
+      withDbIsolated(pgVersion, async (db) => {
+        await roundtripFidelityTest({
+          mainSession: db.main,
+          branchSession: db.branch,
+          initialSetup: dedent`CREATE SCHEMA test_schema;`,
+          testSql: dedent`
+            CREATE DOMAIN ${DOMAIN} AS int;
+            REVOKE USAGE ON DOMAIN ${DOMAIN} FROM PUBLIC;
+          `,
+          assertSqlStatements: (sqlStatements) => {
+            expect(
+              sqlStatements.some((s) => s.startsWith("CREATE DOMAIN")),
+            ).toBe(true);
+            expect(sqlStatements).toContain(
+              "REVOKE ALL ON DOMAIN test_schema.secret_dom FROM PUBLIC",
+            );
+          },
+        });
+      }),
+    );
+
+    test(
+      "alter: emits REVOKE USAGE ... FROM PUBLIC for an existing domain",
+      withDbIsolated(pgVersion, async (db) => {
+        const { main, branch } = db;
+        const setup = dedent`
+          CREATE SCHEMA test_schema;
+          CREATE DOMAIN ${DOMAIN} AS int;
+        `;
+        await main.query(setup);
+        await branch.query(setup);
+        await branch.query(
+          dedent`REVOKE USAGE ON DOMAIN ${DOMAIN} FROM PUBLIC;`,
+        );
+
+        const sql = await generatedSql(main, branch);
+        expect(sql.join("\n")).toContain("FROM PUBLIC");
+      }),
+    );
+  });
+}


### PR DESCRIPTION
## What

`filterPublicBuiltInDefaults` stripped any `grantee === "PUBLIC"` entry matching an object type's implicit default privilege (EXECUTE for procedures/aggregates, USAGE for domains/enums/ranges/composite types/languages) from **both sides** of a privilege diff, unconditionally. This silently dropped `REVOKE ... FROM PUBLIC` from generated migrations whenever the desired/branch state explicitly revoked PostgreSQL's automatic PUBLIC grant, in two distinct ways:

- **Alter path** (existing object on both sides): both sides' `.privileges` are already extracted via `COALESCE(<acl-column>, acldefault(...))`, so they correctly and symmetrically reflect PostgreSQL's implicit PUBLIC default (or its explicit revocation) with **no filtering needed at all**. Stripping PUBLIC from both sides turned "existing object + a new PUBLIC revoke on one side" into an empty diff.
- **Create path** (new object): the "effective defaults" side (`ALTER DEFAULT PRIVILEGES` tracking via `DefaultPrivilegeState`) never encodes PostgreSQL's hardcoded PUBLIC fallback, while the desired object's real ACL does — filtering PUBLIC off the desired side to paper over that asymmetry erased the signal whenever the desired state revoked PUBLIC's default.

## Fix

- Alter path (all 7 affected object types): diff both sides unfiltered.
- Create path: a new `withPublicBuiltInDefault` helper adds PostgreSQL's built-in PUBLIC default back onto the *defaults* side (only if not already explicitly tracked), and the desired side is diffed unfiltered. This keeps both sides symmetric so a genuine `REVOKE ... FROM PUBLIC` in the desired state survives the diff, while a desired state that keeps PUBLIC's default still produces no redundant `GRANT`.
- `filterPublicBuiltInDefaults` itself is unchanged in behavior and stays exported — it's still used by the three foreign-data-wrapper diff files, whose object types have no PUBLIC built-in default and hit the no-op branch either way.

Applied identically to `procedure`, `aggregate`, `domain`, `enum` (including its second create-path branch for label-removal drop+recreate), `range`, and `composite_type`. `language` only has an alter path (no `defaultPrivilegeState` in its diff context), so only that path was fixed there.

## Testing

Test-driven per repo convention — first commit adds the regression suite (including the exact repro from #308) and is RED against pre-fix code (5 of 7 new tests fail); second commit is the fix and turns it GREEN.

- New regression suite: `7 pass, 0 fail` (procedure/EXECUTE cases from #308, plus an analogous domain/USAGE suite proving the fix generalizes beyond functions).
- Touched object types' unit tests: `59 pass, 0 fail`.
- Existing privilege/default-privilege integration coverage (`privilege-operations`, `default-privileges-edge-case`, `default-privileges-dependency-ordering`): `46 pass, 0 fail`.
- `dbdev-roundtrip.test.ts` (its own known default-privilege-subtraction scenario): `1 pass, 0 fail`.
- `format-and-lint`, `check-types`, `knip` all clean.

Also independently reproduced end-to-end against `supabase db diff --use-pg-delta` in the Supabase CLI, which is what surfaced this: declarative-schema ACL revokes on functions were silently dropped from generated migrations.

Fixes #308