### PR TITLE
fix(pg-topo): slice statements by byte offsets so non-ASCII SQL is carried verbatim

### DIFF
--- a/.changeset/spotty-clocks-repair.md
+++ b/.changeset/spotty-clocks-repair.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-topo": patch
+---
+
+Slice statements by UTF-8 byte offsets so SQL containing non-ASCII text is carried verbatim. libpg_query reports `stmt_location`/`stmt_len` in bytes, but statements were sliced with UTF-16 string indices — any non-ASCII content misaligned the slice and silently swapped the authored text for a deparse fallback that renders `COMMENT ON TRIGGER/POLICY/RULE` targets as invalid dotted names (e.g. `COMMENT ON TRIGGER public.t.tr`). `sourceOffset` is now a character offset (it was a byte offset consumed as a character index by downstream line:column rendering), and a deparse fallback that fails to re-parse now surfaces a `PARSE_ERROR` diagnostic instead of returning invalid SQL.

--- a/packages/pg-topo/src/ingest/parse.ts
+++ b/packages/pg-topo/src/ingest/parse.ts
@@ -57,16 +57,29 @@ const reparses = (candidate: string): boolean => {
   }
 };
 
-/** Convert a byte offset into `contentBytes` to a UTF-16 character offset.
- *  Statement locations always fall on character boundaries, so decoding the
- *  byte prefix is exact. */
-const byteToCharOffset = (
+/** Convert byte offsets into `contentBytes` to UTF-16 character offsets.
+ *  Statement locations always fall on character boundaries, so decoding byte
+ *  prefixes is exact. Offsets are converted incrementally (statements arrive
+ *  in source order), so the total decode work stays linear in the content
+ *  size instead of quadratic in the statement count. */
+const makeByteToCharOffset = (
   contentBytes: Uint8Array,
-  byteOffset: number,
-): number =>
-  textDecoder.decode(
-    contentBytes.subarray(0, Math.min(byteOffset, contentBytes.length)),
-  ).length;
+): ((byteOffset: number) => number) => {
+  let prevByte = 0;
+  let prevChar = 0;
+  return (byteOffset: number): number => {
+    const clamped = Math.min(Math.max(byteOffset, 0), contentBytes.length);
+    if (clamped < prevByte) {
+      prevByte = 0;
+      prevChar = 0;
+    }
+    prevChar += textDecoder.decode(
+      contentBytes.subarray(prevByte, clamped),
+    ).length;
+    prevByte = clamped;
+    return prevChar;
+  };
+};
 
 /** Recover a statement's SQL text, preferring the verbatim source slice.
  *  `stmt_location`/`stmt_len` are UTF-8 BYTE offsets (libpg_query), so the
@@ -78,9 +91,13 @@ const byteToCharOffset = (
 const extractStatementSql = async (
   contentBytes: Uint8Array,
   statement: RawParserStatement,
+  isLast: boolean,
 ): Promise<string | null> => {
   const location = statement.stmt_location ?? 0;
-  const length = statement.stmt_len ?? 0;
+  // libpg_query omits stmt_len for a final statement that has no terminating
+  // semicolon; the statement then runs to the end of the content.
+  const length =
+    statement.stmt_len ?? (isLast ? contentBytes.length - location : 0);
   if (
     Number.isInteger(location) &&
     Number.isInteger(length) &&
@@ -142,6 +159,7 @@ export const parseSqlContent = async (
   const statements: ParsedStatement[] = [];
   const parserStatements = parseResult.stmts ?? [];
   const contentBytes = textEncoder.encode(content);
+  const byteToCharOffset = makeByteToCharOffset(contentBytes);
 
   for (let index = 0; index < parserStatements.length; index += 1) {
     const statement = parserStatements[index];
@@ -157,7 +175,11 @@ export const parseSqlContent = async (
       continue;
     }
 
-    const sql = await extractStatementSql(contentBytes, statement);
+    const sql = await extractStatementSql(
+      contentBytes,
+      statement,
+      index === parserStatements.length - 1,
+    );
     if (sql === null) {
       diagnostics.push({
         code: "PARSE_ERROR",
@@ -177,10 +199,7 @@ export const parseSqlContent = async (
     // of the statement (e.g. "CREATE"); statement IDs and diagnostics then refer to
     // the real start of the statement for display and editor jump-to.
     // stmt_location is a byte offset; convert to a character offset first.
-    let sourceOffset = byteToCharOffset(
-      contentBytes,
-      statement.stmt_location ?? 0,
-    );
+    let sourceOffset = byteToCharOffset(statement.stmt_location ?? 0);
     while (
       sourceOffset < content.length &&
       /\s/.test(content[sourceOffset] ?? "")

--- a/packages/pg-topo/src/ingest/parse.ts
+++ b/packages/pg-topo/src/ingest/parse.ts
@@ -44,10 +44,41 @@ const ensureParserModuleLoaded = async (): Promise<void> => {
 const ensureStatementTerminator = (sql: string): string =>
   sql.trimEnd().endsWith(";") ? sql.trim() : `${sql.trim()};`;
 
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+/** Re-parse `candidate` and report whether it is executable on its own. */
+const reparses = (candidate: string): boolean => {
+  try {
+    const parsed = parseSql(candidate) as RawParserResult;
+    return (parsed.stmts ?? []).length > 0;
+  } catch {
+    return false;
+  }
+};
+
+/** Convert a byte offset into `contentBytes` to a UTF-16 character offset.
+ *  Statement locations always fall on character boundaries, so decoding the
+ *  byte prefix is exact. */
+const byteToCharOffset = (
+  contentBytes: Uint8Array,
+  byteOffset: number,
+): number =>
+  textDecoder.decode(
+    contentBytes.subarray(0, Math.min(byteOffset, contentBytes.length)),
+  ).length;
+
+/** Recover a statement's SQL text, preferring the verbatim source slice.
+ *  `stmt_location`/`stmt_len` are UTF-8 BYTE offsets (libpg_query), so the
+ *  slice must be taken from the encoded content, never from the JS string —
+ *  UTF-16 indices drift on any non-ASCII content (supabase/pg-toolbelt#369).
+ *  Returns `null` when no executable text can be recovered: the deparse
+ *  fallback is not trusted blindly because plpgsql-parser deparses some
+ *  statements into invalid SQL (e.g. `COMMENT ON TRIGGER public.t.tr`). */
 const extractStatementSql = async (
-  fileContent: string,
+  contentBytes: Uint8Array,
   statement: RawParserStatement,
-): Promise<string> => {
+): Promise<string | null> => {
   const location = statement.stmt_location ?? 0;
   const length = statement.stmt_len ?? 0;
   if (
@@ -55,28 +86,35 @@ const extractStatementSql = async (
     Number.isInteger(length) &&
     location >= 0 &&
     length > 0 &&
-    location + length <= fileContent.length
+    location + length <= contentBytes.length
   ) {
-    const sliced = fileContent.slice(location, location + length).trim();
+    const sliced = textDecoder
+      .decode(contentBytes.subarray(location, location + length))
+      .trim();
     if (sliced.length > 0) {
       const candidate = ensureStatementTerminator(sliced);
-      try {
-        const parsed = parseSql(candidate) as RawParserResult;
-        if ((parsed.stmts ?? []).length > 0) {
-          return candidate;
-        }
-      } catch {
-        // Fallback to deparse below when stmt_location slice is not executable.
+      if (reparses(candidate)) {
+        return candidate;
       }
+      // Fallback to deparse below when the stmt_location slice is not
+      // executable on its own.
     }
   }
 
   if (statement.stmt) {
-    const deparsed = await deparseSql(statement.stmt as object);
-    return ensureStatementTerminator(deparsed);
+    try {
+      const deparsed = ensureStatementTerminator(
+        await deparseSql(statement.stmt as object),
+      );
+      if (reparses(deparsed)) {
+        return deparsed;
+      }
+    } catch {
+      // fall through to the unrecoverable result
+    }
   }
 
-  return "";
+  return null;
 };
 
 export const parseSqlContent = async (
@@ -103,6 +141,7 @@ export const parseSqlContent = async (
 
   const statements: ParsedStatement[] = [];
   const parserStatements = parseResult.stmts ?? [];
+  const contentBytes = textEncoder.encode(content);
 
   for (let index = 0; index < parserStatements.length; index += 1) {
     const statement = parserStatements[index];
@@ -118,13 +157,30 @@ export const parseSqlContent = async (
       continue;
     }
 
-    const sql = await extractStatementSql(content, statement);
+    const sql = await extractStatementSql(contentBytes, statement);
+    if (sql === null) {
+      diagnostics.push({
+        code: "PARSE_ERROR",
+        message:
+          "Statement text could not be recovered: neither the source slice " +
+          "nor its deparsed fallback re-parses as executable SQL.",
+        statementId: {
+          filePath: sourceLabel,
+          statementIndex: index,
+        },
+      });
+      continue;
+    }
     const annotationResult = parseAnnotations(sql);
 
     // Advance past leading whitespace so sourceOffset points to the first character
     // of the statement (e.g. "CREATE"); statement IDs and diagnostics then refer to
     // the real start of the statement for display and editor jump-to.
-    let sourceOffset = statement.stmt_location ?? 0;
+    // stmt_location is a byte offset; convert to a character offset first.
+    let sourceOffset = byteToCharOffset(
+      contentBytes,
+      statement.stmt_location ?? 0,
+    );
     while (
       sourceOffset < content.length &&
       /\s/.test(content[sourceOffset] ?? "")

--- a/packages/pg-topo/src/model/types.ts
+++ b/packages/pg-topo/src/model/types.ts
@@ -40,7 +40,7 @@ export type PhaseTag =
 export type StatementId = {
   filePath: string;
   statementIndex: number;
-  /** Byte offset in original source content (for line:column resolution). */
+  /** Character offset (UTF-16 code units) in original source content (for line:column resolution). */
   sourceOffset?: number;
 };
 

--- a/packages/pg-topo/test/analyze-and-sort.test.ts
+++ b/packages/pg-topo/test/analyze-and-sort.test.ts
@@ -354,4 +354,20 @@ describe("analyzeAndSort", () => {
       ),
     ).toEqual(orderedIds);
   });
+
+  // Regression for supabase/pg-toolbelt#369: ordered output must carry the
+  // authored statement text verbatim even when it contains non-ASCII content
+  // (byte-offset slicing previously fell back to a deparse that renders
+  // COMMENT ON TRIGGER/POLICY in an invalid dotted form).
+  test("carries non-ASCII statements verbatim through ordering", async () => {
+    const table = "create table public.t(id int primary key);";
+    const trigger = "COMMENT ON TRIGGER tr ON public.t IS '→→→';";
+    const policy = "COMMENT ON POLICY p ON public.t IS '→→→';";
+    const result = await analyzeAndSort([trigger, policy, table]);
+
+    expect(result.ordered.length).toBe(3);
+    const orderedSql = result.ordered.map((statement) => statement.sql);
+    expect(orderedSql).toContain(trigger);
+    expect(orderedSql).toContain(policy);
+  });
 });

--- a/packages/pg-topo/test/parse.test.ts
+++ b/packages/pg-topo/test/parse.test.ts
@@ -54,4 +54,59 @@ create schema app;
     expect(invalidAnnotations[0]?.statementId?.filePath).toBe("annot.sql");
     expect(invalidAnnotations[0]?.statementId?.statementIndex).toBe(0);
   });
