### PR TITLE
fix(pg-delta): disambiguate case-colliding schema export paths

### DIFF
--- a/packages/pg-delta/src/core/export/grouper.test.ts
+++ b/packages/pg-delta/src/core/export/grouper.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Change } from "../change.types.ts";
+import { loadDeclarativeSchema } from "../declarative-apply/discover-sql.ts";
+import { disambiguateCaseCollisions, groupChangesByFile } from "./grouper.ts";
+
+// ============================================================================
+// Helpers – minimal Change stubs
+// ============================================================================
+
+/** Minimal table change stub. */
+function tableChange(opts: { schema: string; name: string }): Change {
+  return {
+    objectType: "table",
+    operation: "create",
+    scope: "object",
+    table: {
+      schema: opts.schema,
+      name: opts.name,
+      is_partition: false,
+      parent_name: null,
+      parent_schema: null,
+    },
+    serialize: () => `CREATE TABLE "${opts.schema}"."${opts.name}" ()`,
+  } as unknown as Change;
+}
+
+/** All paths in a group list, for assertions. */
+function paths(groups: ReturnType<typeof groupChangesByFile>): string[] {
+  return groups.map((group) => group.path);
+}
+
+// ============================================================================
+// disambiguateCaseCollisions
+// ============================================================================
+
+describe("disambiguateCaseCollisions", () => {
+  test("returns an empty map when no paths collide", () => {
+    const renames = disambiguateCaseCollisions([
+      "schemas/public/tables/users.sql",
+      "schemas/public/tables/orders.sql",
+      "schemas/public/views/users.sql",
+    ]);
+    expect(renames.size).toBe(0);
+  });
+
+  test("renames every member of a case-colliding set", () => {
+    const renames = disambiguateCaseCollisions([
+      "schemas/public/tables/Users.sql",
+      "schemas/public/tables/users.sql",
+      "schemas/public/tables/orders.sql",
+    ]);
+    expect(renames.size).toBe(2);
+    expect(renames.has("schemas/public/tables/Users.sql")).toBe(true);
+    expect(renames.has("schemas/public/tables/users.sql")).toBe(true);
+    // Non-colliding path untouched.
+    expect(renames.has("schemas/public/tables/orders.sql")).toBe(false);
+  });
+
+  test("renamed paths keep the .sql extension and original casing", () => {
+    const renames = disambiguateCaseCollisions([
+      "schemas/public/tables/Users.sql",
+      "schemas/public/tables/users.sql",
+    ]);
+    const renamed = renames.get("schemas/public/tables/Users.sql");
+    expect(renamed).toMatch(
+      /^schemas\/public\/tables\/Users-[0-9a-f]{8}\.sql$/,
+    );
+  });
+
+  test("renames are deterministic and independent of input order", () => {
+    const forward = disambiguateCaseCollisions([
+      "schemas/public/tables/Users.sql",
+      "schemas/public/tables/users.sql",
+    ]);
+    const backward = disambiguateCaseCollisions([
+      "schemas/public/tables/users.sql",
+      "schemas/public/tables/Users.sql",
+    ]);
+    expect(forward.get("schemas/public/tables/Users.sql")).toBe(
+      backward.get("schemas/public/tables/Users.sql") as string,
+    );
+    expect(forward.get("schemas/public/tables/users.sql")).toBe(
+      backward.get("schemas/public/tables/users.sql") as string,
+    );
+  });
+
+  test("detects collisions across directory segments (schema case twins)", () => {
+    const renames = disambiguateCaseCollisions([
+      "schemas/Public/tables/users.sql",
+      "schemas/public/tables/users.sql",
+    ]);
+    expect(renames.size).toBe(2);
+    const values = [...renames.values()].map((p) => p.toLowerCase());
+    expect(new Set(values).size).toBe(2);
+  });
+});
+
+// ============================================================================
+// groupChangesByFile – case-twin handling
+// ============================================================================
+
+describe("groupChangesByFile case-insensitive collisions", () => {
+  test("case-twin tables map to case-insensitively distinct paths", () => {
+    const groups = groupChangesByFile([
+      tableChange({ schema: "public", name: "Users" }),
+      tableChange({ schema: "public", name: "users" }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    const [first, second] = paths(groups);
+    expect(first).not.toBe(second);
+    expect((first as string).toLowerCase()).not.toBe(
+      (second as string).toLowerCase(),
+    );
+  });
+
+  test("non-colliding tables keep their current paths", () => {
+    const groups = groupChangesByFile([
+      tableChange({ schema: "public", name: "users" }),
+      tableChange({ schema: "public", name: "orders" }),
+    ]);
+
+    expect(paths(groups).sort()).toEqual([
+      "schemas/public/tables/orders.sql",
+      "schemas/public/tables/users.sql",
+    ]);
+  });
+
+  test("a collision does not rename unrelated files", () => {
+    const groups = groupChangesByFile([
+      tableChange({ schema: "public", name: "Users" }),
+      tableChange({ schema: "public", name: "users" }),
+      tableChange({ schema: "public", name: "orders" }),
+    ]);
+
+    expect(paths(groups)).toContain("schemas/public/tables/orders.sql");
+    expect(paths(groups)).not.toContain("schemas/public/tables/users.sql");
+    expect(paths(groups)).not.toContain("schemas/public/tables/Users.sql");
+  });
+
+  test("renamed paths are stable across export runs and input order", () => {
+    const groups = groupChangesByFile([
+      tableChange({ schema: "public", name: "Users" }),
+      tableChange({ schema: "public", name: "users" }),
+    ]);
+    const reversed = groupChangesByFile([
+      tableChange({ schema: "public", name: "users" }),
+      tableChange({ schema: "public", name: "Users" }),
+    ]);
+
+    expect(paths(groups).sort()).toEqual(paths(reversed).sort());
+  });
+
+  test("case-twin exports survive a write to a real filesystem", async () => {
+    // On case-insensitive filesystems (APFS/NTFS) `Users.sql` and `users.sql`
+    // are one physical file; without disambiguation the second write silently
+    // overwrites the first (issue #365). This reproduces the CLI write loop.
+    const groups = groupChangesByFile([
+      tableChange({ schema: "public", name: "Users" }),
+      tableChange({ schema: "public", name: "users" }),
+      tableChange({ schema: "public", name: "orders" }),
+    ]);
+
+    const outDir = await mkdtemp(path.join(tmpdir(), "pg-delta-export-"));
+    try {
+      for (const group of groups) {
+        const filePath = path.join(outDir, group.path);
+        await mkdir(path.dirname(filePath), { recursive: true });
+        const sql = group.changes
+          .map((change) => change.serialize())
+          .join("\n");
+        await writeFile(filePath, sql);
+      }
+
+      // Every manifest entry must exist as its own physical file.
+      const tablesDir = path.join(outDir, "schemas", "public", "tables");
+      const onDisk = await readdir(tablesDir);
+      expect(onDisk.length).toBe(groups.length);
+
+      // Reimport: discovery must find one entry per exported object, and no
+      // object's DDL may have been overwritten.
+      const entries = await loadDeclarativeSchema(outDir);
+      expect(entries).toHaveLength(groups.length);
+      const allSql = entries.map((entry) => entry.sql).join("\n");
+      expect(allSql).toContain('CREATE TABLE "public"."Users" ()');
+      expect(allSql).toContain('CREATE TABLE "public"."users" ()');
+      expect(allSql).toContain('CREATE TABLE "public"."orders" ()');
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/pg-delta/src/core/export/grouper.ts
+++ b/packages/pg-delta/src/core/export/grouper.ts
@@ -2,6 +2,8 @@
  * Group changes into declarative schema files and order them for readability.
  */
 
+import { createHash } from "node:crypto";
+import createDebug from "debug";
 import type { Change } from "../change.types.ts";
 import { getFilePath } from "./file-mapper.ts";
 import type { FileCategory, FileMetadata, FilePath } from "./types.ts";
@@ -60,6 +62,106 @@ function sortChangesWithinFile(changes: Change[]): Change[] {
   return tagged.map((t) => t.change);
 }
 
+const debugExport = createDebug("pg-delta:export");
+
+// ============================================================================
+// Case-collision disambiguation
+// ============================================================================
+
+/** Initial length of the hex hash suffix appended to case-colliding paths. */
+const CASE_HASH_LENGTH = 8;
+
+/** Full length of a sha256 hex digest -- upper bound for suffix growth. */
+const MAX_CASE_HASH_LENGTH = 64;
+
+function caseHashSuffix(originalPath: string, length: number): string {
+  return createHash("sha256")
+    .update(originalPath, "utf8")
+    .digest("hex")
+    .slice(0, length);
+}
+
+/** Insert `-<hash>` before the extension: `Users.sql` -> `Users-1a2b3c4d.sql`. */
+function appendCaseHash(originalPath: string, length: number): string {
+  const suffix = caseHashSuffix(originalPath, length);
+  const dot = originalPath.lastIndexOf(".");
+  if (dot <= originalPath.lastIndexOf("/")) {
+    return `${originalPath}-${suffix}`;
+  }
+  return `${originalPath.slice(0, dot)}-${suffix}${originalPath.slice(dot)}`;
+}
+
+/**
+ * Compute renames for paths that differ only by case ("case twins", e.g.
+ * `schemas/public/tables/Users.sql` vs `schemas/public/tables/users.sql`).
+ *
+ * PostgreSQL identifiers are case-sensitive, but the default filesystems on
+ * macOS (APFS) and Windows (NTFS) are case-insensitive: both paths resolve to
+ * the same physical file and the second write silently overwrites the first.
+ * Exports are portable artifacts (written on Linux, checked out on a Mac), so
+ * collisions are prevented at write time on every platform.
+ *
+ * Every member of a colliding set gets a deterministic `-<hash>` suffix
+ * derived from its original case-sensitive path, so renames are stable across
+ * exports and independent of input order. Non-colliding paths are left
+ * untouched (backward compatible).
+ *
+ * @param paths - Distinct case-sensitive file paths.
+ * @returns Map from original path to disambiguated path (colliding paths only).
+ */
+export function disambiguateCaseCollisions(
+  paths: readonly string[],
+): Map<string, string> {
+  const byFolded = new Map<string, string[]>();
+  for (const path of paths) {
+    const key = path.toLowerCase();
+    const bucket = byFolded.get(key);
+    if (bucket) {
+      bucket.push(path);
+    } else {
+      byFolded.set(key, [path]);
+    }
+  }
+
+  const colliding = new Set<string>();
+  for (const bucket of byFolded.values()) {
+    if (bucket.length > 1) {
+      for (const path of bucket) {
+        colliding.add(path);
+      }
+    }
+  }
+  if (colliding.size === 0) return new Map();
+
+  // Grow the suffix until the full path set is case-insensitively unique.
+  // 8 hex chars is virtually always enough; the loop only guards against the
+  // pathological case where a suffixed name collides with an existing object.
+  for (
+    let length = CASE_HASH_LENGTH;
+    length <= MAX_CASE_HASH_LENGTH;
+    length++
+  ) {
+    const renames = new Map<string, string>();
+    for (const path of colliding) {
+      renames.set(path, appendCaseHash(path, length));
+    }
+
+    const folded = new Set<string>();
+    let unique = true;
+    for (const path of paths) {
+      const key = (renames.get(path) ?? path).toLowerCase();
+      if (folded.has(key)) {
+        unique = false;
+        break;
+      }
+      folded.add(key);
+    }
+    if (unique) return renames;
+  }
+
+  throw new Error("Unable to disambiguate case-colliding export paths");
+}
+
 // ============================================================================
 // Grouping & Ordering
 // ============================================================================
@@ -92,8 +194,25 @@ export function groupChangesByFile(
     group.changes = sortChangesWithinFile(group.changes);
   }
 
+  const result = Array.from(groups.values());
+
+  // Rename paths that would collide on case-insensitive filesystems
+  // (APFS/NTFS), where e.g. `Users.sql` and `users.sql` are one physical file.
+  const renames = disambiguateCaseCollisions(result.map((group) => group.path));
+  for (const group of result) {
+    const renamed = renames.get(group.path);
+    if (renamed) {
+      debugExport(
+        "case-insensitive path collision: renaming '%s' -> '%s'",
+        group.path,
+        renamed,
+      );
+      group.path = renamed;
+    }
+  }
+
   // Sort files by category priority, then alphabetically by path.
-  return Array.from(groups.values()).sort(sortByCategory);
+  return result.sort(sortByCategory);
 }
 
 /**


### PR DESCRIPTION
Fixes #365, reported by @w3b6x9.

PostgreSQL identifiers are case-sensitive, but APFS and NTFS are not. When a schema contains case twins (say `Users` and `users`), pg-delta exported both to the same physical file, the second write silently overwrote the first, and apply then wedged on the missing object's dependents.

This detects export paths that collide case-insensitively and appends a short deterministic sha256 suffix (derived from the original case-sensitive path) to every member of a colliding set. Non-colliding names keep their current paths, and the rename happens on every platform so an export written on Linux still checks out cleanly on a Mac.

Tests cover the disambiguation logic (deterministic, order-independent) plus a real-filesystem round trip that reproduces the overwrite on APFS without the fix. Full suite: 1159 tests pass locally.
