### PR TITLE
fix(pg-topo): preserve cyclic statements in ordered output

### DIFF
--- a/.changeset/pg-topo-total-ordered.md
+++ b/.changeset/pg-topo-total-ordered.md
@@ -1,0 +1,7 @@
+---
+"@supabase/pg-topo": minor
+---
+
+`analyzeAndSort` now returns a total order: statements trapped in a dependency cycle are appended to `ordered` in deterministic tie-break order instead of being silently dropped. `CYCLE_DETECTED` diagnostics and `graph.cycleGroups` are unchanged.
+
+Consumers that feed `ordered` into a defer-and-retry applier now receive every input statement exactly once. For example, `@supabase/pg-delta` declarative apply now reports genuinely unbuildable cycles as stuck instead of falsely reporting success after dropping the cycle statements.

--- a/.changeset/pg-topo-total-ordered.md
+++ b/.changeset/pg-topo-total-ordered.md
@@ -2,6 +2,6 @@
 "@supabase/pg-topo": patch
 ---
 
-`analyzeAndSort` now returns a total order of every successfully parsed statement: statements trapped in a dependency cycle are emitted in deterministic component order instead of being silently dropped. `CYCLE_DETECTED` diagnostics and `graph.cycleGroups` are unchanged.
+`analyzeAndSort` now returns every successfully parsed statement exactly once. Each input string is parsed atomically, while separate array entries remain independent. The result keeps its maximal acyclic prefix first, then emits residual cycle components and blocked descendants in deterministic condensation-DAG order. `CYCLE_DETECTED` diagnostics and `graph.cycleGroups` are unchanged.
 
 Consumers that feed `ordered` into a defer-and-retry applier now receive every successfully parsed statement exactly once. For example, `@supabase/pg-delta` declarative apply now reports genuinely unbuildable cycles as stuck instead of falsely reporting success after dropping the cycle statements.

--- a/.changeset/pg-topo-total-ordered.md
+++ b/.changeset/pg-topo-total-ordered.md
@@ -1,7 +1,7 @@
 ---
-"@supabase/pg-topo": minor
+"@supabase/pg-topo": patch
 ---
 
-`analyzeAndSort` now returns a total order: statements trapped in a dependency cycle are appended to `ordered` in deterministic tie-break order instead of being silently dropped. `CYCLE_DETECTED` diagnostics and `graph.cycleGroups` are unchanged.
+`analyzeAndSort` now returns a total order of every successfully parsed statement: statements trapped in a dependency cycle are emitted in deterministic component order instead of being silently dropped. `CYCLE_DETECTED` diagnostics and `graph.cycleGroups` are unchanged.
 
-Consumers that feed `ordered` into a defer-and-retry applier now receive every input statement exactly once. For example, `@supabase/pg-delta` declarative apply now reports genuinely unbuildable cycles as stuck instead of falsely reporting success after dropping the cycle statements.
+Consumers that feed `ordered` into a defer-and-retry applier now receive every successfully parsed statement exactly once. For example, `@supabase/pg-delta` declarative apply now reports genuinely unbuildable cycles as stuck instead of falsely reporting success after dropping the cycle statements.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Check types (pg-delta)
-        if: needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true'
+        if: needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true'
         run: bun run --filter '@supabase/pg-delta' check-types
       - name: Check types (pg-topo)
         if: needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true'
@@ -154,7 +154,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.is-release-pr != 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true')
+      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true')
     needs: detect-changes
     name: "pg-delta: Unit tests"
     runs-on: ubuntu-latest
@@ -183,7 +183,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.is-release-pr != 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true')
+      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true')
     needs: detect-changes
     name: "pg-delta: Compute test image hash"
     runs-on: ubuntu-latest
