### PR TITLE
test(pg-delta): add corpus coverage for per-function REVOKE EXECUTE FROM PUBLIC

### DIFF
--- a/packages/pg-delta/corpus/function-ops--revoke-public-execute-existing/a.sql
+++ b/packages/pg-delta/corpus/function-ops--revoke-public-execute-existing/a.sql
@@ -1,0 +1,3 @@
+-- state A: the function exists with its built-in defaults (PUBLIC EXECUTE
+-- intact); acl is NULL in the catalog (issue #308, alter path).
+CREATE FUNCTION public.secret_fn() RETURNS integer LANGUAGE sql AS $$ SELECT 1 $$;

--- a/packages/pg-delta/corpus/function-ops--revoke-public-execute-existing/b.sql
+++ b/packages/pg-delta/corpus/function-ops--revoke-public-execute-existing/b.sql
@@ -1,0 +1,5 @@
+-- state B: same function, only the PUBLIC EXECUTE default is revoked. The diff
+-- must emit `REVOKE ALL ... FROM PUBLIC` (forward) and re-grant EXECUTE TO
+-- PUBLIC (reverse) — issue #308's second manifestation was an EMPTY diff here.
+CREATE FUNCTION public.secret_fn() RETURNS integer LANGUAGE sql AS $$ SELECT 1 $$;
+REVOKE EXECUTE ON FUNCTION public.secret_fn() FROM PUBLIC;

--- a/packages/pg-delta/corpus/function-ops--revoke-public-execute/a.sql
+++ b/packages/pg-delta/corpus/function-ops--revoke-public-execute/a.sql
@@ -1,0 +1,1 @@
+-- state A: empty — the function does not exist yet (issue #308, create path).

--- a/packages/pg-delta/corpus/function-ops--revoke-public-execute/b.sql
+++ b/packages/pg-delta/corpus/function-ops--revoke-public-execute/b.sql
@@ -1,0 +1,7 @@
+-- state B: a function whose built-in PUBLIC EXECUTE default is revoked, with NO
+-- compensating named-role grant (issue #308's minimal repro). The lone revoke is
+-- represented as the ABSENCE of the create-time default, so the create path must
+-- co-emit `REVOKE ALL ... FROM PUBLIC` or the migrated function stays
+-- PUBLIC-executable.
+CREATE FUNCTION public.secret_fn() RETURNS integer LANGUAGE sql AS $$ SELECT 1 $$;
+REVOKE EXECUTE ON FUNCTION public.secret_fn() FROM PUBLIC;


### PR DESCRIPTION
## Summary

Verification of issue #308 (`REVOKE EXECUTE ON FUNCTION ... FROM PUBLIC` silently dropped from the diff) against the next engine (`feat/pg-delta-next`): **the bug does not reproduce there**. The rewrite handles the revoked PUBLIC default at extract time — `aclJson` in `src/extract/scope.ts` synthesizes an empty PUBLIC entry when a customized ACL lacks the kind's built-in PUBLIC default, so the generic diff plans `REVOKE ALL ... FROM PUBLIC`. Because the "kind has a PUBLIC default" test is derived from `acldefault()`, the issue's untested-scope note (domains/types/languages default `USAGE`) is covered by the same mechanism.

This PR pins the issue's two manifestations as corpus scenarios so the proof loop guards them permanently:

1. **Create path** (`function-ops--revoke-public-execute`): empty → function whose built-in PUBLIC EXECUTE is revoked, with no compensating named-role grant. The CREATE must co-emit `REVOKE ALL ... FROM PUBLIC` (the old engine emitted a bare CREATE, leaving the function PUBLIC-executable).
2. **Alter path** (`function-ops--revoke-public-execute-existing`): existing function → lone revoke. The diff must emit the REVOKE forward and re-grant `EXECUTE TO PUBLIC` in reverse (the old engine produced an empty diff).

Both pass the proof loop in both directions and both compact modes on `postgres:17-alpine`; emitted plans verified to contain `REVOKE ALL ON FUNCTION "public"."secret_fn"() FROM PUBLIC`.

## Linked issue

Refs #308 — coverage only; the issue still reproduces on the current engine on `main`, so this PR must not auto-close it. It can be closed as superseded once the next engine ships.

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [ ] Changeset added if this is a user-facing fix/feature (`bunx changeset`) — not needed: test-only, no package behavior change
- [x] `bun run format-and-lint` and `bun run check-types` pass

https://claude.ai/code/session_01H8KLXEx8tA3c2rHGqnsfjx