### PR TITLE
fix(pg-delta): carry non-ASCII SQL verbatim through the reorder assist

### DIFF
--- a/.changeset/eighty-pianos-brake.md
+++ b/.changeset/eighty-pianos-brake.md
@@ -1,0 +1,5 @@
+---
+"@supabase/pg-delta": patch
+---
+
+`schema apply` no longer corrupts `COMMENT ON TRIGGER`/`COMMENT ON POLICY` statements containing non-ASCII text during shadow-load reordering. The underlying fix lands in `@supabase/pg-topo` (statements are now sliced by UTF-8 byte offsets and carried verbatim); pg-delta picks it up through its optional peer range and adds regression coverage across the reorder → shadow-load path. Reordered error locations (`file:line:col`) are also exact after non-ASCII content, since `sourceOffset` is now a character offset.

--- a/packages/pg-delta/corpus/rls-operations--policy-comment/b.sql
+++ b/packages/pg-delta/corpus/rls-operations--policy-comment/b.sql
@@ -5,4 +5,4 @@ CREATE TABLE app.docs (
 );
 ALTER TABLE app.docs ENABLE ROW LEVEL SECURITY;
 CREATE POLICY owner_only ON app.docs FOR ALL TO public USING (true);
-COMMENT ON POLICY owner_only ON app.docs IS 'only owners have access';
+COMMENT ON POLICY owner_only ON app.docs IS 'only owners have access →';

--- a/packages/pg-delta/corpus/trigger-operations--trigger-comment/b.sql
+++ b/packages/pg-delta/corpus/trigger-operations--trigger-comment/b.sql
@@ -18,4 +18,4 @@ CREATE TRIGGER logs_insert_trigger
   FOR EACH ROW
   EXECUTE FUNCTION test_schema.log_insert();
 
-COMMENT ON TRIGGER logs_insert_trigger ON test_schema.logs IS 'logs insert trigger';
+COMMENT ON TRIGGER logs_insert_trigger ON test_schema.logs IS 'logs insert trigger →';

--- a/packages/pg-delta/src/cli/reorder-display.test.ts
+++ b/packages/pg-delta/src/cli/reorder-display.test.ts
@@ -74,6 +74,21 @@ describe("formatStatementLocation", () => {
       formatStatementLocation({ filePath: "schema.sql", statementIndex: 0 }),
     ).toBe("schema.sql");
   });