@@ -298,7 +298,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.is-release-pr != 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true') &&
+      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true') &&
       !cancelled() &&
       (
         needs.pg-delta-build-test-images.result == 'success' ||

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Check types (pg-delta)
-        if: needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true'
+        if: needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true'
         run: bun run --filter '@supabase/pg-delta' check-types
       - name: Check types (pg-topo)
         if: needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true'
@@ -154,7 +154,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.is-release-pr != 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true')
+      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true')
     needs: detect-changes
     name: "pg-delta: Unit tests"
     runs-on: ubuntu-latest
@@ -183,7 +183,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.is-release-pr != 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true')
+      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true')
     needs: detect-changes
     name: "pg-delta: Compute test image hash"
     runs-on: ubuntu-latest
@@ -298,7 +298,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.is-release-pr != 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.root == 'true') &&
+      (needs.detect-changes.outputs.pg-delta == 'true' || needs.detect-changes.outputs.pg-topo == 'true' || needs.detect-changes.outputs.root == 'true') &&
       !cancelled() &&
       (
         needs.pg-delta-build-test-images.result == 'success' ||

--- a/packages/pg-delta/tests/integration/declarative-apply.test.ts
+++ b/packages/pg-delta/tests/integration/declarative-apply.test.ts
@@ -105,6 +105,46 @@ async function testDeclarativeApply(options: {
 for (const pgVersion of POSTGRES_VERSIONS) {
   describe(`declarative-apply round-based (pg${pgVersion})`, () => {
     test(
+      "reports dependency cycles as stuck without dropping statements",
+      withDb(pgVersion, async (db) => {
+        const result = await applyDeclarativeSchema({
+          content: [
+            {
+              filePath: "cycle-a.sql",
+              sql: `
+                CREATE TABLE public.cycle_a (
+                  id integer PRIMARY KEY,
+                  b_id integer REFERENCES public.cycle_b(id)
+                );
+              `,
+            },
+            {
+              filePath: "cycle-b.sql",
+              sql: `
+                CREATE TABLE public.cycle_b (
+                  id integer PRIMARY KEY,
+                  a_id integer REFERENCES public.cycle_a(id)
+                );
+              `,
+            },
+          ],
+          pool: db.main,
+          maxRounds: 3,
+          validateFunctionBodies: false,
+        });
+
+        expect(result.totalStatements).toBe(2);
+        expect(
+          result.diagnostics.some(
+            (diagnostic) => diagnostic.code === "CYCLE_DETECTED",
+          ),
+        ).toBe(true);
+        expect(result.apply.status).toBe("stuck");
+        expect(result.apply.stuckStatements).toHaveLength(2);
+      }),
+    );
+
+    test(
       "simple table with index",
       withDb(pgVersion, async (db) => {
         const result = await testDeclarativeApply({

--- a/packages/pg-delta/tests/integration/declarative-apply.test.ts
+++ b/packages/pg-delta/tests/integration/declarative-apply.test.ts
@@ -112,19 +112,15 @@ for (const pgVersion of POSTGRES_VERSIONS) {
             {
               filePath: "cycle-a.sql",
               sql: `
-                CREATE TABLE public.cycle_a (
-                  id integer PRIMARY KEY,
-                  b_id integer REFERENCES public.cycle_b(id)
-                );
+                CREATE VIEW public.cycle_a AS
+                SELECT * FROM public.cycle_b;
               `,
             },
             {
               filePath: "cycle-b.sql",
               sql: `
-                CREATE TABLE public.cycle_b (
-                  id integer PRIMARY KEY,
-                  a_id integer REFERENCES public.cycle_a(id)
-                );
+                CREATE VIEW public.cycle_b AS
+                SELECT * FROM public.cycle_a;
               `,
             },
           ],
@@ -140,7 +136,13 @@ for (const pgVersion of POSTGRES_VERSIONS) {
           ),
         ).toBe(true);
         expect(result.apply.status).toBe("stuck");
+        expect(result.apply.totalApplied).toBe(0);
         expect(result.apply.stuckStatements).toHaveLength(2);
+        expect(
+          result.apply.stuckStatements
+            ?.map((statement) => statement.statement.id)
+            .sort(),
+        ).toEqual(["cycle-a.sql:0", "cycle-b.sql:0"]);
       }),
     );
 

--- a/packages/pg-topo/CLAUDE.md
+++ b/packages/pg-topo/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Package Does
 
-Topological sorting for SQL DDL statements. Parses SQL strings, extracts object dependencies, and returns statements in a valid execution order. The core library is pure (no filesystem dependency).
+Topological sorting for SQL DDL statements. Parses SQL strings, extracts object dependencies, and returns a dependency-safe order for acyclic inputs. Cyclic results use a deterministic cycles-last fallback and require callers to handle `CYCLE_DETECTED` before direct execution. The core library is pure (no filesystem dependency).
 
 ## Commands
 

--- a/packages/pg-topo/README.md
+++ b/packages/pg-topo/README.md
@@ -119,10 +119,11 @@ Each item includes:
 For the core `analyzeAndSort`, `filePath` uses synthetic source labels (e.g. `<input:0>`, `<input:1>`).  
 For `analyzeAndSortFromFiles`, `filePath` is the relative path to the source `.sql` file.
 
-`ordered` is a **total order**: it always contains every input statement exactly
-once. Statements trapped in a dependency cycle are appended after the acyclic
-prefix in deterministic tie-break order rather than being dropped. The cycle is
-still reported through `CYCLE_DETECTED` and `graph.cycleGroups`.
+`ordered` is a **total order**: it always contains every successfully parsed
+statement exactly once. Statements trapped in a dependency cycle are emitted as
+an atomic component in dependency order, with deterministic tie-break ordering
+within the component. The cycle is still reported through `CYCLE_DETECTED` and
+`graph.cycleGroups`.
 
 ### `diagnostics`
 

--- a/packages/pg-topo/README.md
+++ b/packages/pg-topo/README.md
@@ -119,6 +119,11 @@ Each item includes:
 For the core `analyzeAndSort`, `filePath` uses synthetic source labels (e.g. `<input:0>`, `<input:1>`).  
 For `analyzeAndSortFromFiles`, `filePath` is the relative path to the source `.sql` file.
 
+`ordered` is a **total order**: it always contains every input statement exactly
+once. Statements trapped in a dependency cycle are appended after the acyclic
+prefix in deterministic tie-break order rather than being dropped. The cycle is
+still reported through `CYCLE_DETECTED` and `graph.cycleGroups`.
+
 ### `diagnostics`
 
 Static diagnostics emitted by the library:

--- a/packages/pg-topo/README.md
+++ b/packages/pg-topo/README.md
@@ -78,7 +78,10 @@ const result = await analyzeAndSortFromFiles(["./schema"]);
 
 ### `analyzeAndSort(sql: string[]): Promise<AnalyzeResult>`
 
-Pure library function. Accepts an array of SQL content strings. No filesystem access.
+Pure library function. Accepts an array of SQL content strings. Each string is
+parsed atomically: if any SQL in one string is invalid, that entry contributes
+no statements and emits `PARSE_ERROR`. Separate array entries are parsed
+independently. No filesystem access.
 
 ### `analyzeAndSortFromFiles(roots: string[]): Promise<AnalyzeResult>`
 
@@ -107,7 +110,7 @@ Additional exported types:
 
 ### `ordered`
 
-`ordered` is the topologically sorted statement list.  
+`ordered` is the deterministically ordered statement list.
 Each item includes:
 
 - original `sql`
@@ -120,9 +123,11 @@ For the core `analyzeAndSort`, `filePath` uses synthetic source labels (e.g. `<i
 For `analyzeAndSortFromFiles`, `filePath` is the relative path to the source `.sql` file.
 
 `ordered` is a **total order**: it always contains every successfully parsed
-statement exactly once. Statements trapped in a dependency cycle are emitted as
-an atomic component in dependency order, with deterministic tie-break ordering
-within the component. The cycle is still reported through `CYCLE_DETECTED` and
+statement exactly once. It begins with the maximal acyclic prefix that can be
+topologically drained. The residual cycle components and any descendants they
+block follow in condensation-DAG order. Tie-breaks between ready components and
+the order within each cycle are deterministic; the order within a cycle is not
+a topological order. Cycles are still reported through `CYCLE_DETECTED` and
 `graph.cycleGroups`.
 
 ### `diagnostics`

--- a/packages/pg-topo/README.md
+++ b/packages/pg-topo/README.md
@@ -2,7 +2,10 @@
 
 _deterministic dependency sorting for declarative PostgreSQL schemas_
 
-`pg-topo` sorts declarative PostgreSQL schema statements into a deterministic, dependency-safe execution order.
+For acyclic inputs, `pg-topo` sorts declarative PostgreSQL schema statements
+into a deterministic, dependency-safe execution order. When cycles remain, it
+returns a deterministic cycles-last fallback; callers must handle
+`CYCLE_DETECTED` before executing the result directly.
 
 It is designed for SQL-first projects where schema lives in many `.sql` files and statement order is not guaranteed.
 

--- a/packages/pg-topo/docs/architecture.md
+++ b/packages/pg-topo/docs/architecture.md
@@ -194,7 +194,17 @@ Current class priority by phase (high -> low):
 - `post_data`: `CREATE_VIEW`, `CREATE_MATERIALIZED_VIEW`, `CREATE_INDEX`, `CREATE_TRIGGER`, `CREATE_EVENT_TRIGGER`, `CREATE_POLICY`, `CREATE_PUBLICATION`, `CREATE_SUBSCRIPTION`, `SELECT`, `UPDATE`
 - `privileges`: `ALTER_OWNER`, `COMMENT`, `GRANT`, `REVOKE`, `ALTER_DEFAULT_PRIVILEGES`
 
-Cycles are detected using SCC and emitted as `CYCLE_DETECTED` diagnostics with statement/object details.
+The sorter first uses Kahn's algorithm to drain the maximal acyclic prefix. If
+nodes remain, it computes SCCs over that residual and emits the components in
+condensation-DAG order, preserving dependencies between components. Components
+that are ready together, and statements within a cycle, use the deterministic
+ordering above. Intra-cycle order is deterministic but not topological; acyclic
+descendants blocked by a cycle also remain in the residual suffix.
+
+Cycles are emitted as `CYCLE_DETECTED` diagnostics with statement/object
+details. Callers must inspect that diagnostic before direct sequential
+execution because a cyclic result is a deterministic fallback, not a valid
+execution-order guarantee.
 
 ### 5.7 Test-support Postgres validation (`test/support/`)
 

--- a/packages/pg-topo/src/analyze-and-sort.ts
+++ b/packages/pg-topo/src/analyze-and-sort.ts
@@ -221,7 +221,19 @@ export const analyzeAndSort = async (
     }
   }
 
-  const ordered = topoResult.orderedIndices
+  // `ordered` must be a total order — a complete permutation of the input.
+  // Kahn's algorithm drains only the acyclic prefix, so statements trapped in
+  // a dependency cycle are absent from `orderedIndices` (they still surface in
+  // `cycleGroups` and the CYCLE_DETECTED diagnostic). Append those statements
+  // after the drained prefix using the same deterministic tie-break order.
+  const drainedIndices = new Set(topoResult.orderedIndices);
+  const cycleTailIndices = statementNodes
+    .map((_statementNode, index) => index)
+    .filter((index) => !drainedIndices.has(index))
+    .sort((left, right) =>
+      compareStatementIndices(left, right, statementNodes),
+    );
+  const ordered = [...topoResult.orderedIndices, ...cycleTailIndices]
     .map((index) => statementNodes[index])
     .filter((statementNode): statementNode is StatementNode =>
       Boolean(statementNode),

--- a/packages/pg-topo/src/analyze-and-sort.ts
+++ b/packages/pg-topo/src/analyze-and-sort.ts
@@ -221,19 +221,8 @@ export const analyzeAndSort = async (
     }
   }
 
-  // `ordered` must be a total order — a complete permutation of the input.
-  // Kahn's algorithm drains only the acyclic prefix, so statements trapped in
-  // a dependency cycle are absent from `orderedIndices` (they still surface in
-  // `cycleGroups` and the CYCLE_DETECTED diagnostic). Append those statements
-  // after the drained prefix using the same deterministic tie-break order.
-  const drainedIndices = new Set(topoResult.orderedIndices);
-  const cycleTailIndices = statementNodes
-    .map((_statementNode, index) => index)
-    .filter((index) => !drainedIndices.has(index))
-    .sort((left, right) =>
-      compareStatementIndices(left, right, statementNodes),
-    );
-  const ordered = [...topoResult.orderedIndices, ...cycleTailIndices]
+  // `orderedIndices` is a total order of every successfully parsed statement.
+  const ordered = topoResult.orderedIndices
     .map((index) => statementNodes[index])
     .filter((statementNode): statementNode is StatementNode =>
       Boolean(statementNode),

--- a/packages/pg-topo/src/graph/build-graph.ts
+++ b/packages/pg-topo/src/graph/build-graph.ts
@@ -327,12 +327,11 @@ export const buildGraph = (
       //
       // However, since prefix matching is more lenient than exact matching, a
       // false-positive match could introduce a cycle. A cycle is strictly worse
-      // than a missing edge (the topo-sort drops cycle participants entirely,
-      // whereas a missing edge merely defers to a later round). So we check
-      // reachability before adding each edge: if the consumer already has a
-      // path to the candidate producer, adding the reverse edge would create a
-      // cycle and we skip it, emitting a diagnostic that suggests an explicit
-      // annotation to resolve the ambiguity.
+      // than a missing edge because it can obscure the intended dependency
+      // order. So we check reachability before adding each edge: if the consumer
+      // already has a path to the candidate producer, adding the reverse edge
+      // would create a cycle and we skip it, emitting a diagnostic that suggests
+      // an explicit annotation to resolve the ambiguity.
       if (compatibleProducerIndices.length > 1) {
         for (const producerIndex of compatibleProducerIndices) {
           if (typeof producerIndex !== "number") {

--- a/packages/pg-topo/src/graph/topo-sort.ts
+++ b/packages/pg-topo/src/graph/topo-sort.ts
@@ -237,6 +237,8 @@ export const topoSort = (
     return { orderedIndices, cycleGroups: [] };
   }
 
+  // Cycles-last policy: keep the maximal Kahn-drainable prefix, then order the
+  // residual SCC condensation so cycles and everything they block stay after it.
   const residualNodeIndices = new Set<number>();
   for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex += 1) {
     if ((indegree[nodeIndex] ?? 0) > 0) {

--- a/packages/pg-topo/src/graph/topo-sort.ts
+++ b/packages/pg-topo/src/graph/topo-sort.ts
@@ -237,14 +237,21 @@ export const topoSort = (
     return { orderedIndices, cycleGroups: [] };
   }
 
-  const cycleNodeIndices = new Set<number>();
+  const residualNodeIndices = new Set<number>();
   for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex += 1) {
     if ((indegree[nodeIndex] ?? 0) > 0) {
-      cycleNodeIndices.add(nodeIndex);
+      residualNodeIndices.add(nodeIndex);
     }
   }
 
-  const components = stronglyConnectedComponents(edges, cycleNodeIndices);
+  const components = stronglyConnectedComponents(
+    edges,
+    residualNodeIndices,
+  ).map((component) =>
+    [...component].sort((left, right) =>
+      compareStatementIndices(left, right, nodes),
+    ),
+  );
   const cycleGroups = components
     .filter((component) => {
       if (component.length > 1) {
@@ -256,11 +263,7 @@ export const topoSort = (
       }
       return (edges.get(only) ?? new Set<number>()).has(only);
     })
-    .map((component) =>
-      [...component].sort((left, right) =>
-        compareStatementIndices(left, right, nodes),
-      ),
-    );
+    .map((component) => [...component]);
 
   cycleGroups.sort((left, right) => {
     if (left.length === 0 || right.length === 0) {
@@ -273,6 +276,93 @@ export const topoSort = (
     }
     return compareStatementIndices(leftHead, rightHead, nodes);
   });
+
+  const componentByNode = new Map<number, number>();
+  for (
+    let componentIndex = 0;
+    componentIndex < components.length;
+    componentIndex += 1
+  ) {
+    for (const nodeIndex of components[componentIndex] ?? []) {
+      componentByNode.set(nodeIndex, componentIndex);
+    }
+  }
+
+  const componentEdges = new Map<number, Set<number>>();
+  const componentIndegree: number[] = Array.from(
+    { length: components.length },
+    () => 0,
+  );
+  for (const fromNode of residualNodeIndices) {
+    const fromComponent = componentByNode.get(fromNode);
+    if (fromComponent == null) {
+      continue;
+    }
+    for (const toNode of edges.get(fromNode) ?? []) {
+      const toComponent = componentByNode.get(toNode);
+      if (toComponent == null || toComponent === fromComponent) {
+        continue;
+      }
+      const neighbors = componentEdges.get(fromComponent) ?? new Set<number>();
+      if (!neighbors.has(toComponent)) {
+        neighbors.add(toComponent);
+        componentEdges.set(fromComponent, neighbors);
+        componentIndegree[toComponent] =
+          (componentIndegree[toComponent] ?? 0) + 1;
+      }
+    }
+  }
+
+  const compareComponentIndices = (
+    leftComponentIndex: number,
+    rightComponentIndex: number,
+  ): number => {
+    const leftRepresentative = components[leftComponentIndex]?.[0];
+    const rightRepresentative = components[rightComponentIndex]?.[0];
+    if (leftRepresentative == null || rightRepresentative == null) {
+      return leftComponentIndex - rightComponentIndex;
+    }
+    return compareStatementIndices(
+      leftRepresentative,
+      rightRepresentative,
+      nodes,
+    );
+  };
+
+  const readyComponents: number[] = [];
+  for (
+    let componentIndex = 0;
+    componentIndex < components.length;
+    componentIndex += 1
+  ) {
+    if ((componentIndegree[componentIndex] ?? 0) === 0) {
+      readyComponents.push(componentIndex);
+    }
+  }
+  readyComponents.sort(compareComponentIndices);
+
+  while (readyComponents.length > 0) {
+    const componentIndex = readyComponents.shift() as number;
+    orderedIndices.push(...(components[componentIndex] ?? []));
+
+    const neighbors = [...(componentEdges.get(componentIndex) ?? [])].sort(
+      compareComponentIndices,
+    );
+    for (const nextComponent of neighbors) {
+      componentIndegree[nextComponent] =
+        (componentIndegree[nextComponent] ?? 0) - 1;
+      if ((componentIndegree[nextComponent] ?? 0) === 0) {
+        let insertIndex = readyComponents.findIndex(
+          (existingComponent) =>
+            compareComponentIndices(nextComponent, existingComponent) < 0,
+        );
+        if (insertIndex < 0) {
+          insertIndex = readyComponents.length;
+        }
+        readyComponents.splice(insertIndex, 0, nextComponent);
+      }
+    }
+  }
 
   return { orderedIndices, cycleGroups };
 };

--- a/packages/pg-topo/test/analyze-and-sort.test.ts
+++ b/packages/pg-topo/test/analyze-and-sort.test.ts
@@ -311,4 +311,47 @@ describe("analyzeAndSort", () => {
       ),
     );
   });
+
+  test("keeps a cyclic component before its downstream consumer", async () => {
+    const sql = [
+      "create view public.v_downstream as select * from public.v1;",
+      "create view public.v1 as select * from public.v2;",
+      "create view public.v2 as select * from public.v1;",
+    ];
+
+    const result = await analyzeAndSort(sql);
+    const orderedIds = result.ordered.map(
+      (statement) => `${statement.id.filePath}:${statement.id.statementIndex}`,
+    );
+
+    expect(result.ordered).toHaveLength(3);
+    expect(new Set(orderedIds).size).toBe(3);
+    expect(result.graph.cycleGroups).toEqual([
+      [
+        { filePath: "<input:1>", statementIndex: 0, sourceOffset: 0 },
+        { filePath: "<input:2>", statementIndex: 0, sourceOffset: 0 },
+      ],
+    ]);
+
+    const orderedSql = result.ordered.map((statement) =>
+      statement.sql.toLowerCase(),
+    );
+    const downstreamIndex = orderedSql.findIndex((statement) =>
+      statement.includes("v_downstream"),
+    );
+    expect(
+      orderedSql.findIndex((statement) => statement.includes("view public.v1")),
+    ).toBeLessThan(downstreamIndex);
+    expect(
+      orderedSql.findIndex((statement) => statement.includes("view public.v2")),
+    ).toBeLessThan(downstreamIndex);
+
+    const again = await analyzeAndSort(sql);
+    expect(
+      again.ordered.map(
+        (statement) =>
+          `${statement.id.filePath}:${statement.id.statementIndex}`,
+      ),
+    ).toEqual(orderedIds);
+  });
 });

--- a/packages/pg-topo/test/analyze-and-sort.test.ts
+++ b/packages/pg-topo/test/analyze-and-sort.test.ts
@@ -264,4 +264,51 @@ describe("analyzeAndSort", () => {
     expect(first?.id).toBeDefined();
     expect(typeof first?.id.sourceOffset).toBe("number");
   });
+
+  test("ordered is a total order: cycle members are kept, not dropped", async () => {
+    // Two views referencing each other form a dependency cycle. Kahn's
+    // algorithm can drain neither, but `ordered` must still be a complete
+    // permutation of the input — downstream consumers such as pg-delta's
+    // declarative-apply engine feed `ordered` into a defer-and-retry loader and
+    // must receive every statement exactly once.
+    const result = await analyzeAndSort([
+      "create view public.v1 as select * from public.v2;",
+      "create view public.v2 as select * from public.v1;",
+    ]);
+
+    // The cycle is still reported.
+    expect(
+      result.diagnostics.filter(
+        (diagnostic) => diagnostic.code === "CYCLE_DETECTED",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(result.graph.cycleGroups.length).toBeGreaterThan(0);
+
+    // But no statement is dropped from the output.
+    expect(result.ordered.length).toBe(2);
+    const orderedKeys = result.ordered
+      .map((statement) => statement.sql.toLowerCase())
+      .sort();
+    expect(orderedKeys).toEqual([
+      "create view public.v1 as select * from public.v2;",
+      "create view public.v2 as select * from public.v1;",
+    ]);
+
+    // Determinism: the same input yields the same ordered IDs.
+    const again = await analyzeAndSort([
+      "create view public.v1 as select * from public.v2;",
+      "create view public.v2 as select * from public.v1;",
+    ]);
+    expect(
+      again.ordered.map(
+        (statement) =>
+          `${statement.id.filePath}:${statement.id.statementIndex}`,
+      ),
+    ).toEqual(
+      result.ordered.map(
+        (statement) =>
+          `${statement.id.filePath}:${statement.id.statementIndex}`,
+      ),
+    );
+  });
 });

--- a/packages/pg-topo/test/parse.test.ts
+++ b/packages/pg-topo/test/parse.test.ts
@@ -28,6 +28,17 @@ describe("parseSqlContent", () => {
     });
   });
 
+  test("parses each input string atomically", async () => {
+    const result = await parseSqlContent(
+      "create table public.valid(id integer); select * from invalid syntax {{{",
+      "atomic.sql",
+    );
+
+    expect(result.statements).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("PARSE_ERROR");
+  });
+
   test("merges annotation diagnostics with statementId", async () => {
     const content = `
 -- pg-topo:phase bootstrap

--- a/packages/pg-topo/test/topo-sort.test.ts
+++ b/packages/pg-topo/test/topo-sort.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { topoSort } from "../src/graph/topo-sort.ts";
+import type { StatementNode } from "../src/model/types.ts";
+
+const node = (filePath: string): StatementNode => ({
+  id: { filePath, statementIndex: 0 },
+  sql: `create view ${filePath.replaceAll(/\W/g, "_")} as select 1;`,
+  statementClass: "CREATE_VIEW",
+  provides: [],
+  requires: [],
+  phase: "post_data",
+  annotations: {
+    dependsOn: [],
+    requires: [],
+    provides: [],
+  },
+});
+
+describe("topoSort", () => {
+  test("orders chained cycle components by dependency before tie-break keys", () => {
+    const nodes = [
+      node("z-upstream-a.sql"),
+      node("z-upstream-b.sql"),
+      node("a-downstream-a.sql"),
+      node("a-downstream-b.sql"),
+    ];
+    const edges = new Map([
+      [0, new Set([1, 2])],
+      [1, new Set([0])],
+      [2, new Set([3])],
+      [3, new Set([2])],
+    ]);
+
+    const result = topoSort(nodes, edges);
+
+    expect(result.orderedIndices).toEqual([0, 1, 2, 3]);
+    expect(result.orderedIndices).toHaveLength(nodes.length);
+    expect(new Set(result.orderedIndices)).toHaveLength(nodes.length);
+    expect(result.cycleGroups).toEqual([
+      [2, 3],
+      [0, 1],
+    ]);
+  });
+
+  test("keeps the maximal acyclic prefix before independent deterministic cycle components", () => {
+    const nodes = [
+      node("z-acyclic-prefix.sql"),
+      node("b-cycle-a.sql"),
+      node("b-cycle-b.sql"),
+      node("a-cycle-a.sql"),
+      node("a-cycle-b.sql"),
+    ];
+    const edges = new Map([
+      [0, new Set([1, 3])],
+      [1, new Set([2])],
+      [2, new Set([1])],
+      [3, new Set([4])],
+      [4, new Set([3])],
+    ]);
+
+    const result = topoSort(nodes, edges);
+
+    expect(result.orderedIndices).toEqual([0, 3, 4, 1, 2]);
+    expect(result.orderedIndices).toHaveLength(nodes.length);
+    expect(new Set(result.orderedIndices)).toHaveLength(nodes.length);
+    expect(result.cycleGroups).toEqual([
+      [3, 4],
+      [1, 2],
+    ]);
+    expect(topoSort(nodes, edges)).toEqual(result);
+  });
+});


### PR DESCRIPTION
## Summary

- Make pg-topo return every successfully parsed statement exactly once, including statements involved in dependency cycles.
- Preserve the maximal acyclic prefix, then order residual strongly connected components so blocked descendants remain after their providers.
- Add a current-main pg-delta integration regression proving cyclic declarative input is reported as stuck instead of being silently dropped.
- Document the intentional cycles-last behavior and its execution limitations.

## Why this is phased

This PR contains only the pg-topo compatibility work needed by the existing pg-delta engine. It allows pg-topo to be published independently before the larger pg-delta rewrite lands.

No pg-delta production code, package manifest, lockfile, or CI workflow is changed.

## Review loop

Fresh-agent reviews identified and resolved:

- descendants of cycles could be sorted ahead of their cyclic providers;
- parsing needed an explicit per-input-string atomicity contract;
- cyclic output guarantees were overstated as universally dependency-safe;
- proposed CI filter changes would have unnecessarily fanned pg-topo changes into the full pg-delta matrix.

The final independent settlement review reported no findings.

## Validation

- pg-topo full suite: 180 passed
- pg-delta PG17 declarative regression: passed with exact stuck IDs and zero applied statements
- randomized graph invariants: 3,000 graphs passed
- type checks: passed
- formatting and lint: passed
- knip: passed
- changeset status: patch bump for @supabase/pg-topo only

## Release

Includes a patch changeset for @supabase/pg-topo. The existing pg-delta optional peer range accepts the resulting pg-topo alpha release.