+
+  // Regression for supabase/pg-toolbelt#369: stmt_location/stmt_len are UTF-8
+  // byte offsets, but statements were sliced with UTF-16 string indices. Any
+  // non-ASCII content misaligned the slice, silently swapping the authored
+  // text for a deparse that renders COMMENT ON TRIGGER/POLICY/RULE targets as
+  // the invalid dotted form (`COMMENT ON TRIGGER public.t.tr`).
+  describe("statement text with non-ASCII content (#369)", () => {
+    test("carries COMMENT ON TRIGGER verbatim", async () => {
+      const content = "COMMENT ON TRIGGER tr ON public.t IS '→→→';";
+      const result = await parseSqlContent(content, "trigger.sql");
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0]?.sql).toBe(content);
+    });
+
+    test("carries COMMENT ON POLICY verbatim", async () => {
+      const content = "COMMENT ON POLICY p ON public.t IS '→→→';";
+      const result = await parseSqlContent(content, "policy.sql");
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0]?.sql).toBe(content);
+    });
+
+    test("carries COMMENT ON RULE verbatim", async () => {
+      const content = "COMMENT ON RULE r ON public.t IS '→→→';";
+      const result = await parseSqlContent(content, "rule.sql");
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0]?.sql).toBe(content);
+    });
+
+    test("slices statements after a non-ASCII statement verbatim", async () => {
+      const first = "comment on table public.t is '→→→';";
+      const second = "create table public.u(id int);";
+      const result = await parseSqlContent(
+        `${first}\n${second}\n`,
+        "drift.sql",
+      );
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.statements).toHaveLength(2);
+      expect(result.statements[0]?.sql).toBe(first);
+      expect(result.statements[1]?.sql).toBe(second);
+    });
+
+    test("sourceOffset is a character offset even after non-ASCII content", async () => {
+      const content =
+        "comment on table public.t is '→→→';\ncreate table public.u(id int);\n";
+      const result = await parseSqlContent(content, "offsets.sql");
+      expect(result.statements).toHaveLength(2);
+      const offset = result.statements[1]?.id.sourceOffset ?? -1;
+      expect(content.slice(offset).startsWith("create table public.u")).toBe(
+        true,
+      );
+    });
+  });
 });

