### PR TITLE
fix(pg-delta): merge case-colliding schema export paths into one shared file

### DIFF
--- a/.changeset/olive-melons-repair.md
+++ b/.changeset/olive-melons-repair.md
@@ -1,0 +1,27 @@
+---
+"@supabase/pg-delta": patch
+---
+
+fix(pg-delta): merge case-colliding schema export paths into one shared file
+
+PostgreSQL identifiers are case-sensitive, but the default filesystems on
+macOS (APFS) and Windows (NTFS) are not: case-twin objects (`"Users"` vs
+`"users"`) exported to paths differing only by case landed in one physical
+file, the second write silently overwrote the first, and `schema apply` from
+that directory wedged on the missing object's dependents. `schema export` now
+folds every case-colliding path segment to a canonical spelling — the
+lexicographically smallest spelling actually present — on every platform, so
+an export written on Linux still checks out cleanly on a Mac: case-twin files
+merge into one shared file holding every twin's DDL in plan order, and
+descendants of case-twin directories agree on the parent's casing. Dependency
+cycles that only exist at the merged-file grain are handled so the loader
+still converges: foreign keys route to the `.fk.sql` post-data split, and
+unsplittable cycles (case-twin views around an interposed view) collapse into
+one file.
+
+Identifiers containing dots now percent-encode them in export file names
+(a table `"Foo.fk"` exports as `Foo%2Efk.sql`), so an identifier can never
+spoof the reserved `.sql` / `.fk.sql` suffixes; over-long encoded names clamp
+deterministically under the 255-byte filename limit. A lone spelling is never
+rewritten, non-colliding paths are unchanged, and each merge is reported as
+an export warning.

--- a/.github/agents/pg-toolbelt.md
+++ b/.github/agents/pg-toolbelt.md
@@ -410,6 +410,31 @@ Start with an empty inline snapshot assertion, run the test once so Bun fills in
 
 Whenever you are told you made a mistake — whether in commands, coding style, or guidelines — extract a generalizable lesson and propose a change to these agent guidelines so the same mistake does not happen again.
 
+### Automated-review loops (Codex and similar bots)
+
+Bot reviewers re-review every push and will keep finding locally-valid issues
+forever — including issues that exist only in your previous round's fix. Left
+unchecked this compounds into scope creep (real incident: PR #368 grew from a
+~200-line fix to ~1,700 lines over 12 review rounds before being trimmed back).
+Rules of engagement:
+
+- **Cap the loop.** After ~2–3 rounds of bot findings on the same PR, stop
+  auto-fixing. Re-read the remaining findings as a set and ask: are these still
+  about the issue being fixed, or are they re-litigating a broader contract
+  (error handling, hardening, performance) one corner at a time?
+- **Scope test per finding.** Fix it in the PR only if it is (a) a defect in
+  code this PR adds, AND (b) reachable without an adversarial or wildly
+  unusual setup. Pre-existing behavior the PR merely touched, and hardening
+  against threat models the surrounding code doesn't defend against, get
+  recorded instead of fixed.
+- **Record instead of re-fixing.** Deliberately-deferred findings go in
+  `docs/roadmap/pg-delta-next-follow-ups.md` (see the per-PR triage sections
+  there, e.g. "PR #368 review triage"). Reply to the bot thread with a link to
+  that section — never silently ignore a finding, and never fix it just to
+  make the thread go away.
+- **Escalate.** When you stop the loop, say so on the PR and hand it to a
+  human reviewer with a summary of what was fixed vs deferred.
+
 ### Common Issues
 
 - Lint errors can usually be detected and auto-fixed by running `bun run format-and-lint:fix && bun run check-types && bun run knip --fix`. Run this after you finish code changes to ensure you don't introduce lint errors into the project.

--- a/docs/roadmap/pg-delta-next-follow-ups.md
+++ b/docs/roadmap/pg-delta-next-follow-ups.md
@@ -595,3 +595,57 @@ a series of real non-superuser failures, each fixed RED-first on this branch:
   its one advantage (no reconstruction) is moot now that the seed is non-superuser-replayable
   (Unit C). Revisit only alongside the baseline-sidecar work, which would make
   bootstrap-vs-target drift detectable.
