### PR TITLE
ci: exempt private org members 

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -25,9 +25,9 @@ and any of these is true:
 - the linked issue is closed, or
 - the linked issue is missing the `open-for-contribution` label.
 
-Authors whose `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`, and bot
-accounts, are **exempt** — Supabase maintainers can keep working from Linear tickets that
-aren't public on GitHub.
+Bots, `OWNER`/`MEMBER`/`COLLABORATOR` authors, and authors with effective `admin` or
+`write` access are **exempt**. The permission check recognizes private organization
+memberships that `author_association` does not expose.
 
 ### Running the gate manually
 

--- a/.github/scripts/contribution-gate.test.ts
+++ b/.github/scripts/contribution-gate.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
+  type AuthorPermission,
   evaluateAllOpenPrs,
   evaluateGate,
+  fetchAuthorPermission,
   GATE_LABEL,
   type GateIo,
   type LinkedIssue,
@@ -9,6 +11,7 @@ import {
 } from "./contribution-gate.ts";
 
 const REPO = "supabase/pg-toolbelt";
+const originalFetch = globalThis.fetch;
 
 describe("evaluateGate", () => {
   test("skips bot authors", () => {
@@ -35,6 +38,22 @@ describe("evaluateGate", () => {
       expect(result.reason).toBe("internal");
     },
   );
+
+  test.each([
+    ["admin", "internal"],
+    ["write", "internal"],
+    ["read", "no-linked-issue"],
+    ["none", "no-linked-issue"],
+  ] as const)("handles %s permission", (authorPermission, reason) => {
+    const result = evaluateGate({
+      repository: REPO,
+      authorAssociation: "CONTRIBUTOR",
+      authorPermission,
+      isBot: false,
+      linkedIssues: [],
+    });
+    expect(result.reason).toBe(reason);
+  });
 
   test("fails when no issue is linked", () => {
     const result = evaluateGate({
@@ -149,31 +168,50 @@ describe("evaluateGate", () => {
 });
 
 describe("evaluateAllOpenPrs", () => {
+  function pr(
+    number: number,
+    authorLogin: string,
+    authorAssociation = "NONE",
+    isBot = false,
+  ): OpenPr {
+    return { number, authorLogin, authorAssociation, isBot };
+  }
+
   function makeIo(
     openPrs: OpenPr[],
     linkedByPr: Record<number, LinkedIssue[]>,
-  ): { io: GateIo; closed: Array<{ number: number; message: string }> } {
+    permissionByLogin: Partial<Record<string, AuthorPermission>> = {},
+  ) {
     const closed: Array<{ number: number; message: string }> = [];
+    const permissionLookups: string[] = [];
+    const linkedIssueLookups: number[] = [];
     const io: GateIo = {
       listOpenPrs: () => Promise.resolve(openPrs),
-      fetchLinkedIssues: (prNumber) =>
-        Promise.resolve(linkedByPr[prNumber] ?? []),
+      fetchPermission: (login) => {
+        permissionLookups.push(login);
+        return Promise.resolve(permissionByLogin[login]);
+      },
+      fetchLinkedIssues: (prNumber) => {
+        linkedIssueLookups.push(prNumber);
+        return Promise.resolve(linkedByPr[prNumber] ?? []);
+      },
       closePr: (prNumber, message) => {
         closed.push({ number: prNumber, message });
         return Promise.resolve();
       },
     };
-    return { io, closed };
+    return { io, closed, permissionLookups, linkedIssueLookups };
   }
 
   test("closes only non-conforming external PRs and leaves the rest", async () => {
-    const { io, closed } = makeIo(
+    const { io, closed, permissionLookups, linkedIssueLookups } = makeIo(
       [
-        { number: 1, authorAssociation: "NONE", isBot: false }, // no issue -> close
-        { number: 2, authorAssociation: "MEMBER", isBot: false }, // internal -> skip
-        { number: 3, authorAssociation: "NONE", isBot: true }, // bot -> skip
-        { number: 4, authorAssociation: "CONTRIBUTOR", isBot: false }, // conforming -> keep
-        { number: 5, authorAssociation: "NONE", isBot: false }, // missing label -> close
+        pr(1, "ext-a"),
+        pr(2, "maint", "MEMBER"),
+        pr(3, "dependabot", "NONE", true),
+        pr(4, "ext-b", "CONTRIBUTOR"),
+        pr(5, "ext-c"),
+        pr(6, "hidden-maint", "CONTRIBUTOR"),
       ],
       {
         4: [
@@ -183,6 +221,7 @@ describe("evaluateAllOpenPrs", () => {
           { repository: REPO, number: 50, state: "OPEN", labels: ["🐛 Bug"] },
         ],
       },
+      { "hidden-maint": "write" },
     );
 
     const entries = await evaluateAllOpenPrs(io, REPO);
@@ -197,18 +236,24 @@ describe("evaluateAllOpenPrs", () => {
     expect(byNumber[3]?.reason).toBe("bot");
     expect(byNumber[4]?.pass).toBe(true);
     expect(byNumber[5]?.reason).toBe("missing-label");
+    expect(byNumber[6]?.pass).toBe(true);
+    expect(byNumber[6]?.reason).toBe("internal");
     expect(closed.find((c) => c.number === 1)?.message).toContain(GATE_LABEL);
+    expect(permissionLookups).toEqual([
+      "ext-a",
+      "ext-b",
+      "ext-c",
+      "hidden-maint",
+    ]);
+    expect(linkedIssueLookups).toEqual([1, 4, 5]);
   });
 
   test("returns an entry per PR and closes none when all conform", async () => {
-    const { io, closed } = makeIo(
-      [{ number: 9, authorAssociation: "NONE", isBot: false }],
-      {
-        9: [
-          { repository: REPO, number: 90, state: "OPEN", labels: [GATE_LABEL] },
-        ],
-      },
-    );
+    const { io, closed } = makeIo([pr(9, "ext")], {
+      9: [
+        { repository: REPO, number: 90, state: "OPEN", labels: [GATE_LABEL] },
+      ],
+    });
 
     const entries = await evaluateAllOpenPrs(io, REPO);
 
@@ -216,4 +261,57 @@ describe("evaluateAllOpenPrs", () => {
     expect(closed).toHaveLength(0);
     expect(entries[0]?.result.pass).toBe(true);
   });
+});
+
+describe("fetchAuthorPermission", () => {
+  const fetchSpy = spyOn(globalThis, "fetch");
+  afterEach(() => {
+    fetchSpy.mockReset();
+  });
+  afterAll(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function stubFetch(status: number, body: unknown): void {
+    fetchSpy.mockImplementation(
+      Object.assign(
+        () => Promise.resolve(new Response(JSON.stringify(body), { status })),
+        { preconnect: () => {} },
+      ),
+    );
+  }
+
+  function getPermission(login = "author") {
+    return fetchAuthorPermission("t", "supabase", "pg-toolbelt", login);
+  }
+
+  test("returns the effective permission for a collaborator", async () => {
+    stubFetch(200, { permission: "admin" });
+    expect(await getPermission()).toBe("admin");
+  });
+
+  test("maps a 404 (non-collaborator fork author) to undefined", async () => {
+    stubFetch(404, { message: "Not Found" });
+    expect(await getPermission()).toBeUndefined();
+  });
+
+  test("throws on other API failures so the run aborts without closing PRs", async () => {
+    stubFetch(403, { message: "Forbidden" });
+    return expect(getPermission()).rejects.toThrow(/403/);
+  });
+
+  test("throws when a successful response has no permission", async () => {
+    stubFetch(200, {});
+    return expect(getPermission()).rejects.toThrow(/permission/);
+  });
+
+  test("skips the network call for a blank login", async () => {
+    stubFetch(200, { permission: "admin" });
+    expect(await getPermission("")).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+test("restores fetch after permission tests", () => {
+  expect(globalThis.fetch).toBe(originalFetch);
 });

--- a/.github/scripts/contribution-gate.ts
+++ b/.github/scripts/contribution-gate.ts
@@ -3,9 +3,8 @@
  * OPEN pull requests opened by external contributors.
  *
  * A PR passes only when it links to an OPEN GitHub issue that carries the
- * `open-for-contribution` label. Members/collaborators/owners and bots are
- * exempt (they work from Linear tickets or automation). PRs that do not follow
- * the process are commented on and closed.
+ * `open-for-contribution` label. Maintainers and bots are exempt. PRs that do
+ * not follow the process are commented on and closed.
  *
  * Two modes, both driven from `main()`:
  *   - single-PR (default): reacts to one PR on `pull_request_target`
@@ -25,8 +24,19 @@
 
 export const GATE_LABEL = "open-for-contribution";
 
-/** Author associations treated as internal (exempt from the gate). */
 const INTERNAL_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+export type AuthorPermission = "admin" | "write" | "read" | "none";
+
+function isInternalAuthor(
+  authorAssociation: string,
+  permission?: AuthorPermission,
+): boolean {
+  return (
+    INTERNAL_ASSOCIATIONS.has(authorAssociation) ||
+    permission === "admin" ||
+    permission === "write"
+  );
+}
 
 export interface LinkedIssue {
   /** `owner/name` of the repo the issue lives in (from GraphQL nameWithOwner). */
@@ -40,6 +50,7 @@ export interface GateInput {
   /** `owner/name` of this repository (from GITHUB_REPOSITORY). */
   repository: string;
   authorAssociation: string;
+  authorPermission?: AuthorPermission;
   isBot: boolean;
   linkedIssues: LinkedIssue[];
 }
@@ -102,7 +113,7 @@ export function evaluateGate(input: GateInput): GateResult {
   if (input.isBot) {
     return { pass: true, reason: "bot" };
   }
-  if (INTERNAL_ASSOCIATIONS.has(input.authorAssociation)) {
+  if (isInternalAuthor(input.authorAssociation, input.authorPermission)) {
     return { pass: true, reason: "internal" };
   }
 
@@ -137,6 +148,7 @@ export function evaluateGate(input: GateInput): GateResult {
 /** Minimal open-PR shape the gate needs to decide exemption. */
 export interface OpenPr {
   number: number;
+  authorLogin: string;
   authorAssociation: string;
   isBot: boolean;
 }
@@ -145,6 +157,7 @@ export interface OpenPr {
 export interface GateIo {
   /** List every open pull request in the repository. */
   listOpenPrs: () => Promise<OpenPr[]>;
+  fetchPermission: (login: string) => Promise<AuthorPermission | undefined>;
   /** Fetch the issues a PR closes (via `closingIssuesReferences`). */
   fetchLinkedIssues: (prNumber: number) => Promise<LinkedIssue[]>;
   /** Comment with `message` then close the PR. Called only for failing PRs. */
@@ -168,10 +181,18 @@ export async function evaluateAllOpenPrs(
   const openPrs = await io.listOpenPrs();
   const entries: SweepEntry[] = [];
   for (const pr of openPrs) {
-    const linkedIssues = await io.fetchLinkedIssues(pr.number);
+    const authorPermission =
+      pr.isBot || INTERNAL_ASSOCIATIONS.has(pr.authorAssociation)
+        ? undefined
+        : await io.fetchPermission(pr.authorLogin);
+    const linkedIssues =
+      pr.isBot || isInternalAuthor(pr.authorAssociation, authorPermission)
+        ? []
+        : await io.fetchLinkedIssues(pr.number);
     const result = evaluateGate({
       repository,
       authorAssociation: pr.authorAssociation,
+      authorPermission,
       isBot: pr.isBot,
       linkedIssues,
     });
@@ -204,6 +225,7 @@ async function githubFetch(
   url: string,
   token: string,
   init: Omit<RequestInit, "headers"> = {},
+  allowStatuses: readonly number[] = [],
 ): Promise<Response> {
   const response = await fetch(url, {
     ...init,
@@ -214,7 +236,7 @@ async function githubFetch(
       "Content-Type": "application/json",
     },
   });
-  if (!response.ok) {
+  if (!response.ok && !allowStatuses.includes(response.status)) {
     const body = await response.text();
     throw new Error(
       `GitHub request failed (${response.status}) for ${url}: ${body}`,
@@ -279,7 +301,7 @@ async function fetchLinkedIssues(
 interface RestPullRequest {
   number: number;
   author_association: string;
-  user: { type: string } | null;
+  user: { login: string; type: string } | null;
 }
 
 async function fetchOpenPullRequests(
@@ -297,6 +319,7 @@ async function fetchOpenPullRequests(
     for (const pr of batch) {
       prs.push({
         number: pr.number,
+        authorLogin: pr.user?.login ?? "",
         authorAssociation: pr.author_association,
         isBot: pr.user?.type === "Bot",
       });
@@ -306,6 +329,35 @@ async function fetchOpenPullRequests(
     }
   }
   return prs;
+}
+
+/** Resolve effective access when private org membership hides the association. */
+export async function fetchAuthorPermission(
+  token: string,
+  owner: string,
+  repo: string,
+  login: string,
+): Promise<AuthorPermission | undefined> {
+  if (!login) {
+    return undefined;
+  }
+  const url =
+    `https://api.github.com/repos/${owner}/${repo}/collaborators/` +
+    `${encodeURIComponent(login)}/permission`;
+  const response = await githubFetch(url, token, {}, [404]);
+  if (response.status === 404) {
+    return undefined;
+  }
+  const { permission } = (await response.json()) as { permission?: unknown };
+  if (
+    permission !== "admin" &&
+    permission !== "write" &&
+    permission !== "read" &&
+    permission !== "none"
+  ) {
+    throw new Error("GitHub permission response is missing a valid permission");
+  }
+  return permission;
 }
 
 /**
@@ -342,19 +394,28 @@ async function runSinglePr(
 ): Promise<void> {
   const prNumber = Number(requireEnv("PR_NUMBER"));
   const authorAssociation = process.env.PR_AUTHOR_ASSOCIATION ?? "NONE";
+  const authorLogin = process.env.PR_AUTHOR_LOGIN ?? "";
   const isBot = (process.env.PR_AUTHOR_TYPE ?? "User") === "Bot";
-
-  const linkedIssues = await fetchLinkedIssues(token, owner, repo, prNumber);
+  const authorPermission =
+    isBot || INTERNAL_ASSOCIATIONS.has(authorAssociation)
+      ? undefined
+      : await fetchAuthorPermission(token, owner, repo, authorLogin);
+  const linkedIssues =
+    isBot || isInternalAuthor(authorAssociation, authorPermission)
+      ? []
+      : await fetchLinkedIssues(token, owner, repo, prNumber);
   const result = evaluateGate({
     repository,
     authorAssociation,
+    authorPermission,
     isBot,
     linkedIssues,
   });
 
   console.log(
     `Contribution gate for PR #${prNumber}: pass=${result.pass} reason=${result.reason} ` +
-      `(author_association=${authorAssociation}, bot=${isBot}, linked_issues=${linkedIssues.length})`,
+      `(author_association=${authorAssociation}, permission=${authorPermission ?? "n/a"}, ` +
+      `bot=${isBot}, linked_issues=${linkedIssues.length})`,
   );
 
   if (result.pass || !result.message) {
@@ -377,6 +438,8 @@ async function runSweep(
   const base = `https://api.github.com/repos/${owner}/${repo}`;
   const io: GateIo = {
     listOpenPrs: () => fetchOpenPullRequests(token, owner, repo),
+    fetchPermission: (login) =>
+      fetchAuthorPermission(token, owner, repo, login),
     fetchLinkedIssues: (prNumber) =>
       fetchLinkedIssues(token, owner, repo, prNumber),
     closePr: makeCloser(token, base, dryRun),

--- a/.github/workflows/contribution-gate.yml
+++ b/.github/workflows/contribution-gate.yml
@@ -51,6 +51,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
         run: bun .github/scripts/contribution-gate.ts
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,8 @@ jobs:
         uses: ./.github/actions/setup
       - name: Format and lint
         run: bun run format-and-lint
+      - name: Test contribution gate
+        run: bun run test:contribution-gate
 
   knip:
     if: >-

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format-and-lint:fix": "oxfmt . && oxlint --fix",
     "knip": "bun run --filter '*' knip",
     "docs:pg-delta": "bun run --filter '@supabase/pg-delta' docs",
+    "test:contribution-gate": "bun test ./.github/scripts/contribution-gate.test.ts",
     "test:pg-delta": "bun run --filter '@supabase/pg-delta' test",
     "test:pg-topo": "bun run --filter '@supabase/pg-topo' test",
     "verdaccio:start": "verdaccio --config ./verdaccio/config.yaml",


### PR DESCRIPTION
## TL;DR

Extends the same permission checking pattern used in supabase/cli#5848 to, preventing the contribution gate from closing PRs opened by contributors/private members with effective `admin` or `write` access....

The gate now checks the author’s effective repository permission when their organization association is ambiguous, while failing safely..

## Refs 
- supabase/cli#5848