+
+  test("line:col stays exact after non-ASCII content (#369)", () => {
+    // sourceOffset is a character offset (pg-topo converts libpg_query's byte
+    // offsets), so non-ASCII text before the statement must not shift the
+    // rendered location.
+    const content =
+      "comment on table public.t is '→→→';\ncreate view v as select 1;";
+    const offset = content.indexOf("create view");
+    expect(
+      formatStatementLocation(
+        { filePath: "schema.sql", statementIndex: 1, sourceOffset: offset },
+        content,
+      ),
+    ).toBe("schema.sql:2:1");
+  });
 });
 
 describe("rewriteReorderedShadowError", () => {

--- a/packages/pg-delta/src/frontends/sql-order.test.ts
+++ b/packages/pg-delta/src/frontends/sql-order.test.ts
@@ -154,6 +154,25 @@ describe("orderForShadow — split + topological pre-sort", () => {
     expect(ordered[0]?.sql).toContain("create   table  public.t");
   });
 
+  test("carries non-ASCII statements verbatim (#369)", async () => {
+    // Regression for supabase/pg-toolbelt#369: pg-topo sliced statements by
+    // UTF-8 byte offsets applied to UTF-16 string indices, so any non-ASCII
+    // content swapped the authored text for a deparse that renders
+    // COMMENT ON TRIGGER/POLICY targets as the invalid dotted form
+    // (`COMMENT ON TRIGGER public.t.tr`) — which then fails in the shadow.
+    const table = "CREATE TABLE public.t (id integer PRIMARY KEY);";
+    const trigger = "COMMENT ON TRIGGER tr ON public.t IS '→→→';";
+    const policy = "COMMENT ON POLICY p ON public.t IS '→→→';";
+    const files = [file("schema.sql", `${table}\n${trigger}\n${policy}\n`)];
+
+    const ordered = await orderForShadow(files);
+
+    expect(ordered).toHaveLength(3);
+    const sqls = ordered.map((f) => f.sql);
+    expect(sqls).toContain(trigger);
+    expect(sqls).toContain(policy);
+  });
+
   test("is deterministic for the same input", async () => {
     const files = [
       file("schema.sql", "create schema app;"),

--- a/packages/pg-delta/src/frontends/sql-order.ts
+++ b/packages/pg-delta/src/frontends/sql-order.ts
@@ -38,8 +38,8 @@ export interface StatementProvenance {
   filePath: string;
   /** Index of the statement within its original file (0-based). */
   statementIndex: number;
-  /** Byte offset of the statement in the original file content, when pg-topo
-   *  resolves it (used for line:column rendering). */
+  /** Character offset (UTF-16 code units) of the statement in the original
+   *  file content, when pg-topo resolves it (used for line:column rendering). */
   sourceOffset?: number;
 }
 

--- a/packages/pg-delta/tests/reorder-shadow.test.ts
+++ b/packages/pg-delta/tests/reorder-shadow.test.ts
@@ -60,6 +60,48 @@ describe("statement-reordering assist (orderForShadow → loadSqlFiles)", () => 
     }
   }, 60_000);
 
+  test("non-ASCII COMMENT ON TRIGGER/POLICY loads verbatim through reorder (#369)", async () => {
+    // Regression for supabase/pg-toolbelt#369: pg-topo sliced statements by
+    // UTF-8 byte offsets applied as UTF-16 string indices, so any non-ASCII
+    // content replaced the authored text with a deparse that renders these
+    // targets in an invalid dotted form (`COMMENT ON TRIGGER public.t.tr`),
+    // making the shadow load stick on a syntax error.
+    const files = [
+      {
+        name: "schema.sql",
+        sql: [
+          "CREATE TABLE public.t (id integer PRIMARY KEY);",
+          "CREATE FUNCTION public.t_fn() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;",
+          "CREATE TRIGGER tr BEFORE INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION public.t_fn();",
+          "COMMENT ON TRIGGER tr ON public.t IS '→→→';",
+          "ALTER TABLE public.t ENABLE ROW LEVEL SECURITY;",
+          "CREATE POLICY p ON public.t FOR ALL TO public USING (true);",
+          "COMMENT ON POLICY p ON public.t IS '→→→';",
+        ].join("\n"),
+      },
+    ];
+
+    const shadow = await createTestDb("shadow");
+    try {
+      const ordered = await orderForShadow(files);
+      await loadSqlFiles(ordered, shadow.pool);
+      const { rows: triggerRows } = await shadow.pool.query(
+        `SELECT d.description FROM pg_trigger t
+           JOIN pg_description d ON d.objoid = t.oid
+          WHERE t.tgname = 'tr'`,
+      );
+      const { rows: policyRows } = await shadow.pool.query(
+        `SELECT d.description FROM pg_policy p
+           JOIN pg_description d ON d.objoid = p.oid
+          WHERE p.polname = 'p'`,
+      );
+      expect(triggerRows).toEqual([{ description: "→→→" }]);
+      expect(policyRows).toEqual([{ description: "→→→" }]);
+    } finally {
+      await shadow.drop();
+    }
+  }, 60_000);
+
   test("intra-file VIEW-before-TABLE is STUCK without reorder (--no-reorder)", async () => {
     const files = [
       {


### PR DESCRIPTION
## Summary

pg-delta-side regression coverage for #369 on the `feat/pg-delta-next` rewrite. The underlying fix lives in `@supabase/pg-topo` (shipped from `main` via #372, released as `1.0.0-alpha.5`) and reaches this branch through the sync merge in **#376 — merge that first**; this PR is then a pure pg-delta change and its new tests go green.

Two commits:

1. **`test(pg-delta)` — regression coverage** at every layer pg-delta touches: `orderForShadow` carries non-ASCII `COMMENT ON TRIGGER/POLICY` verbatim (unit); the reorder → shadow-load path applies them and the comments land verbatim in the catalog (integration, Docker); `file:line:col` display stays exact after non-ASCII content; and the `trigger-operations--trigger-comment` / `rls-operations--policy-comment` corpus scenarios now use non-ASCII comment text so the proof loop pins plan-side rendering in both directions. RED capture (against pg-topo before the fix) is in the commit message.
2. **`chore(pg-delta)` — changeset + doc fix**: `StatementProvenance.sourceOffset` was documented as a byte offset but consumed as a character index by the line:column renderer; after the pg-topo fix it genuinely is one. No manifest change: pg-delta's existing `^1.0.0-alpha.3` peer range already resolves to the fixed alpha.5 at install time.

Validation (with the fixed pg-topo in the tree, i.e. the post-#376 state): pg-topo suite 190/190, pg-delta unit 947/947, `reorder-shadow` integration 6/6, both modified corpus scenarios pass in both directions on `postgres:17-alpine`, and a full 640/640 corpus run passed with these scenario edits. The original issue repro (`schema apply` with non-ASCII trigger/policy comments) applies end-to-end and the comments land verbatim in the target catalog.

> **Depends on #376.** Until it merges, the new regression tests here fail against next's pre-fix workspace pg-topo — that failure is the regression being demonstrated.

## Linked issue

Refs #369 (closed by #372 — the released pg-topo fix; this PR adds the rewrite-side coverage)

- [x] The linked issue is **open** and carries the `open-for-contribution` label (or I'm a Supabase maintainer).

## Checklist

- [x] Tests added or updated for the change
- [x] Changeset added if this is a user-facing fix/feature (`bunx changeset`)
- [x] `bun run format-and-lint` and `bun run check-types` pass