+
+## PR #368 review triage (Codex) — `schema export` out-dir hardening (deferred by design)
+
+PR #368 (case-twin export path collisions, issue #365) went through ~12 rounds
+of automated Codex review. The core fix and its load-bearing consequences were
+kept; a large writer-hardening layer that grew out of the loop was **removed
+before merge, deliberately**. This section is the record — if an automated
+review re-flags one of these, reply with a link here instead of re-fixing.
+
+**Kept (in the PR):** case-collision folding (canonical member spelling per
+segment; twins share one file), file-grain cycle handling (two-grain
+`cyclicForeignKeys` + `mergeDependencyCycles` — without these, merged files
+provably wedge the raw loader), dot-encoding in `seg()` (`Foo.fk` →
+`Foo%2Efk.sql`; reserves the `.sql`/`.fk.sql` suffix namespace and fixes a
+pre-existing bug where a table named `*.fk` received the FK-split header),
+240-byte segment / 255-byte ordered-name clamps (ENAMETOOLONG for dot-rich
+group names), and `resolve(outRoot)` in `writeExportFiles` (pre-existing
+relative-`--out-dir` prune misbehavior).
+
+**Removed (the deferred hardening layer).** The writer's contract is: **the
+export owns every destination it writes**; only *out-of-set* `.sql` files get
+the unmanaged refusal (`--prune-unmanaged` to override). This matches
+pre-#368 behavior and tools like `tar -x` into a user-chosen directory. The
+review loop demanded stronger guarantees for destinations whose *spelling* the
+PR introduced (fold-composed paths, dot-encoded names, clamped names), and the
+resulting subsystem (~350 lines) was cut because it hardened only the new
+spellings to a standard the rest of the writer has never met:
+
+- **In-set overwrite protection** — refusing a pre-existing, not-manifest-owned
+  file at a destination the export is about to write (per-file
+  `needsOwnershipCheck` marks, lstat probes, guard-before-prune ordering).
+- **Symlink/entry attacks inside `--out-dir`** — non-following existence
+  probes, top-down ancestor scans rejecting symlinked/non-directory ancestors,
+  link-only deletion under `--prune-unmanaged`. Threat model: someone plants
+  entries inside your own export directory; if an attacker can do that, the
+  pre-existing writer was equally exposed at every old spelling.
+- **Case-alias ownership on APFS/NTFS upgrades** — dev+ino identity so a
+  manifest path differing only by case counts as owned. Without it, the first
+  re-export over a pre-#368 corrupted directory may need `--prune-unmanaged`
+  once (fail-closed, self-healing).
+
+If out-dir hardening is ever wanted, do it as a deliberate, whole-writer design
+(uniform policy for ALL destinations, not per-spelling marks) — the removed
+implementation and its tests live in the PR #368 history up to commit
+`176c843` for reference. Known accepted consequences until then: a
+hand-authored file placed at exactly a managed object's export path is
+overwritten without refusal (as before #368), and exports into directories
+containing symlinks follow them (as before #368).
+
+**Meta-lesson (also in AGENTS.md):** cap automated-review iterations. Each
+round's finding was locally valid, but the sum re-litigated the writer's
+contract one exotic corner at a time. When a bot's findings drift from the
+issue's scope — or start finding bugs only in the previous round's fix — stop
+patching, decide the contract explicitly, and record it here.

--- a/packages/pg-delta/src/cli/commands/collect-sql-files.test.ts
+++ b/packages/pg-delta/src/cli/commands/collect-sql-files.test.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { readExportManifest } from "../../frontends/export-manifest.ts";
 import {
   collectSqlFiles,
@@ -153,6 +153,30 @@ describe("writeExportFiles", () => {
     );
     expect(existsSync(join(target, "schemas", "app", "t.sql"))).toBe(false);
     expect(existsSync(join(target, ".pgdelta-export.json"))).toBe(false);
+  });
+
+  test("a RELATIVE out-dir re-exports without spurious removals", () => {
+    // The manifest's owned paths resolve to ABSOLUTE paths while the keep set
+    // was joined onto the raw outRoot: with a relative --out-dir the pruner
+    // misread its own current files as out-of-set and deleted-then-rewrote
+    // them on every re-export (removed misreported; PR #368 review).
+    // writeExportFiles must normalize outRoot once up front.
+    const target = join(root, "relative-root");
+    const relTarget = relative(process.cwd(), target);
+    const file = {
+      name: join("schemas", "app", "t.sql"),
+      sql: "CREATE TABLE app.t ();\n",
+    };
+    writeExportFiles(relTarget, [file], { redactSecrets: false }, false);
+    const { removed, unmanaged } = writeExportFiles(
+      relTarget,
+      [file],
+      { redactSecrets: false },
+      false,
+    );
+    expect(removed).toEqual([]);
+    expect(unmanaged).toEqual([]);
+    expect(existsSync(join(target, "schemas", "app", "t.sql"))).toBe(true);
   });
 
   test("--prune-unmanaged deletes the unmanaged file and proceeds", () => {

--- a/packages/pg-delta/src/cli/commands/schema.ts
+++ b/packages/pg-delta/src/cli/commands/schema.ts
@@ -213,6 +213,12 @@ export function writeExportFiles(
   },
   pruneUnmanaged: boolean,
 ): { removed: string[]; unmanaged: string[] } {
+  // Normalize ONCE: the manifest's owned paths resolve to absolute paths, so
+  // every path compared against them (the keep set, the pruner's scan) must
+  // be absolute too — with a relative --out-dir the pruner otherwise misreads
+  // its own current files as out-of-set and deletes-then-rewrites them on
+  // every re-export (PR #368 review).
+  outRoot = resolve(outRoot);
   // The PREVIOUS export's owned-file list, read before we write anything. Absent
   // manifest / no `files` field → undefined → every out-of-set `.sql` is
   // unmanaged (pre-feature or hand-authored dir).

--- a/packages/pg-delta/src/frontends/export-case-collisions.test.ts
+++ b/packages/pg-delta/src/frontends/export-case-collisions.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Export paths that differ only by case ("case twins", e.g. `Users.sql` vs
+ * `users.sql`) are one physical file on the default macOS (APFS) and Windows
+ * (NTFS) filesystems: the second write silently overwrites the first, an
+ * object vanishes from the export, and apply wedges on its dependents
+ * (issue #365). Exports are portable artifacts — written on Linux, checked
+ * out on APFS — so collisions must be prevented at write time on EVERY
+ * platform: every path segment folds to a CANONICAL spelling (the
+ * lexicographically smallest spelling actually present), so case-twin files
+ * merge into one shared file and every descendant of case-twin directories
+ * agrees on the parent's casing. Each segment's canonical spelling is one a
+ * member actually uses. Pure — no DB.
+ */
+import { describe, expect, test } from "bun:test";
+import { buildFactBase, type Fact } from "../core/fact.ts";
+import { foldCaseCollidingPaths } from "./export-case-collisions.ts";
+import { exportSqlFiles, type ExportOptions } from "./export-sql-files.ts";
+
+function names(files: { name: string; sql: string }[]): string[] {
+  return files.map((f) => f.name);
+}
+
+function expectCaseInsensitivelyUnique(paths: string[]): void {
+  const folded = paths.map((p) => p.toLowerCase());
+  expect(new Set(folded).size).toBe(paths.length);
+}
+
+describe("foldCaseCollidingPaths", () => {
+  test("no collisions → empty map (every path keeps its own file)", () => {
+    const folds = foldCaseCollidingPaths([
+      "schemas/public/tables/users.sql",
+      "schemas/public/tables/orders.sql",
+      "schemas/public/views/users.sql", // same basename, different dir — fine
+    ]);
+    expect(folds.size).toBe(0);
+  });
+
+  test("colliding twins fold to the lexicographically-smallest member", () => {
+    const folds = foldCaseCollidingPaths([
+      "schemas/public/tables/Users.sql",
+      "schemas/public/tables/users.sql",
+      "schemas/public/tables/orders.sql",
+    ]);
+    // "Users.sql" < "users.sql" — the canonical member keeps its own path
+    // (identity → absent from the map); the other twin folds onto it.
+    expect(folds.has("schemas/public/tables/Users.sql")).toBe(false);
+    expect(folds.get("schemas/public/tables/users.sql")).toBe(
+      "schemas/public/tables/Users.sql",
+    );
+    // bystander untouched
+    expect(folds.has("schemas/public/tables/orders.sql")).toBe(false);
+  });
+
+  test("the fold target is always a member — never a synthesized path", () => {
+    // No all-lowercase member: folding to a synthesized "users.sql" could
+    // silently overwrite a hand-authored file at that path (PR #368 review).
+    const folds = foldCaseCollidingPaths([
+      "schemas/public/tables/Users.sql",
+      "schemas/public/tables/USERS.sql",
+    ]);
+    expect(folds.has("schemas/public/tables/USERS.sql")).toBe(false);
+    expect(folds.get("schemas/public/tables/Users.sql")).toBe(
+      "schemas/public/tables/USERS.sql",
+    );
+  });
+
+  test("a lone twin keeps its spelling; adding the other merges INTO it", () => {
+    // no-churn guarantee (PR #368 review): a singleton is never rewritten,
+    // and the merge lands on the pre-existing spelling when it sorts first.
+    expect(
+      foldCaseCollidingPaths(["schemas/public/tables/Users.sql"]).size,
+    ).toBe(0);
+    const folds = foldCaseCollidingPaths([
+      "schemas/public/tables/Users.sql",
+      "schemas/public/tables/users.sql",
+    ]);
+    expect(folds.has("schemas/public/tables/Users.sql")).toBe(false);
+  });
+
+  test("folding is independent of input order", () => {
+    const forward = foldCaseCollidingPaths([
+      "schemas/public/tables/Users.sql",
+      "schemas/public/tables/users.sql",
+    ]);
+    const backward = foldCaseCollidingPaths([
+      "schemas/public/tables/users.sql",
+      "schemas/public/tables/Users.sql",
+    ]);
+    expect(Object.fromEntries(forward)).toEqual(Object.fromEntries(backward));
+  });
+
+  test("descendants of case-twin directories fold to one casing", () => {
+    // Schema case twins with DIFFERENT object sets (PR #368 review): the
+    // singleton table under `app` must agree with the canonical `App`
+    // directory casing, or the manifest and the physical APFS tree disagree
+    // and the next re-export refuses ("unmanaged" false positive).
+    const folds = foldCaseCollidingPaths([
+      "schemas/App/schema.sql",
+      "schemas/app/schema.sql",
+      "schemas/App/tables/a.sql",
+      "schemas/app/tables/b.sql",
+    ]);
+    expect(folds.get("schemas/app/schema.sql")).toBe("schemas/App/schema.sql");
+    // no exact-path peer, but the parent directory is case-colliding
+    expect(folds.get("schemas/app/tables/b.sql")).toBe(
+      "schemas/App/tables/b.sql",
+    );
+    expect(folds.has("schemas/App/tables/a.sql")).toBe(false);
+  });
+
+  test("multi-segment divergence composes a synthesized destination", () => {
+    // Case twins in TWO segments with opposite lexical winners: per-segment
+    // canonicalization composes `schemas/App/tables/FOO.sql`, a path that is
+    // NEITHER member. Directory-casing consistency requires this composition
+    // (a whole-path member would re-split the `App`/`app` tree). The export
+    // owns every destination it writes — see the PR #368 triage section in
+    // docs/roadmap/pg-delta-next-follow-ups.md.
+    const folds = foldCaseCollidingPaths([
+      "schemas/App/tables/foo.sql",
+      "schemas/app/tables/FOO.sql",
+    ]);
+    expect(folds.get("schemas/App/tables/foo.sql")).toBe(
+      "schemas/App/tables/FOO.sql",
+    );
+    expect(folds.get("schemas/app/tables/FOO.sql")).toBe(
+      "schemas/App/tables/FOO.sql",
+    );
+  });
+
+  test("duplicate mentions of one path are not a collision", () => {
+    const folds = foldCaseCollidingPaths([
+      "schemas/public/tables/users.sql",
+      "schemas/public/tables/users.sql",
+    ]);
+    expect(folds.size).toBe(0);
+  });
+
+  test("merges and casing rewrites are reported through onWarning", () => {
+    const warnings: string[] = [];
+    foldCaseCollidingPaths(
+      [
+        "schemas/public/tables/Users.sql",
+        "schemas/public/tables/users.sql",
+        "schemas/public/tables/orders.sql",
+      ],
+      (message) => warnings.push(message),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("schemas/public/tables/Users.sql");
+    expect(warnings[0]).toContain("schemas/public/tables/users.sql");
+    expect(warnings[0]).not.toContain("orders.sql");
+  });
+});
+
+// end-to-end through exportSqlFiles: case-twin objects must share one file —
+// never two paths that are one physical file on a case-insensitive filesystem.
+describe("exportSqlFiles merges case-colliding paths into one file", () => {
+  const facts: Fact[] = [
+    { id: { kind: "schema", name: "public" }, payload: {} },
+    {
+      id: { kind: "table", schema: "public", name: "Users" },
+      parent: { kind: "schema", name: "public" },
+      payload: { persistence: "p" },
+    },
+    {
+      id: { kind: "table", schema: "public", name: "users" },
+      parent: { kind: "schema", name: "public" },
+      payload: { persistence: "p" },
+    },
+    {
+      id: { kind: "table", schema: "public", name: "orders" },
+      parent: { kind: "schema", name: "public" },
+      payload: { persistence: "p" },
+    },
+  ];
+
+  for (const layout of ["by-object", "grouped"] as const) {
+    test(`case-twin tables share the canonical member file (${layout})`, () => {
+      const options: ExportOptions = { layout };
+      const files = exportSqlFiles(buildFactBase(facts, []), options);
+      expectCaseInsensitivelyUnique(names(files));
+      // both twins' DDL lands in ONE shared file at the canonical member path
+      const merged = files.find(
+        (f) => f.name === "schemas/public/tables/Users.sql",
+      );
+      expect(merged?.sql).toContain(`"Users"`);
+      expect(merged?.sql).toContain(`"users"`);
+      expect(names(files)).not.toContain("schemas/public/tables/users.sql");
+      // bystander untouched
+      expect(names(files)).toContain("schemas/public/tables/orders.sql");
+    });
+  }
+
+  test("export names are stable across runs and fact order", () => {
+    const forward = exportSqlFiles(buildFactBase(facts, []));
+    const backward = exportSqlFiles(buildFactBase([...facts].reverse(), []));
+    expect(names(forward).sort()).toEqual(names(backward).sort());
+  });
+
+  test("identifier dots are encoded — the .sql/.fk.sql namespace is reserved", () => {
+    // A table literally named "Foo.fk" must NOT export to `Foo.fk.sql`: that
+    // name case-folds into another table's cyclic-FK split file (`foo.fk.sql`,
+    // post-data isolation the loader depends on) and wrongly receives the FK
+    // split header today (PR #368 review). Dots in identifiers are encoded
+    // (`Foo%2Efk.sql`), so no identifier can spoof the literal `.sql` or
+    // `.fk.sql` suffixes and no directory segment can ever end in `.sql`
+    // (which also rules out file-vs-directory prefix conflicts from group
+    // names like "schema.sql").
+    const dotted: Fact[] = [
+      { id: { kind: "schema", name: "public" }, payload: {} },
+      {
+        id: { kind: "table", schema: "public", name: "Foo.fk" },
+        parent: { kind: "schema", name: "public" },
+        payload: { persistence: "p" },
+      },
+    ];
+    const files = exportSqlFiles(buildFactBase(dotted, []));
+    const table = files.find((f) => f.name.includes("Foo"));
+    expect(table?.name).toBe("schemas/public/tables/Foo%2Efk.sql");
+    // no spoofed split-file header on an ordinary table file
+    expect(table?.sql).not.toContain("reference cycle");
+  });
+
+  test("grouped-layout segments stay within the 255-byte component limit", () => {
+    // Group names come from user config and are UNBOUNDED (unlike 63-byte
+    // identifiers): a dot-rich group name grows ~3x under dot encoding and
+    // overflowed the per-component limit — mkdir/write failed ENAMETOOLONG
+    // (PR #368 review). Every seg()-encoded component clamps deterministically.
+    const dottedGroup = `a${".a".repeat(70)}`; // 141 chars, 70 dots → 281 encoded
+    const facts: Fact[] = [
+      { id: { kind: "schema", name: "public" }, payload: {} },
+      {
+        id: { kind: "table", schema: "public", name: "widgets" },
+        parent: { kind: "schema", name: "public" },
+        payload: { persistence: "p" },
+      },
+    ];
+    for (const mode of ["subdirectory", "single-file"] as const) {
+      const files = exportSqlFiles(buildFactBase(facts, []), {
+        layout: "grouped",
+        grouping: {
+          mode,
+          groupPatterns: [{ pattern: "^widgets$", name: dottedGroup }],
+        },
+      });
+      const grouped = files.filter((f) => f.name.includes("a%2Ea"));
+      expect(grouped.length).toBeGreaterThan(0);
+      for (const file of files) {
+        for (const segment of file.name.split("/")) {
+          expect(Buffer.byteLength(segment)).toBeLessThanOrEqual(255);
+        }
+      }
+    }
+  });
+
+  test("ordered-layout names stay within the 255-byte filename limit", () => {
+    // Dot encoding can TRIPLE a dot-heavy identifier's length; the ordered
+    // layout flattens the whole path into ONE filename component, so two
+    // 63-byte identifiers full of dots overflowed the common 255-byte limit
+    // and the write failed ENAMETOOLONG (PR #368 review). Over-long names
+    // clamp to a deterministic truncate+hash tail — ordered names are
+    // positional and renumber on every export, so no stability is lost.
+    const dotted = `v${".b".repeat(31)}`; // 63 chars, 31 dots
+    const facts: Fact[] = [
+      { id: { kind: "schema", name: dotted }, payload: {} },
+      {
+        id: { kind: "table", schema: dotted, name: dotted },
+        parent: { kind: "schema", name: dotted },
+        payload: { persistence: "p" },
+      },
+    ];
+    const files = exportSqlFiles(buildFactBase(facts, []), {
+      layout: "ordered",
+    });
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      expect(Buffer.byteLength(file.name)).toBeLessThanOrEqual(255);
+      expect(file.name.endsWith(".sql")).toBe(true);
+    }
+    // clamping is deterministic across runs
+    const again = exportSqlFiles(buildFactBase(facts, []), {
+      layout: "ordered",
+    });
+    expect(names(again)).toEqual(names(files));
+  });
+});

--- a/packages/pg-delta/src/frontends/export-case-collisions.ts
+++ b/packages/pg-delta/src/frontends/export-case-collisions.ts
@@ -1,0 +1,133 @@
+/**
+ * Fold export paths that collide on case-insensitive filesystems into one
+ * shared file.
+ *
+ * PostgreSQL identifiers are case-sensitive (`"Users"` and `"users"` are
+ * distinct objects), but the default filesystems on macOS (APFS) and Windows
+ * (NTFS) are not: two export paths differing only by case resolve to ONE
+ * physical file, so the second write silently overwrites the first — an
+ * object vanishes from the export with no diagnostic, and apply wedges on the
+ * missing object's dependents (issue #365). Exports are portable artifacts
+ * (written on Linux, checked out on a Mac), so the collision is prevented at
+ * write time on EVERY platform, not detected on the affected ones.
+ *
+ * Every path SEGMENT with case-twin spellings folds to a canonical spelling —
+ * the lexicographically smallest spelling actually present:
+ *
+ * - Case-twin FILES merge into one shared file (`Users.sql` + `users.sql` →
+ *   both objects' DDL in `Users.sql`): multi-object files are already
+ *   first-class in the export/loader contract, so no name is invented and the
+ *   shared file sits exactly where a reader would look.
+ * - Every descendant of case-twin DIRECTORIES agrees on the parent's casing
+ *   (`schemas/App/…` + `schemas/app/…` → one `schemas/App/…` tree), so the
+ *   manifest matches the single physical directory APFS/NTFS create and a
+ *   re-export cannot misread its own files as unmanaged (PR #368 review).
+ *
+ * Each SEGMENT's canonical spelling is a spelling some member actually uses —
+ * never an invented one (e.g. all-lowercase) — so a same-directory twin set
+ * always merges into a member path, a lone spelling is never rewritten, and
+ * adding a twin that sorts after an existing file merges INTO the existing
+ * path: stable across re-exports and input order. (Under MULTI-SEGMENT
+ * divergence with opposite lexical winners the composed whole path can be a
+ * combination no single object produced — `schemas/App/tables/foo.sql` +
+ * `schemas/app/tables/FOO.sql` → `schemas/App/tables/FOO.sql` — which is
+ * fine: the export owns every destination it writes; see the PR #368 triage
+ * section in docs/roadmap/pg-delta-next-follow-ups.md for the deliberately
+ * deferred hardening around pre-existing out-dir content.) Non-colliding
+ * paths — all of them, in practice — are never touched.
+ */
+
+interface TrieNode {
+  /** Distinct spellings seen for this segment (same case-folded key). */
+  spellings: Set<string>;
+  /** Child segments, keyed by their case-folded spelling. */
+  children: Map<string, TrieNode>;
+  /** Memoized {@link canonicalSpelling} — computed once per node, not once
+   *  per path, so a large colliding bucket stays O(N) instead of O(N²)
+   *  (PR #368 review). */
+  canonical?: string;
+}
+
+function childOf(node: TrieNode, segment: string): TrieNode {
+  const key = segment.toLowerCase();
+  let child = node.children.get(key);
+  if (child === undefined) {
+    child = { spellings: new Set(), children: new Map() };
+    node.children.set(key, child);
+  }
+  child.spellings.add(segment);
+  return child;
+}
+
+/** The lexicographically smallest spelling — the deterministic canonical
+ *  representative of a case-twin segment. */
+function canonicalSpelling(spellings: ReadonlySet<string>): string {
+  let smallest: string | undefined;
+  for (const spelling of spellings) {
+    if (smallest === undefined || spelling < smallest) smallest = spelling;
+  }
+  return smallest!;
+}
+
+/**
+ * Map every path whose spelling changes under case-collision folding to its
+ * canonical path. Paths already canonical (including every non-colliding
+ * path, and duplicate mentions of one path — already one file) are absent
+ * from the map. Each colliding set is reported once through `onWarning`.
+ */
+export function foldCaseCollidingPaths(
+  paths: Iterable<string>,
+  onWarning?: (message: string) => void,
+): Map<string, string> {
+  const distinct = new Set(paths);
+  const root: TrieNode = { spellings: new Set(), children: new Map() };
+  for (const path of distinct) {
+    let node = root;
+    for (const segment of path.split("/")) {
+      node = childOf(node, segment);
+    }
+  }
+
+  const folds = new Map<string, string>();
+  const byCanonical = new Map<string, string[]>();
+  for (const path of distinct) {
+    let node = root;
+    const segments = path.split("/").map((segment) => {
+      node = node.children.get(segment.toLowerCase())!;
+      return node.spellings.size > 1
+        ? (node.canonical ??= canonicalSpelling(node.spellings))
+        : segment;
+    });
+    const canonical = segments.join("/");
+    if (canonical !== path) folds.set(path, canonical);
+    const members = byCanonical.get(canonical);
+    if (members === undefined) {
+      byCanonical.set(canonical, [path]);
+    } else {
+      members.push(path);
+    }
+  }
+
+  if (onWarning !== undefined) {
+    for (const [canonical, members] of byCanonical) {
+      if (members.length > 1) {
+        const sorted = [...members].sort((a, b) =>
+          a < b ? -1 : a > b ? 1 : 0,
+        );
+        onWarning(
+          `export paths ${sorted.map((m) => `"${m}"`).join(", ")} differ ` +
+            `only by case and would be one physical file on case-insensitive ` +
+            `filesystems (APFS/NTFS); merging them into "${canonical}"`,
+        );
+      } else if (members[0] !== canonical) {
+        onWarning(
+          `export path "${members[0]}" sits under a directory whose name ` +
+            `differs only by case from another export path's; writing it as ` +
+            `"${canonical}" so the tree has one spelling on case-insensitive ` +
+            `filesystems (APFS/NTFS)`,
+        );
+      }
+    }
+  }
+  return folds;
+}

--- a/packages/pg-delta/src/frontends/export-sql-files.ts
+++ b/packages/pg-delta/src/frontends/export-sql-files.ts
@@ -13,11 +13,13 @@
  *   order, so lexicographic discovery IS dependency order and the loader
  *   converges with zero deferred rounds (the stage-9 zero-round gate).
  */
+import { createHash } from "node:crypto";
 import { buildFactBase, type FactBase } from "../core/fact.ts";
 import { encodeId, type StableId } from "../core/stable-id.ts";
 import { plan, type Action } from "../plan/plan.ts";
 import type { IntentRuleIndex } from "../plan/rules.ts";
 import { extensionMemberReferenceOnly } from "../policy/view.ts";
+import { foldCaseCollidingPaths } from "./export-case-collisions.ts";
 import type { SqlFile } from "./load-sql-files.ts";
 import {
   formatSqlStatements,
@@ -67,6 +69,23 @@ export interface ExportOptions {
    *  instead of throwing "no intent rule registered". Omit for profiles with no
    *  intent handlers. */
   intentRules?: IntentRuleIndex;
+}
+
+/** Longest filename COMPONENT most filesystems accept (ext4/APFS/NTFS). The
+ *  ordered layout flattens a whole path into one component, and dot encoding
+ *  can triple a dot-heavy identifier's length — two 63-byte identifiers full
+ *  of dots overflow this limit (PR #368 review). Every seg()-encoded name is
+ *  pure ASCII, so string length equals byte length. */
+const MAX_FILENAME_LENGTH = 255;
+
+/** Clamp an over-long flattened name to a deterministic truncate+hash tail,
+ *  preserving the `.sql` suffix the loader discovers by. Uniqueness holds
+ *  because the ordered layout's sequence prefix survives the truncation. */
+function clampFileName(name: string): string {
+  if (name.length <= MAX_FILENAME_LENGTH) return name;
+  const hash = createHash("sha256").update(name, "utf8").digest("hex");
+  const tail = `-${hash.slice(0, 16)}.sql`;
+  return `${name.slice(0, MAX_FILENAME_LENGTH - tail.length)}${tail}`;
 }
 
 /** Assemble a file's SQL from bare (semicolon-less) statements: optionally
@@ -280,14 +299,33 @@ const TABLE_SCOPED = new Set([
  * can contain `/`, `\`, `..`, and other path-significant characters, which
  * would otherwise let an object name escape the output directory or collide
  * with `.`/`..` (review P2). encodeURIComponent handles separators reversibly;
- * the extra rule encodes dot-only segments (`.`, `..`) which it leaves alone.
- * Ordinary identifiers (alphanumerics + `_`) pass through unchanged, so the
- * common export layout is unaffected.
+ * every DOT is additionally encoded (`%2E`) so an identifier can never spoof
+ * the code-reserved `.sql` / `.fk.sql` suffixes: a table named `Foo.fk` would
+ * otherwise export to `Foo.fk.sql` — case-folding into another table's
+ * cyclic-FK split file and wrongly receiving the split header — and a group
+ * name like `schema.sql` would become a DIRECTORY ending in `.sql`, prefix
+ * colliding with a real file (PR #368 review). This also covers dot-only
+ * segments (`.`, `..`). Ordinary identifiers (alphanumerics + `_`) pass
+ * through unchanged, so the common export layout is unaffected.
  */
 function seg(name: string): string {
-  return encodeURIComponent(name).replace(/^\.+$/, (m) =>
-    m.replace(/\./g, "%2E"),
-  );
+  return clampSegment(encodeURIComponent(name).replaceAll(".", "%2E"));
+}
+
+/** Longest encoded SEGMENT the exporter emits, leaving room for the code
+ *  appended suffixes (`.sql`, `.fk.sql`) under the 255-byte filesystem
+ *  component limit. Identifiers (≤63 bytes → ≤189 encoded) never hit this;
+ *  GROUP NAMES come from user config and are unbounded — a dot-rich name
+ *  grows ~3x under dot encoding and overflowed the limit (ENAMETOOLONG,
+ *  PR #368 review). Encoded segments are pure ASCII, so string length equals
+ *  byte length. */
+const MAX_SEGMENT_LENGTH = 240;
+
+/** Deterministic truncate+hash clamp for an over-long encoded segment. */
+function clampSegment(segment: string): string {
+  if (segment.length <= MAX_SEGMENT_LENGTH) return segment;
+  const hash = createHash("sha256").update(segment, "utf8").digest("hex");
+  return `${segment.slice(0, MAX_SEGMENT_LENGTH - 17)}-${hash.slice(0, 16)}`;
 }
 
 /** Precomputed routing context threaded through {@link pathFor}: the cyclic-FK
@@ -402,6 +440,22 @@ function owningTableKey(id: StableId): string | undefined {
  * `depends` on the referenced table's columns / unique constraint), so no SQL
  * is parsed here. Cycle test: Tarjan SCC over the table-reference graph — an FK
  * is cyclic iff its owning table and a referenced table share a component.
+ *
+ * The cycle test runs at TWO grains and unions the results (PR #368 review):
+ * - RAW table keys — mutual FKs between distinctly-spelled tables, including
+ *   the twins themselves (`"Foo"` ⇄ `"foo"`): folding alone would erase that
+ *   mutual reference as a self-edge, leaving both FKs inline in the merged
+ *   file, which could then never apply (each CREATE references the twin the
+ *   same file has not created yet).
+ * - CASE-FOLDED keys — case-twin tables merge into one physical file
+ *   (export-case-collisions.ts) and the atomic unit at load time is the
+ *   FILE, so an FK chain acyclic at table grain (`"Foo"` → helper → `"foo"`)
+ *   is a real cycle at file grain. Folding the RAW names is conservative for
+ *   non-ASCII identifiers (it can contract twins whose percent-encoded paths
+ *   would not actually merge) — the cost is an unnecessary `.fk.sql` split,
+ *   never a wedged load.
+ * A genuine self-referential FK (a table referencing itself) is skipped at
+ * both grains via the RAW comparison and stays inline, where it is valid.
  */
 function cyclicForeignKeys(fb: FactBase): Set<string> {
   interface Fk {
@@ -420,12 +474,14 @@ function cyclicForeignKeys(fb: FactBase): Set<string> {
   }
   if (fks.size === 0) return new Set();
 
-  // table-reference graph: owner → referenced table, per FK edge
+  // table-reference graph on RAW keys: owner → referenced table, per FK edge
   const adjacency = new Map<string, Set<string>>();
   for (const edge of fb.edges) {
     const fk = fks.get(encodeId(edge.from));
     if (fk === undefined) continue;
     const ref = owningTableKey(edge.to);
+    // RAW comparison: only a genuine self-reference is dropped — a case-twin
+    // reference is a distinct table and must stay a graph edge.
     if (ref === undefined || ref === fk.owner) continue;
     fk.refs.add(ref);
     let targets = adjacency.get(fk.owner);
@@ -436,83 +492,191 @@ function cyclicForeignKeys(fb: FactBase): Set<string> {
     targets.add(ref);
   }
 
-  // Tarjan SCC (iterative — no recursion-depth ceiling on large schemas)
-  const sccOf = new Map<string, number>();
-  {
-    const index = new Map<string, number>();
-    const low = new Map<string, number>();
-    const onStack = new Set<string>();
-    const stack: string[] = [];
-    let counter = 0;
-    let sccCount = 0;
-    const nodes = new Set<string>(adjacency.keys());
-    for (const targets of adjacency.values()) {
-      for (const t of targets) nodes.add(t);
+  // the same graph contracted to case-folded keys (file grain)
+  const foldedAdjacency = new Map<string, Set<string>>();
+  for (const [owner, targets] of adjacency) {
+    const foldedOwner = owner.toLowerCase();
+    let folded = foldedAdjacency.get(foldedOwner);
+    if (folded === undefined) {
+      folded = new Set();
+      foldedAdjacency.set(foldedOwner, folded);
     }
-    interface Frame {
-      node: string;
-      neighbors: string[];
-      i: number;
-    }
-    const visit = (frames: Frame[], node: string): void => {
-      index.set(node, counter);
-      low.set(node, counter);
-      counter++;
-      stack.push(node);
-      onStack.add(node);
-      frames.push({ node, neighbors: [...(adjacency.get(node) ?? [])], i: 0 });
-    };
-    for (const root of nodes) {
-      if (index.has(root)) continue;
-      const frames: Frame[] = [];
-      visit(frames, root);
-      while (frames.length > 0) {
-        const frame = frames[frames.length - 1]!;
-        if (frame.i < frame.neighbors.length) {
-          const next = frame.neighbors[frame.i++]!;
-          if (!index.has(next)) {
-            visit(frames, next);
-          } else if (onStack.has(next)) {
-            low.set(
-              frame.node,
-              Math.min(low.get(frame.node)!, index.get(next)!),
-            );
-          }
-        } else {
-          frames.pop();
-          const parent = frames[frames.length - 1];
-          if (parent !== undefined) {
-            low.set(
-              parent.node,
-              Math.min(low.get(parent.node)!, low.get(frame.node)!),
-            );
-          }
-          if (low.get(frame.node) === index.get(frame.node)) {
-            let member: string;
-            do {
-              member = stack.pop()!;
-              onStack.delete(member);
-              sccOf.set(member, sccCount);
-            } while (member !== frame.node);
-            sccCount++;
-          }
-        }
-      }
+    for (const target of targets) {
+      const foldedTarget = target.toLowerCase();
+      // an edge WITHIN a contracted node (twin ⇄ twin) is intra-file; the
+      // raw grain already classifies it
+      if (foldedTarget !== foldedOwner) folded.add(foldedTarget);
     }
   }
 
+  const rawScc = stronglyConnectedComponents(adjacency);
+  const foldedScc = stronglyConnectedComponents(foldedAdjacency);
+
   const cyclic = new Set<string>();
   for (const fk of fks.values()) {
-    const ownerScc = sccOf.get(fk.owner);
-    if (ownerScc === undefined) continue;
+    const ownerRawScc = rawScc.get(fk.owner);
+    const ownerFoldedScc = foldedScc.get(fk.owner.toLowerCase());
     for (const ref of fk.refs) {
-      if (sccOf.get(ref) === ownerScc) {
+      const rawCyclic =
+        ownerRawScc !== undefined && rawScc.get(ref) === ownerRawScc;
+      // a reference to the owner's own case twin is intra-file at folded
+      // grain but still a real forward reference the merged file cannot
+      // satisfy inline — treat it as cyclic (the twins' CREATEs and their
+      // mutual FKs cannot all inline in one atomic file)
+      const twinRef =
+        ref.toLowerCase() === fk.owner.toLowerCase() && ref !== fk.owner;
+      const foldedCyclic =
+        !twinRef &&
+        ownerFoldedScc !== undefined &&
+        foldedScc.get(ref.toLowerCase()) === ownerFoldedScc;
+      if (rawCyclic || foldedCyclic || twinRef) {
         cyclic.add(fk.encoded);
         break;
       }
     }
   }
   return cyclic;
+}
+
+/** Tarjan SCC (iterative — no recursion-depth ceiling on large schemas):
+ *  node → component index, over `adjacency` and every node it mentions. */
+function stronglyConnectedComponents(
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+): Map<string, number> {
+  const sccOf = new Map<string, number>();
+  const index = new Map<string, number>();
+  const low = new Map<string, number>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+  let counter = 0;
+  let sccCount = 0;
+  const nodes = new Set<string>(adjacency.keys());
+  for (const targets of adjacency.values()) {
+    for (const t of targets) nodes.add(t);
+  }
+  interface Frame {
+    node: string;
+    neighbors: string[];
+    i: number;
+  }
+  const visit = (frames: Frame[], node: string): void => {
+    index.set(node, counter);
+    low.set(node, counter);
+    counter++;
+    stack.push(node);
+    onStack.add(node);
+    frames.push({ node, neighbors: [...(adjacency.get(node) ?? [])], i: 0 });
+  };
+  for (const root of nodes) {
+    if (index.has(root)) continue;
+    const frames: Frame[] = [];
+    visit(frames, root);
+    while (frames.length > 0) {
+      const frame = frames[frames.length - 1]!;
+      if (frame.i < frame.neighbors.length) {
+        const next = frame.neighbors[frame.i++]!;
+        if (!index.has(next)) {
+          visit(frames, next);
+        } else if (onStack.has(next)) {
+          low.set(frame.node, Math.min(low.get(frame.node)!, index.get(next)!));
+        }
+      } else {
+        frames.pop();
+        const parent = frames[frames.length - 1];
+        if (parent !== undefined) {
+          low.set(
+            parent.node,
+            Math.min(low.get(parent.node)!, low.get(frame.node)!),
+          );
+        }
+        if (low.get(frame.node) === index.get(frame.node)) {
+          let member: string;
+          do {
+            member = stack.pop()!;
+            onStack.delete(member);
+            sccOf.set(member, sccCount);
+          } while (member !== frame.node);
+          sccCount++;
+        }
+      }
+    }
+  }
+  return sccOf;
+}
+
+/**
+ * Detect multi-file dependency cycles CREATED by case-twin folding and merge
+ * each into ONE file. Export files apply atomically under the raw loader's
+ * bounded retry, so a dependency cycle across files can never load. FK-only
+ * cycles are split into `.fk.sql` post-data files ({@link cyclicForeignKeys},
+ * whose graph is contracted to the same file grain) — but a NON-FK cycle,
+ * e.g. case-twin VIEWS with an interposed view (`"Foo"` selects helper,
+ * helper selects `"foo"`), has no deferrable ALTER to split out: the only
+ * loadable shape is the whole cycle in one file, statements in plan order
+ * (PR #368 review). Only components containing a fold destination are
+ * touched — the export produces no multi-file cycles otherwise; if one
+ * somehow exists it is reported and left unchanged.
+ *
+ * @returns path → merge target (the component's lexicographically smallest
+ *          member); identity mappings are absent.
+ */
+function mergeDependencyCycles(
+  fb: FactBase,
+  idToPath: (id: StableId) => string,
+  emittedPaths: ReadonlySet<string>,
+  foldDestinations: ReadonlySet<string>,
+  onWarning?: (message: string) => void,
+): Map<string, string> {
+  if (foldDestinations.size === 0) return new Map();
+  const adjacency = new Map<string, Set<string>>();
+  for (const edge of fb.edges) {
+    const from = idToPath(edge.from);
+    const to = idToPath(edge.to);
+    if (from === to) continue;
+    if (!emittedPaths.has(from) || !emittedPaths.has(to)) continue;
+    let targets = adjacency.get(from);
+    if (targets === undefined) {
+      targets = new Set();
+      adjacency.set(from, targets);
+    }
+    targets.add(to);
+  }
+  if (adjacency.size === 0) return new Map();
+
+  const sccOf = stronglyConnectedComponents(adjacency);
+  const componentMembers = new Map<number, string[]>();
+  for (const [path, component] of sccOf) {
+    const members = componentMembers.get(component);
+    if (members === undefined) {
+      componentMembers.set(component, [path]);
+    } else {
+      members.push(path);
+    }
+  }
+
+  const merges = new Map<string, string>();
+  for (const members of componentMembers.values()) {
+    if (members.length < 2) continue;
+    const sorted = [...members].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const list = sorted.map((p) => `"${p}"`).join(", ");
+    if (!sorted.some((path) => foldDestinations.has(path))) {
+      onWarning?.(
+        `export files ${list} form a dependency cycle the file-atomic ` +
+          `loader cannot apply; leaving them unchanged (the cycle is not ` +
+          `caused by case-collision merging)`,
+      );
+      continue;
+    }
+    const target = sorted[0]!;
+    onWarning?.(
+      `export files ${list} form a dependency cycle once case twins merge; ` +
+        `combining them into "${target}" so every file stays loadable`,
+    );
+    for (const path of sorted) {
+      if (path !== target) merges.set(path, target);
+    }
+  }
+  return merges;
 }
 
 function pathFor(id: StableId, ctx: PathContext): string {
@@ -679,33 +843,24 @@ export function exportSqlFiles(
     return exportGrouped(rendered.actions, fb, options, pathContext);
   }
 
-  // group statements by file, preserving plan order within AND across
-  // groups (first-statement order decides file order). Statements are stored
-  // BARE (no trailing `;`) so the optional formatter sees clean input.
-  const files = new Map<string, { firstAt: number; statements: string[] }>();
-  rendered.actions.forEach((action, position) => {
+  // Each action's file path, in plan order (shared by both layouts below).
+  const actionPaths = rendered.actions.map((action) => {
     const subject = subjectOf(action);
-    const path =
-      subject === undefined
-        ? "cluster/misc.sql"
-        : pathFor(subject, pathContext);
-    const entry = files.get(path) ?? { firstAt: position, statements: [] };
-    entry.statements.push(action.sql);
-    files.set(path, entry);
+    return subject === undefined
+      ? "cluster/misc.sql"
+      : pathFor(subject, pathContext);
   });
 
   if (layout === "ordered") {
     // statement-true splitting: runs of CONSECUTIVE same-object actions
     // become one numbered file, so lexicographic discovery IS plan order
     // and the loader converges in a single pass — an object interleaved
-    // with its dependencies simply spans several numbered files
+    // with its dependencies simply spans several numbered files. Case-twin
+    // paths need no folding here: the sequence prefix already makes every
+    // file name case-insensitively unique.
     const runs: { path: string; statements: string[] }[] = [];
-    rendered.actions.forEach((action) => {
-      const subject = subjectOf(action);
-      const path =
-        subject === undefined
-          ? "cluster/misc.sql"
-          : pathFor(subject, pathContext);
+    rendered.actions.forEach((action, position) => {
+      const path = actionPaths[position]!;
       const last = runs[runs.length - 1];
       if (last !== undefined && last.path === path) {
         last.statements.push(action.sql);
@@ -714,10 +869,41 @@ export function exportSqlFiles(
       }
     });
     return runs.map((run, index) => ({
-      name: `${String(index).padStart(4, "0")}_${run.path.replaceAll("/", "_")}`,
+      name: clampFileName(
+        `${String(index).padStart(4, "0")}_${run.path.replaceAll("/", "_")}`,
+      ),
       sql: renderFileSql(run.statements, options.format),
     }));
   }
+
+  // group statements by file, preserving plan order within AND across
+  // groups (first-statement order decides file order). Statements are stored
+  // BARE (no trailing `;`) so the optional formatter sees clean input.
+  // Case-twin paths (`Users.sql` vs `users.sql`) are one physical file on
+  // APFS/NTFS — fold each colliding set to its canonical spelling so the
+  // twins SHARE a file instead of silently overwriting each other (#365).
+  const folds = foldCaseCollidingPaths(actionPaths, options.onWarning);
+  const foldedPaths = actionPaths.map((p) => folds.get(p) ?? p);
+  // a dependency cycle the fold created (case-twin views around an interposed
+  // view) must collapse into ONE file — a no-op when nothing folded.
+  const cycleMerges = mergeDependencyCycles(
+    fb,
+    (id) => {
+      const raw = pathFor(id, pathContext);
+      return folds.get(raw) ?? raw;
+    },
+    new Set(foldedPaths),
+    new Set(folds.values()),
+    options.onWarning,
+  );
+  const files = new Map<string, { firstAt: number; statements: string[] }>();
+  rendered.actions.forEach((action, position) => {
+    const folded = foldedPaths[position]!;
+    const path = cycleMerges.get(folded) ?? folded;
+    const entry = files.get(path) ?? { firstAt: position, statements: [] };
+    entry.statements.push(action.sql);
+    files.set(path, entry);
+  });
 
   const ordered = [...files.entries()].sort(
     (a, b) => a[1].firstAt - b[1].firstAt,
@@ -851,11 +1037,32 @@ function exportGrouped(
     category: Category;
     items: { sql: string; verbRank: number; scopeRank: number; at: number }[];
   }
+  // Case-twin paths fold to one shared file, exactly like the by-object
+  // layout (issue #365) — regrouping cannot re-split them because the fold is
+  // computed on the final grouped paths.
+  const actionPaths = actions.map((action) => {
+    const subject = subjectOf(action);
+    return subject === undefined ? "cluster/misc.sql" : groupedPath(subject);
+  });
+  const folds = foldCaseCollidingPaths(actionPaths, options.onWarning);
+  const foldedPaths = actionPaths.map((p) => folds.get(p) ?? p);
+  // a dependency cycle the fold created collapses into ONE file, exactly as
+  // in the by-object layout — a no-op when nothing folded.
+  const cycleMerges = mergeDependencyCycles(
+    fb,
+    (id) => {
+      const raw = groupedPath(id);
+      return folds.get(raw) ?? raw;
+    },
+    new Set(foldedPaths),
+    new Set(folds.values()),
+    options.onWarning,
+  );
   const files = new Map<string, GroupedFile>();
   actions.forEach((action, at) => {
     const subject = subjectOf(action);
-    const path =
-      subject === undefined ? "cluster/misc.sql" : groupedPath(subject);
+    const folded = foldedPaths[at]!;
+    const path = cycleMerges.get(folded) ?? folded;
     const category = subject === undefined ? "misc" : categoryFor(subject);
     const entry = files.get(path) ?? { category, items: [] };
     entry.items.push({

--- a/packages/pg-delta/tests/export-case-collision.test.ts
+++ b/packages/pg-delta/tests/export-case-collision.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Case-twin objects (`"Users"` vs `"users"`) must survive a declarative export
+ * (issue #365): PostgreSQL identifiers are case-sensitive but APFS/NTFS are
+ * not, so two export paths differing only by case are ONE physical file there
+ * and the second write silently destroys the first object. The exporter folds
+ * each colliding set into one SHARED file — the lexicographically-smallest
+ * member path holds every twin's DDL — on every platform; exports are
+ * portable artifacts, written on Linux, checked out on a Mac.
+ *
+ * This gates, for every layout: (1) the emitted paths are case-insensitively
+ * unique, so the export cannot be corrupted by a case-insensitive disk; and
+ * (2) the merged files still round-trip — `load(export(fb)) ≡ fb`.
+ *
+ * Docker required.
+ */
+import { describe, expect, test } from "bun:test";
+import { extract } from "../src/extract/extract.ts";
+import {
+  exportSqlFiles,
+  type ExportOptions,
+} from "../src/frontends/export-sql-files.ts";
+import { loadSqlFiles } from "../src/frontends/load-sql-files.ts";
+import { sharedCluster } from "./containers.ts";
+
+const LAYOUTS: NonNullable<ExportOptions["layout"]>[] = [
+  "by-object",
+  "ordered",
+  "grouped",
+];
+
+// Case twins across object kinds: tables (with an FK between the twins, so a
+// dependent wedges if one twin vanishes), a view twin over a table name, and
+// function twins.
+const CASE_TWIN_SQL = `
+  CREATE TABLE "Users" (id integer PRIMARY KEY);
+  CREATE TABLE "users" (id integer PRIMARY KEY, "User_id" integer REFERENCES "Users" (id));
+  CREATE VIEW "USERS" AS SELECT id FROM "users";
+  CREATE FUNCTION "Get_user"() RETURNS integer LANGUAGE sql IMMUTABLE AS 'SELECT 1';
+  CREATE FUNCTION "get_user"() RETURNS integer LANGUAGE sql IMMUTABLE AS 'SELECT 2';
+`;
+
+function forLoad(files: { name: string; sql: string }[]) {
+  // cluster-global roles already exist in the shared cluster (same filter as
+  // export-fidelity.test.ts).
+  return files.filter((f) => !/cluster[_/]roles/.test(f.name));
+}
+
+// An FK chain that is ACYCLIC at table grain becomes a real cycle at FILE
+// grain once case twins merge: "Foo" → helper → "foo" with Foo/foo sharing a
+// file means the merged file waits for helper while helper waits for the
+// merged file — the raw file-atomic loader would exhaust its retry rounds
+// (PR #368 review). The cycle analysis must treat tables that will share a
+// file as one node, so these FKs take the .fk.sql split and the load
+// converges.
+const TWIN_FK_CHAIN_SQL = `
+  CREATE TABLE "foo" (id integer PRIMARY KEY);
+  CREATE TABLE helper (id integer PRIMARY KEY,
+    f integer REFERENCES "foo" (id));
+  CREATE TABLE "Foo" (id integer PRIMARY KEY,
+    h integer REFERENCES helper (id));
+`;
+
+describe("export: FK chain through case twins stays loadable", () => {
+  for (const layout of ["by-object", "grouped"] as const) {
+    test(`merged twins + interposed FK round-trip (${layout})`, async () => {
+      const cluster = await sharedCluster();
+      const src = await cluster.createDb(
+        `twin_fk_src_${layout.replace("-", "_")}`,
+      );
+      const shadow = await cluster.createDb(
+        `twin_fk_shadow_${layout.replace("-", "_")}`,
+      );
+      try {
+        await src.pool.query(TWIN_FK_CHAIN_SQL);
+        const fb = (await extract(src.pool)).factBase;
+        const files = forLoad(exportSqlFiles(fb, { layout }));
+        const loaded = await loadSqlFiles(files, shadow.pool);
+        expect(loaded.factBase.rootHash).toBe(fb.rootHash);
+      } finally {
+        await Promise.all([src.drop(), shadow.drop()]);
+      }
+    }, 120_000);
+  }
+});
+
+// MUTUAL FKs directly between the case twins (PR #368 review): folding both
+// table keys to one node must not erase the twins' mutual reference as a
+// self-edge — the merged file contains both CREATEs, and an inline FK to the
+// other twin references a table the same file has not created yet, so the
+// file can never apply. Both FKs must take the .fk.sql split (as they did
+// for distinctly-named mutual FK tables all along).
+const MUTUAL_TWIN_FK_SQL = `
+  CREATE TABLE "Foo" (id integer PRIMARY KEY, other integer);
+  CREATE TABLE "foo" (id integer PRIMARY KEY,
+    other integer REFERENCES "Foo" (id));
+  ALTER TABLE "Foo"
+    ADD CONSTRAINT foo_other_fk FOREIGN KEY (other) REFERENCES "foo" (id);
+`;
+
+describe("export: mutual FKs between case twins stay loadable", () => {
+  for (const layout of ["by-object", "grouped"] as const) {
+    test(`mutual twin FKs round-trip (${layout})`, async () => {
+      const cluster = await sharedCluster();
+      const src = await cluster.createDb(
+        `mutual_twin_src_${layout.replace("-", "_")}`,
+      );
+      const shadow = await cluster.createDb(
+        `mutual_twin_shadow_${layout.replace("-", "_")}`,
+      );
+      try {
+        await src.pool.query(MUTUAL_TWIN_FK_SQL);
+        const fb = (await extract(src.pool)).factBase;
+        const files = forLoad(exportSqlFiles(fb, { layout }));
+        const loaded = await loadSqlFiles(files, shadow.pool);
+        expect(loaded.factBase.rootHash).toBe(fb.rootHash);
+      } finally {
+        await Promise.all([src.drop(), shadow.drop()]);
+      }
+    }, 120_000);
+  }
+});
+
+// The same file-grain cycle with NON-FK dependencies (PR #368 review): view
+// "Foo" selects helper, helper selects case-twin view "foo". There is no
+// deferrable ALTER to split out of a CREATE VIEW, so the only way the raw
+// file-atomic loader can converge is merging the whole dependency cycle —
+// twins AND the interposed helper — into one file, in plan order.
+const TWIN_VIEW_CHAIN_SQL = `
+  CREATE VIEW "foo" AS SELECT 1 AS x;
+  CREATE VIEW helper AS SELECT x FROM "foo";
+  CREATE VIEW "Foo" AS SELECT x FROM helper;
+`;
+
+describe("export: non-FK dependency chain through case twins stays loadable", () => {
+  for (const layout of ["by-object", "grouped"] as const) {
+    test(`merged twin views + interposed view round-trip (${layout})`, async () => {
+      const cluster = await sharedCluster();
+      const src = await cluster.createDb(
+        `twin_view_src_${layout.replace("-", "_")}`,
+      );
+      const shadow = await cluster.createDb(
+        `twin_view_shadow_${layout.replace("-", "_")}`,
+      );
+      try {
+        await src.pool.query(TWIN_VIEW_CHAIN_SQL);
+        const fb = (await extract(src.pool)).factBase;
+        const files = forLoad(exportSqlFiles(fb, { layout }));
+        const loaded = await loadSqlFiles(files, shadow.pool);
+        expect(loaded.factBase.rootHash).toBe(fb.rootHash);
+      } finally {
+        await Promise.all([src.drop(), shadow.drop()]);
+      }
+    }, 120_000);
+  }
+});
+
+describe("export: case-twin objects survive case-insensitive filesystems", () => {
+  for (const layout of LAYOUTS) {
+    test(`paths are case-insensitively unique and round-trip (${layout})`, async () => {
+      const cluster = await sharedCluster();
+      const src = await cluster.createDb(
+        `case_twin_src_${layout.replace("-", "_")}`,
+      );
+      const shadow = await cluster.createDb(
+        `case_twin_shadow_${layout.replace("-", "_")}`,
+      );
+      try {
+        await src.pool.query(CASE_TWIN_SQL);
+        const fb = (await extract(src.pool)).factBase;
+
+        const files = forLoad(exportSqlFiles(fb, { layout }));
+
+        // (1) no two paths may be one physical file on APFS/NTFS
+        const folded = files.map((f) => f.name.toLowerCase());
+        expect(new Set(folded).size).toBe(files.length);
+
+        // the table twins share ONE file at the canonical member path (the
+        // ordered layout instead keeps them apart via its sequence prefix)
+        if (layout !== "ordered") {
+          const merged = files.find(
+            (f) => f.name === "schemas/public/tables/Users.sql",
+          );
+          expect(merged?.sql).toContain(`"Users"`);
+          expect(merged?.sql).toContain(`"users"`);
+        }
+
+        // no object silently lost from the emitted SQL
+        const all = files.map((f) => f.sql).join("\n");
+        expect(all).toContain(`"Users"`);
+        expect(all).toContain(`"USERS"`);
+        expect(all).toContain(`"Get_user"`);
+        expect(all).toContain(`"get_user"`);
+
+        // (2) the renamed files still reload to the identical fact base
+        const loaded = await loadSqlFiles(files, shadow.pool);
+        expect(loaded.factBase.rootHash).toBe(fb.rootHash);
+      } finally {
+        await Promise.all([src.drop(), shadow.drop()]);
+      }
+    }, 120_000);
+  }
+});


### PR DESCRIPTION
## Summary

PostgreSQL identifiers are case-sensitive, but the default filesystems on macOS (APFS) and Windows (NTFS) are not: case-twin objects (`"Users"` vs `"users"`) exported to paths differing only by case land in **one physical file** there — the second write silently overwrites the first, the manifest no longer matches the disk, and `schema apply` from that directory wedges on the missing object's dependents. Exports are portable artifacts (written on Linux, checked out on a Mac), so the collision is prevented at write time on every platform.

**The fix.** `schema export` folds every case-colliding **path segment** to a canonical spelling — the lexicographically smallest spelling actually present:

- **Case-twin files merge into one shared file** (`Users.sql` + `users.sql` → both objects' DDL in `Users.sql`, interleaved in plan order). Multi-object files are already first-class in the export/loader contract, so no synthetic name is invented.
- **Descendants of case-twin directories agree on the parent's casing**, so the manifest matches the single physical directory APFS/NTFS create.
- A lone spelling is never rewritten; renames are deterministic and order-independent; each merge is reported as an export warning.

**Loadability.** Merging coarsens the loader's atomic unit to the file, so cycles that are acyclic at object grain become real at file grain. Two mechanisms keep every export loadable (each backed by a Docker round-trip test that reproduces the raw-loader wedge without it): `cyclicForeignKeys` runs at both grains (mutual twin FKs and interposed chains route to the `.fk.sql` post-data split), and `mergeDependencyCycles` collapses unsplittable cycles (case-twin views) into one file.

**Suffix-namespace integrity.** `seg()` percent-encodes identifier dots (`"Foo.fk"` → `Foo%2Efk.sql`), so no identifier can spoof the reserved `.sql`/`.fk.sql` suffixes (a dotted table could case-fold into another table's FK-split file — and wrongly received the split header even before this PR); over-long names clamp deterministically under the 255-byte filename limit. `writeExportFiles` also resolves `--out-dir` once up front, fixing a pre-existing prune misbehavior with relative paths.

## Deliberately deferred (please read before re-flagging)

Earlier revisions of this PR accumulated a ~350-line writer-hardening subsystem (per-file ownership marks, symlink-ancestor scans, dev+ino case-alias ownership) over ~12 rounds of automated review. It was **removed by maintainer decision**: it hardened only the new path spellings against threat models (attacker-controlled content inside your own `--out-dir`) that the rest of the writer has never defended against. The writer's contract remains: *the export owns every destination it writes; out-of-set `.sql` files get the unmanaged refusal.* The full rationale, the accepted consequences, and the removed implementation's reference commit are recorded in `docs/roadmap/pg-delta-next-follow-ups.md` → **"PR #368 review triage (Codex)"**. Automated-review findings in that class should be answered with a link there, not new commits.

Related: #366 proposed a hash-suffix approach against a file layout that no longer exists in this repo — credit to @Mohith26 for the earlier investigation.

## Linked issue

Closes #365

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhRgWBSpbtbVP9jng1Gs84