--- a/packages/pg-topo/test/parse.test.ts
+++ b/packages/pg-topo/test/parse.test.ts
@@ -108,5 +108,58 @@ create schema app;
         true,
       );
     });
+
+    test("sourceOffsets stay exact across many statements with non-ASCII content", async () => {
+      const statements = [
+        "comment on table public.a is '→';",
+        "create table public.b(id int);",
+        "comment on table public.b is '→→';",
+        "create table public.c(id int);",
+      ];
+      const content = statements.join("\n");
+      const result = await parseSqlContent(content, "many.sql");
+      expect(result.statements).toHaveLength(statements.length);
+      for (const [index, statement] of statements.entries()) {
+        const offset = result.statements[index]?.id.sourceOffset ?? -1;
+        expect(content.slice(offset, offset + statement.length)).toBe(
+          statement,
+        );
+      }
+    });
+  });
+
+  // libpg_query omits stmt_len for a final statement with no terminating
+  // semicolon, so the byte-slice path must extend to the end of the content
+  // instead of falling back to the deparser (which is invalid for
+  // COMMENT ON TRIGGER/POLICY/RULE and would drop the statement).
+  describe("final statement without a terminating semicolon", () => {
+    test("recovers an unterminated COMMENT ON TRIGGER verbatim", async () => {
+      const content = "COMMENT ON TRIGGER tr ON public.t IS 'x'";
+      const result = await parseSqlContent(content, "unterminated.sql");
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0]?.sql).toBe(`${content};`);
+    });
+
+    test("recovers an unterminated non-ASCII COMMENT ON TRIGGER verbatim", async () => {
+      const content = "COMMENT ON TRIGGER tr ON public.t IS '→→→'";
+      const result = await parseSqlContent(content, "unterminated.sql");
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.statements).toHaveLength(1);
+      expect(result.statements[0]?.sql).toBe(`${content};`);
+    });
+
+    test("recovers an unterminated final statement after earlier statements", async () => {
+      const first = "comment on table public.t is '→→→';";
+      const second = "COMMENT ON POLICY p ON public.t IS 'x'";
+      const result = await parseSqlContent(
+        `${first}\n${second}`,
+        "unterminated.sql",
+      );
+      expect(result.diagnostics).toHaveLength(0);
+      expect(result.statements).toHaveLength(2);
+      expect(result.statements[0]?.sql).toBe(first);
+      expect(result.statements[1]?.sql).toBe(`${second};`);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`pgdelta declarative apply` rewrote `COMMENT ON TRIGGER tr ON public.t IS '→→→'` into the invalid `COMMENT ON TRIGGER public.t.tr IS '→→→'` (same for `POLICY`/`RULE`), failing with `syntax error at or near "."` — but only when the statement contained non-ASCII text (supabase/pg-toolbelt#369).

Root cause, two stacked defects in pg-topo's statement extraction (`src/ingest/parse.ts`):

1. **Byte offsets applied to a JS string.** libpg_query reports `stmt_location`/`stmt_len` as UTF-8 *byte* offsets, but `extractStatementSql` sliced the source with UTF-16 string indices. Any non-ASCII content misaligned the slice (the repro statement is 48 bytes but 43 chars), failed the re-parse guard, and silently abandoned the verbatim source text.
2. **Invalid deparse fallback.** The fallback `deparseSql` (from the external `plpgsql-parser` dep) renders relation-scoped comment targets in the dotted form Postgres rejects — for ASCII input too; ASCII just never reaches the fallback.

The fix:

* Encode the file once and slice statements from the **bytes**, so the verbatim authored text is always recovered when libpg_query parsed it. (This also stops the deparse fallback from silently stripping `-- pg-topo:` annotation comments on affected statements.)
* Convert `sourceOffset` from a byte offset to a **character offset** — every consumer (including pg-delta's `file:line:col` rendering) indexes JS strings with it, so locations after non-ASCII text were drifting.
* Harden the deparse fallback: output that does not re-parse now yields a `PARSE_ERROR` diagnostic instead of known-invalid SQL. `PARSE_ERROR` is deliberately reused (not a new code) because downstream consumers (pg-delta's `orderForShadow`) already treat it as refuse-to-shrink.

RED → GREEN: the first commit adds the regression tests alone; against the unfixed code they fail with

```
Expected: "COMMENT ON TRIGGER tr ON public.t IS '→→→';"
Received: "COMMENT ON TRIGGER public.t.tr IS '→→→';"
(6 fail / 16 pass)
```

With the fix: full pg-topo suite 186/186 pass.

Follow-ups:

* The `plpgsql-parser` deparse bug (`COMMENT ON TRIGGER/POLICY/RULE` → dotted form) is worth reporting upstream; with this fix it can no longer emit invalid SQL here, but the deparser itself remains wrong.
* A sibling branch ports the same fix to the `feat/pg-delta-next` rewrite (its pg-topo copy lags this one) and adds pg-delta-side regression coverage across the reorder → shadow-load path.

## Linked issue

Closes supabase/pg-toolbelt#369

- [X] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [X] Tests added or updated for the change
- [X] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [X] `bun run format-and-lint` and `bun run check-types` pass

---

*Generated by [Claude Code](<https://claude.ai/code/session_01WTxotbe7crySvbWdQc2tU9>)*